### PR TITLE
Change Python versions in ci/cd

### DIFF
--- a/.github/workflows/pod.yml
+++ b/.github/workflows/pod.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pod.yml
+++ b/.github/workflows/pod.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/pod/authentication/rest_views.py
+++ b/pod/authentication/rest_views.py
@@ -23,6 +23,7 @@ class OwnerSerializer(serializers.HyperlinkedModelSerializer):
             "commentaire",
             "hashkey",
             "userpicture",
+            "sites"
         )
 
 
@@ -72,7 +73,7 @@ class SiteSerializer(serializers.HyperlinkedModelSerializer):
 class AccessGroupSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = AccessGroup
-        fields = ("display_name", "code_name", "sites", "users")
+        fields = ("display_name", "code_name", "sites", "users", "sites")
 
 
 # ViewSets define the view behavior.

--- a/pod/authentication/rest_views.py
+++ b/pod/authentication/rest_views.py
@@ -23,7 +23,7 @@ class OwnerSerializer(serializers.HyperlinkedModelSerializer):
             "commentaire",
             "hashkey",
             "userpicture",
-            "sites"
+            "sites",
         )
 
 

--- a/pod/live/rest_views.py
+++ b/pod/live/rest_views.py
@@ -7,7 +7,7 @@ from rest_framework import serializers, viewsets
 class BuildingSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Building
-        fields = ("id", "url", "name", "headband", "gmapurl")
+        fields = ("id", "url", "name", "headband", "gmapurl", "sites")
 
 
 class BroadcasterSerializer(serializers.HyperlinkedModelSerializer):

--- a/pod/recorder/rest_views.py
+++ b/pod/recorder/rest_views.py
@@ -11,14 +11,7 @@ class RecordingModelSerializer(serializers.HyperlinkedModelSerializer):
 class RecorderModelSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Recorder
-        fields = (
-            "id",
-            "name",
-            "description",
-            "address_ip",
-            "recording_type",
-            "sites"
-        )
+        fields = ("id", "name", "description", "address_ip", "recording_type", "sites")
 
 
 class RecordingFileModelSerializer(serializers.HyperlinkedModelSerializer):

--- a/pod/recorder/rest_views.py
+++ b/pod/recorder/rest_views.py
@@ -11,7 +11,14 @@ class RecordingModelSerializer(serializers.HyperlinkedModelSerializer):
 class RecorderModelSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Recorder
-        fields = ("id",)
+        fields = (
+            "id",
+            "name",
+            "description",
+            "address_ip",
+            "recording_type",
+            "sites"
+        )
 
 
 class RecordingFileModelSerializer(serializers.HyperlinkedModelSerializer):

--- a/pod/video/rest_views.py
+++ b/pod/video/rest_views.py
@@ -38,6 +38,7 @@ class ChannelSerializer(serializers.HyperlinkedModelSerializer):
             "users",
             "visible",
             "themes",
+            "sites"
         )
 
 
@@ -171,6 +172,7 @@ class VideoRenditionSerializer(serializers.HyperlinkedModelSerializer):
             "video_bitrate",
             "audio_bitrate",
             "encode_mp4",
+            "sites"
         )
 
 

--- a/pod/video/rest_views.py
+++ b/pod/video/rest_views.py
@@ -38,7 +38,7 @@ class ChannelSerializer(serializers.HyperlinkedModelSerializer):
             "users",
             "visible",
             "themes",
-            "sites"
+            "sites",
         )
 
 
@@ -172,7 +172,7 @@ class VideoRenditionSerializer(serializers.HyperlinkedModelSerializer):
             "video_bitrate",
             "audio_bitrate",
             "encode_mp4",
-            "sites"
+            "sites",
         )
 
 


### PR DESCRIPTION
Je propose de supprimer python 3.5 des versions à tester lors du ci/cd et de plutot rajouter python 3.8 