### PR TITLE
Trim username's spaces when user authenticates via CAS.

### DIFF
--- a/pod/authentication/populatedCASbackend.py
+++ b/pod/authentication/populatedCASbackend.py
@@ -79,6 +79,7 @@ def populateUser(tree):
     username_element = tree.find(
         ".//{http://www.yale.edu/tp/cas}%s" % AUTH_CAS_USER_SEARCH
     )
+    username_element.text = username_element.text.strip()
     username = username_element.text
     if CAS_FORCE_LOWERCASE_USERNAME:
         username = username.lower()


### PR DESCRIPTION
This pull request assumes that there is no case needing username with spaces when CAS authentication is used. So this behavior is not configurable. However if you feel it should be, I can make it configurable.