### PR TITLE
Add draft link in video info share tab

### DIFF
--- a/pod/video/templates/videos/video-info.html
+++ b/pod/video/templates/videos/video-info.html
@@ -27,7 +27,7 @@
     <h5><i data-feather="info"></i>&nbsp;{% trans 'Infos' %}</h5>
     <div class="row">
       <div class="col-3">
-      {% trans 'Added by' %}&nbsp;: 
+      {% trans 'Added by' %}&nbsp;:
       </div>
       <div class="col-9">
       <a href="{% url 'videos' %}?owner={{ video.owner.username }}" title="{{ video.owner.get_full_name }}" {% if request.GET.is_iframe %}target="_blank"{% endif %}>
@@ -39,7 +39,7 @@
     </div>
     {% if video.additional_owners.all %}
 	  <div class="row">
-      <div class="col-3">	     
+      <div class="col-3">
 		    {% trans 'Additional owners' %}&nbsp;:<br/>
       </div>
       <div class="col-9">
@@ -153,7 +153,7 @@
         {%endif%}
       </div>
       <div class="col-4">
-      {% if video.allow_downloading %}  
+      {% if video.allow_downloading %}
       {% if video.get_video_mp3 %}
       <div>{% trans 'Audio file' %} :<br/>
       <form method="post" action="{% url 'download_file' %}">
@@ -215,15 +215,15 @@
         </div>
         <div class="form-group ">
           <label for="txtintegration">{% trans 'Copy the content of this text box and paste it in the page' %}&nbsp;:</label>
-          <textarea name="txtintegration" id="txtintegration" class="form-control" rows="4">&lt;iframe src="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}?is_iframe=true" width="640" height="360" style="padding: 0; margin: 0; border:0" allowfullscreen &gt;&lt;/iframe&gt;</textarea>
+          <textarea name="txtintegration" id="txtintegration" class="form-control" rows="4">&lt;iframe src="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}{% if video.is_draft == True %}{{ video.get_hashkey }}/{% endif %}?is_iframe=true" width="640" height="360" style="padding: 0; margin: 0; border:0" allowfullscreen &gt;&lt;/iframe&gt;</textarea>
         </div>
         <div class="form-group">
           <label for="txtpartage">{% trans 'Use this link to share the video' %} :</label>
-          <input class="form-control" type="text" name="txtpartage" id="txtpartage" value="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}" />
+          <input class="form-control" type="text" name="txtpartage" id="txtpartage" value="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}{% if video.is_draft == True %}{{ video.get_hashkey }}/{% endif %}" />
         </div>
         <div class="form-group">
           <label>{% trans 'QR code for this link' %} :</label>
-          <img src="//chart.apis.google.com/chart?cht=qr&chs=200x200&chl={% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}" alt="qrcode" id="qrcode"/>
+          <img src="//chart.apis.google.com/chart?cht=qr&chs=200x200&chl={% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}{% if video.is_draft == True %}{{ video.get_hashkey }}/{% endif %}" alt="qrcode" id="qrcode"/>
         </div>
       </fieldset>
   </div>


### PR DESCRIPTION
Proposition de mettre le lien de partage pour une vidéo dans les éléments de partage sous la vidéo (comme c'était le cas dans pod V1) ... plutôt que dans un bloc bien trop planqué ;-)
Supprimer la branche si cette fonctionnalité n'est pas voulue.

A+
Alain