### PR TITLE
Csrf samesite chrome support

### DIFF
--- a/pod/custom/settings_local.py.example
+++ b/pod/custom/settings_local.py.example
@@ -1015,7 +1015,7 @@ H5P_LANGUAGE = 'fr'
 BASE_URL = 'https://pod.univ.fr/'
 
 """
-#Vous pouvez définir le drapeau SameSite sur tous les cookies
-#(même sur ceux provenant d'applications Django tierces)
+# Vous pouvez définir le drapeau SameSite sur tous les cookies
+# (même sur ceux provenant d'applications Django tierces)
 """
 SESSION_COOKIE_SAMESITE_FORCE_ALL = True

--- a/pod/custom/settings_local.py.example
+++ b/pod/custom/settings_local.py.example
@@ -1014,3 +1014,8 @@ H5P_EXPORT = '/exports/'
 H5P_LANGUAGE = 'fr'
 BASE_URL = 'https://pod.univ.fr/'
 
+"""
+#Vous pouvez définir le drapeau SameSite sur tous les cookies
+#(même sur ceux provenant d'applications Django tierces)
+"""
+SESSION_COOKIE_SAMESITE_FORCE_ALL = True

--- a/pod/custom/settings_local.py.example
+++ b/pod/custom/settings_local.py.example
@@ -1015,7 +1015,12 @@ H5P_LANGUAGE = 'fr'
 BASE_URL = 'https://pod.univ.fr/'
 
 """
-# Vous pouvez définir le drapeau SameSite sur tous les cookies
+# Vous pouvez définir le drapeau Http cookie SameSite sur tous les cookies
 # (même sur ceux provenant d'applications Django tierces)
 """
 SESSION_COOKIE_SAMESITE_FORCE_ALL = True
+"""
+# Vous pouvez définir le drapeau Http cookie SameSite à:
+# 'Strict', 'Lax' ou 'None'
+"""
+SESSION_COOKIE_SAMESITE = 'Lax'

--- a/pod/settings.py
+++ b/pod/settings.py
@@ -67,6 +67,8 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    # Django 3.1 starts to support SameSite middleware
+    'django_cookies_samesite.middleware.CookiesSameSite',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ django-shibboleth-remoteuser
 django-chunked-upload==2.0.0
 requests==2.25.1
 chardet==4.0.0
+django-cookies-samesite==0.8.0


### PR DESCRIPTION
@ptitloup  @JoshuaBaubry Fixer problème csrf  lors de la soumission du formulaire sur le partage inter-serveur  par iframe des vidéos protégées par un mdp.
PS: Pas besoin de ce package avec la version 3.1 de Django