### PR TITLE
Réduction des vignettes

### DIFF
--- a/pod/video/encode.py
+++ b/pod/video/encode.py
@@ -204,7 +204,7 @@ def encode_video(video_id):
             # create encoding video command
             change_encoding_step(
                 video_id, 4,
-                "encoding video file : 1/11 get video command")
+                "encoding video file : 1/12 get video command")
             video_command_playlist = get_video_command_playlist(
                 video_id,
                 video_data,
@@ -222,7 +222,7 @@ def encode_video(video_id):
             # launch encode video
             change_encoding_step(
                 video_id, 4,
-                "encoding video file : 2/11 encode_video_playlist")
+                "encoding video file : 2/12 encode_video_playlist")
             msg = encode_video_playlist(
                 video_to_encode.video.path,
                 video_command_playlist["cmd"],
@@ -232,7 +232,7 @@ def encode_video(video_id):
                 "encode_video_playlist : %s" % msg)
             change_encoding_step(
                 video_id, 4,
-                "encoding video file : 3/11 encode_video_mp4")
+                "encoding video file : 3/12 encode_video_mp4")
             msg = encode_video_mp4(
                 video_to_encode.video.path,
                 video_command_mp4["cmd"],
@@ -243,7 +243,7 @@ def encode_video(video_id):
             # save playlist files
             change_encoding_step(
                 video_id, 4,
-                "encoding video file : 4/11 save_playlist_file")
+                "encoding video file : 4/12 save_playlist_file")
             msg = save_playlist_file(
                 video_id,
                 video_command_playlist["list_file"],
@@ -254,7 +254,7 @@ def encode_video(video_id):
             # save_playlist_master
             change_encoding_step(
                 video_id, 4,
-                "encoding video file : 5/11 save_playlist_master")
+                "encoding video file : 5/12 save_playlist_master")
             msg = save_playlist_master(
                 video_id,
                 output_dir,
@@ -265,7 +265,7 @@ def encode_video(video_id):
             # save mp4 files
             change_encoding_step(
                 video_id, 4,
-                "encoding video file : 6/11 save_mp4_file")
+                "encoding video file : 6/12 save_mp4_file")
             msg = save_mp4_file(
                 video_id,
                 video_command_mp4["list_file"],
@@ -294,13 +294,13 @@ def encode_video(video_id):
             image_width = video_mp4.width / 4  # width of generate image file
             change_encoding_step(
                 video_id, 4,
-                "encoding video file : 7/11 remove_previous_overview")
+                "encoding video file : 7/12 remove_previous_overview")
             remove_previous_overview(overviewfilename, overviewimagefilename)
             nb_img = 99 if (
                 video_data["duration"] > 99) else video_data["duration"]
             change_encoding_step(
                 video_id, 4,
-                "encoding video file : 8/11 create_overview_image")
+                "encoding video file : 8/12 create_overview_image")
             msg = create_overview_image(
                 video_id,
                 video_mp4.video.video.path, video_data["duration"],
@@ -311,7 +311,7 @@ def encode_video(video_id):
             # create small thumbnail
             change_encoding_step(
                 video_id, 4,
-                "encoding video file : 12/12 create_and_save_small_thumbnails")
+                "encoding video file : 11/12 create_and_save_small_thumbnails")
             msg = create_and_save_thumbnails(
                 video_mp4.video.video.path, 300, video_id)
             add_encoding_log(
@@ -320,7 +320,7 @@ def encode_video(video_id):
             # create thumbnail
             change_encoding_step(
                 video_id, 4,
-                "encoding video file : 11/11 create_and_save_thumbnails")
+                "encoding video file : 12/12 create_and_save_thumbnails")
             msg = create_and_save_thumbnails(
                 video_mp4.video.video.path, video_mp4.width, video_id)
             add_encoding_log(

--- a/pod/video/encode.py
+++ b/pod/video/encode.py
@@ -983,10 +983,16 @@ def create_and_save_thumbnails(source, image_width, video_id):
                     folder=videodir,
                     created_by=video_to_encode.owner
                 )
-                thumbnail.file.save(
-                    "%s_%s_%s.png" % (video_to_encode.slug, i, image_width),
-                    File(open(thumbnailfilename, "rb")),
-                    save=True)
+                if image_width == 300:
+                    thumbnail.file.save(
+                        "%s_%s_300.png" % (video_to_encode.slug, i),
+                        File(open(thumbnailfilename, "rb")),
+                        save=True)
+                else:
+                    thumbnail.file.save(
+                        "%s_%s.png" % (video_to_encode.slug, i),
+                        File(open(thumbnailfilename, "rb")),
+                        save=True)
                 thumbnail.save()
                 if i == 0:
                     video_to_encode = Video.objects.get(id=video_id)
@@ -994,10 +1000,16 @@ def create_and_save_thumbnails(source, image_width, video_id):
                     video_to_encode.save()
             else:
                 thumbnail = CustomImageModel()
-                thumbnail.file.save(
-                    "%d_%s_%s.png" % (video_id, i, image_width),
-                    File(open(thumbnailfilename, "rb")),
-                    save=True)
+                if image_width == 300:
+                    thumbnail.file.save(
+                        "%d_%s_300.png" % (video_id, i),
+                        File(open(thumbnailfilename, "rb")),
+                        save=True)
+                else:
+                    thumbnail.file.save(
+                        "%d_%s.png" % (video_id, i),
+                        File(open(thumbnailfilename, "rb")),
+                        save=True)
                 thumbnail.save()
                 if i == 0:
                     video_to_encode = Video.objects.get(id=video_id)

--- a/pod/video/encode.py
+++ b/pod/video/encode.py
@@ -308,6 +308,15 @@ def encode_video(video_id):
             add_encoding_log(
                 video_id,
                 "create_overview_image : %s" % msg)
+            # create small thumbnail
+            change_encoding_step(
+                video_id, 4,
+                "encoding video file : 12/12 create_and_save_small_thumbnails")
+            msg = create_and_save_thumbnails(
+                video_mp4.video.video.path, 300, video_id)
+            add_encoding_log(
+                video_id,
+                "create_and_save_small_thumbnails : %s" % msg)
             # create thumbnail
             change_encoding_step(
                 video_id, 4,
@@ -975,7 +984,7 @@ def create_and_save_thumbnails(source, image_width, video_id):
                     created_by=video_to_encode.owner
                 )
                 thumbnail.file.save(
-                    "%s_%s.png" % (video_to_encode.slug, i),
+                    "%s_%s_%s.png" % (video_to_encode.slug, i, image_width),
                     File(open(thumbnailfilename, "rb")),
                     save=True)
                 thumbnail.save()
@@ -986,7 +995,7 @@ def create_and_save_thumbnails(source, image_width, video_id):
             else:
                 thumbnail = CustomImageModel()
                 thumbnail.file.save(
-                    "%d_%s.png" % (video_id, i),
+                    "%d_%s_%s.png" % (video_id, i, image_width),
                     File(open(thumbnailfilename, "rb")),
                     save=True)
                 thumbnail.save()

--- a/pod/video/encode.py
+++ b/pod/video/encode.py
@@ -971,6 +971,10 @@ def create_and_save_thumbnails(source, image_width, video_id):
             'tempfile': tempimgfile.name
         }
         if check_file(thumbnailfilename):
+            if image_width == 300:
+                wid = "_300"
+            else:
+                wid = ""
             if FILEPICKER:
                 video_to_encode = Video.objects.get(id=video_id)
                 homedir, created = UserFolder.objects.get_or_create(
@@ -983,16 +987,10 @@ def create_and_save_thumbnails(source, image_width, video_id):
                     folder=videodir,
                     created_by=video_to_encode.owner
                 )
-                if image_width == 300:
-                    thumbnail.file.save(
-                        "%s_%s_300.png" % (video_to_encode.slug, i),
-                        File(open(thumbnailfilename, "rb")),
-                        save=True)
-                else:
-                    thumbnail.file.save(
-                        "%s_%s.png" % (video_to_encode.slug, i),
-                        File(open(thumbnailfilename, "rb")),
-                        save=True)
+                thumbnail.file.save(
+                    "%s_%s%s.png" % (video_to_encode.slug, i, wid),
+                    File(open(thumbnailfilename, "rb")),
+                    save=True)
                 thumbnail.save()
                 if i == 0:
                     video_to_encode = Video.objects.get(id=video_id)
@@ -1000,16 +998,10 @@ def create_and_save_thumbnails(source, image_width, video_id):
                     video_to_encode.save()
             else:
                 thumbnail = CustomImageModel()
-                if image_width == 300:
-                    thumbnail.file.save(
-                        "%d_%s_300.png" % (video_id, i),
-                        File(open(thumbnailfilename, "rb")),
-                        save=True)
-                else:
-                    thumbnail.file.save(
-                        "%d_%s.png" % (video_id, i),
-                        File(open(thumbnailfilename, "rb")),
-                        save=True)
+                thumbnail.file.save(
+                    "%d_%s%s.png" % (video_id, i, wid),
+                    File(open(thumbnailfilename, "rb")),
+                    save=True)
                 thumbnail.save()
                 if i == 0:
                     video_to_encode = Video.objects.get(id=video_id)

--- a/pod/video/models.py
+++ b/pod/video/models.py
@@ -642,8 +642,13 @@ class Video(models.Model):
     get_thumbnail_admin.fget.short_description = _('Thumbnails')
 
     def get_thumbnail_card(self):
+        if self.get_thumbnail_url().count('_') == 2:
+            tuple = self.get_thumbnail_url().split("_")
+            filename = tuple[0]+"_"+tuple[1]+"_300.png"
+        else:
+            filename = self.get_thumbnail_url()
         return '<img class="card-img-top" src="%s" alt="%s" />' % (
-            self.get_thumbnail_url(), self.title)
+            filename, self.title)
 
     @property
     def duration_in_time(self):

--- a/pod/video/templates/videos/video-info.html
+++ b/pod/video/templates/videos/video-info.html
@@ -27,7 +27,7 @@
     <h5><i data-feather="info"></i>&nbsp;{% trans 'Infos' %}</h5>
     <div class="row">
       <div class="col-3">
-      {% trans 'Added by' %}&nbsp;: 
+      {% trans 'Added by' %}&nbsp;:
       </div>
       <div class="col-9">
       <a href="{% url 'videos' %}?owner={{ video.owner.username }}" title="{{ video.owner.get_full_name }}" {% if request.GET.is_iframe %}target="_blank"{% endif %}>
@@ -39,7 +39,7 @@
     </div>
     {% if video.additional_owners.all %}
 	  <div class="row">
-      <div class="col-3">	     
+      <div class="col-3">
 		    {% trans 'Additional owners' %}&nbsp;:<br/>
       </div>
       <div class="col-9">
@@ -153,7 +153,7 @@
         {%endif%}
       </div>
       <div class="col-4">
-      {% if video.allow_downloading %}  
+      {% if video.allow_downloading %}
       {% if video.get_video_mp3 %}
       <div>{% trans 'Audio file' %} :<br/>
       <form method="post" action="{% url 'download_file' %}">
@@ -215,15 +215,15 @@
         </div>
         <div class="form-group ">
           <label for="txtintegration">{% trans 'Copy the content of this text box and paste it in the page' %}&nbsp;:</label>
-          <textarea name="txtintegration" id="txtintegration" class="form-control" rows="4">&lt;iframe src="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}?is_iframe=true" width="640" height="360" style="padding: 0; margin: 0; border:0" allowfullscreen &gt;&lt;/iframe&gt;</textarea>
+          <textarea name="txtintegration" id="txtintegration" class="form-control" rows="4">&lt;iframe src="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}{% if video.is_draft == True %}{{ video.get_hashkey }}/{% endif %}?is_iframe=true" width="640" height="360" style="padding: 0; margin: 0; border:0" allowfullscreen &gt;&lt;/iframe&gt;</textarea>
         </div>
         <div class="form-group">
           <label for="txtpartage">{% trans 'Use this link to share the video' %} :</label>
-          <input class="form-control" type="text" name="txtpartage" id="txtpartage" value="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}" />
+          <input class="form-control" type="text" name="txtpartage" id="txtpartage" value="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}{% if video.is_draft == True %}{{ video.get_hashkey }}/{% endif %}" />
         </div>
         <div class="form-group">
           <label>{% trans 'QR code for this link' %} :</label>
-          <img src="//chart.apis.google.com/chart?cht=qr&chs=200x200&chl={% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}" alt="qrcode" id="qrcode"/>
+          <img src="//chart.apis.google.com/chart?cht=qr&chs=200x200&chl={% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}{% if video.is_draft == True %}{{ video.get_hashkey }}/{% endif %}" alt="qrcode" id="qrcode"/>
         </div>
       </fieldset>
   </div>


### PR DESCRIPTION
J'ai fait une tentative de réduction de vignette.
J'ai créé une nouvelle branche pour que ce soit plus facile à supprimer si cela ne convient pas.
Ne pas hésiter à me dire si ce n'est pas bon ;-) ... je ne suis vraiment pas sur de moi.
J'ai testé avec use_podfile = true et false.
Les corrections proposées créent 2 vignettes à l'encodage, dont une petite de 300px de large.
Pour générer les vignettes des anciennes vidéos, lorsqu'on cherche l'image de 300px et qu'elle n'existe pas, elle est créée. Elle n'est pas tout de suite utilisée, mais si on recharge la page, elle est bien actualisée.