### PR TITLE
Lien de partage pour vidéo en mode brouillon

### DIFF
--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -47,6 +47,10 @@ padding:.25rem 1.25rem;
   margin-top: 7px;
 }
 
+.hidespinner {
+  display: none;
+}
+
 /*** navbar **/
 /*.nav-link.btn-connexion{
   background: #b03c7e;

--- a/pod/main/static/js/main.js
+++ b/pod/main/static/js/main.js
@@ -82,15 +82,14 @@ $(document).on('change', '#loop', function() {
 $(document).on('change', "#displaytime", function(e) {
     if($('#displaytime').is(':checked')){
         if($('#txtpartage').val().indexOf('start')<0){
-             $('#txtpartage').val($('#txtpartage').val()+'?start='+parseInt(player.currentTime()));
+             $('#txtpartage').val($('#txtpartage').val()+'&start='+parseInt(player.currentTime()));
              if ($('#txtpartage').val().indexOf('??') > 0) $('#txtpartage').val($('#txtpartage').val().replace('??', '?'));
              var valeur = $('#txtintegration').val();
              $('#txtintegration').val(valeur.replace('/?', '/?start=' + parseInt(player.currentTime())+'&'));
-
         }
         $('#txtposition').val(player.currentTime().toHHMMSS());
     }else{
-         $('#txtpartage').val($('#txtpartage').val().replace(/(\?start=)\d+/, '').replace(/(\?start=)\d+/, ''));
+         $('#txtpartage').val($('#txtpartage').val().replace(/(\&start=)\d+/, '').replace(/(\start=)\d+/, '').replace(/(\?start=)\d+/, ''));
 
          $('#txtintegration').val($('#txtintegration').val().replace(/(start=)\d+&/, ''));
          $('#txtposition').val("");

--- a/pod/video/templates/videos/video-info.html
+++ b/pod/video/templates/videos/video-info.html
@@ -167,15 +167,15 @@
         </div>
         <div class="form-group ">
           <label for="txtintegration">{% trans 'Copy the content of this text box and paste it in the page' %}&nbsp;:</label>
-          <textarea name="txtintegration" id="txtintegration" class="form-control" rows="4">&lt;iframe src="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}?is_iframe=true" width="640" height="360" style="padding: 0; margin: 0; border:0" allowfullscreen &gt;&lt;/iframe&gt;</textarea>
+          <textarea name="txtintegration" id="txtintegration" class="form-control" rows="4">&lt;iframe src="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}{% if video.is_draft == True %}{{ video.get_hashkey }}/{% endif %}?is_iframe=true" width="640" height="360" style="padding: 0; margin: 0; border:0" allowfullscreen &gt;&lt;/iframe&gt;</textarea>
         </div>
         <div class="form-group">
           <label for="txtpartage">{% trans 'Use this link to share the video' %} :</label>
-          <input class="form-control" type="text" name="txtpartage" id="txtpartage" value="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}" />
+          <input class="form-control" type="text" name="txtpartage" id="txtpartage" value="{% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}{% if video.is_draft == True %}{{ video.get_hashkey }}/{% endif %}" />
         </div>
         <div class="form-group">
           <label>{% trans 'QR code for this link' %} :</label>
-          <img src="//chart.apis.google.com/chart?cht=qr&chs=200x200&chl={% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}" alt="qrcode" id="qrcode"/>
+          <img src="//chart.apis.google.com/chart?cht=qr&chs=200x200&chl={% if request.is_secure %}https{% else %}http{% endif %}://{{ request.META.HTTP_HOST }}{%if enrichment%}{% url 'enrichment:video_enrichment' slug=video.slug %}{%else%}{% url 'video' slug=video.slug %}{%endif%}{% if video.is_draft == True %}{{ video.get_hashkey }}/{% endif %}" alt="qrcode" id="qrcode"/>
         </div>
       </fieldset>
   </div>

--- a/pod/video/templates/videos/video_edit.html
+++ b/pod/video/templates/videos/video_edit.html
@@ -9,7 +9,7 @@
 {% endblock page_extra_head %}
 
 
-{% block breadcrumbs %}{{ block.super }} 
+{% block breadcrumbs %}{{ block.super }}
 <li class="breadcrumb-item"><a href="{% url 'my_videos' %}" title="{% trans 'My videos' %}">{% trans 'My videos' %}</a></li>
 {% if form.instance.title %}
 <li class="breadcrumb-item"><a href="{% url 'video' slug=form.instance.slug %}" title="{{form.instance.title}}">{{form.instance.title|title|truncatechars:45}}</a></li>
@@ -69,7 +69,7 @@
                 {% trans "The video is currently being encoded." %}
             </p>
             {% endif %}
-            
+
             {% if form.instance.get_encoding_step == "5 : transcripting audio" %}
             <p class="text-info">
                 {% trans "The video is currently being transcripted." %}
@@ -89,7 +89,7 @@
                 {{ field }} <label for="{{ field.id_for_label }}" class="form-check-label" >{{ field.label }}</label>
                 </div>
                 {% else %}
-                <label for="{{ field.id_for_label }}">{{ field.label }}</label> 
+                <label for="{{ field.id_for_label }}">{{ field.label }}</label>
                 {% if "form-control-file" in field.field.widget.attrs.class and form.instance.video %}<br/>{%endif%}
                 {{ field }}
                 {% endif %}
@@ -107,11 +107,9 @@
         <div class="card" id='js-process'>
           <div class="card-body">
             <h5 class="card-title">{% trans "Sending, please wait." %}</h5>
-            <!--
-            <div class="spinner-border" role="status">
+            <div class="spinner-border hidespinner" role="status">
                 <span class="sr-only">{% trans "Loading" %}...</span>
             </div>
-            -->
             <p class="card-text">{% progress_bar %}</p>
           </div>
           <div class="card-footer">
@@ -120,7 +118,7 @@
         </div>
     <!--</div>-->
     <div class="text-center">
-        <button type="submit" class="btn btn-primary btn-sm m-2" name="_continue" value="">{% trans 'Save and continue editing' %}</button> 
+        <button type="submit" class="btn btn-primary btn-sm m-2" name="_continue" value="">{% trans 'Save and continue editing' %}</button>
         {% if form.instance.title %}<button type="submit" class="btn btn-primary btn-sm m-2" name="_saveandsee" value="{{form.instance.get_full_url}}">{% trans 'Save and see' %}</button> {%endif%}
         <a href="{% url 'my_videos' %}" title="{% trans 'My videos' %}" class="btn btn-secondary btn-sm m-2">{% trans 'back to my videos' %}</a>
     </div>


### PR DESCRIPTION
J'ai mis le lien du partage en mode brouillon dans la zone d'info sous la vidéo, onglet partage. J'ai vérifié le javascript et découvert des bugs dans le javascript (selon les cases cochées, on pouvait avoir 2 points d'interrogations dans les paramètres d'url). Reste le QR code qui ne fonctionne pas de manière optimale. Il n'accepte que le premier paramètre dans l'url.