### PR TITLE
Improve filter aside from Videos page

### DIFF
--- a/pod/video/static/js/filter_aside_video_list_refresh.js
+++ b/pod/video/static/js/filter_aside_video_list_refresh.js
@@ -1,0 +1,80 @@
+var infinite_waypoint;
+var formCheckedInputs=[];
+var regExGetOnlyChars = /([\D])/g;
+
+function getInfiniteScrollWaypoint(){
+  // Return Waypoint Infinite object to init/refresh the infinite scroll
+  return new Waypoint.Infinite({
+    element: $('#videos_list')[0],
+    onBeforePageLoad: function () {
+      $('.infinite-loading').show();
+    },
+    onAfterPageLoad: function ($items) {
+      $('.infinite-loading').hide();
+      feather.replace({ class: 'align-bottom'});
+      $('footer.static-pod').addClass('small');
+      $('footer.static-pod').addClass('fixed-bottom');
+      $('footer.static-pod').attr('style','height:80px; overflow-y:auto');
+      $('footer.static-pod .hidden-pod').css('display','none');
+      $(window).scroll(function () {
+        if ($(window).height() + $(window).scrollTop() === $(document).height())
+        {
+          $('footer.static-pod .hidden-pod').css('display','block');
+          $('footer.static-pod').attr('style','height:auto;');
+          $('footer.static-pod').removeClass('fixed-bottom');
+        }
+      });
+    }
+  });
+}
+
+function replaceCountVideos(newCount){
+  // Replace count videos label (h1) with translation and plural
+  var transVideoCount = newCount > 1 ? 'videos found' : 'video found';
+  $('#video_count')[0].innerHTML = newCount +" "+ gettext(transVideoCount);
+}
+
+function refreshVideosSearch(formCheckedInputs){
+  // Ajax request to refresh view with filtered video list
+  return $.ajax({
+    type : 'GET',
+    url: urlVideos,
+    data:formCheckedInputs,
+    dataType : 'html',
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest'
+    },
+    success: function(html, status){
+      if(infinite_waypoint){
+        infinite_waypoint.destroy();
+      }
+      $('.infinite-loading').remove();
+      $('.infinite-more-link').remove();
+      $('#videos_list').replaceWith(html);
+      replaceCountVideos(countVideos);
+      window.history.pushState({}, "", this.url);
+    },
+    error : function(result, status, error){
+      $('#videos_list').html(gettext('An Error occurred while processing '));
+    },
+  });
+}
+
+$('.form-check-input').change(function () {
+  // Filter checkboxes change triggered event
+  formCheckedInputs=[];
+  $('.infinite-loading').show();
+  $('.form-check-input input[type=checkbox]').attr('disabled','true');
+  $('#videos_list').html("");
+  $('input[type=checkbox]:checked').each(function(){
+    formCheckedInputs.push(this);
+  });
+  refreshVideosSearch(formCheckedInputs).done(function() {
+    $('.infinite-loading').hide();
+    infinite_waypoint = getInfiniteScrollWaypoint();
+    $('.form-check-input input[type=checkbox]').removeAttr('disabled');
+  });
+});
+
+// First launch of the infinite scroll
+infinite_waypoint = getInfiniteScrollWaypoint();

--- a/pod/video/templates/videos/filter_aside.html
+++ b/pod/video/templates/videos/filter_aside.html
@@ -11,7 +11,7 @@
 <form action="{% url 'videos' %}" method="get" id="filters">
 {% if not HIDE_USER_FILTER and user.is_authenticated %}
   <fieldset>
-    <legend  class="h5"><i data-feather="users"></i> {% trans "Users" %} <button type="submit" class="btn btn-link btn-sm float-right" title="{% trans "Send" %}"><i data-feather="send"></i></button></legend>
+    <legend  class="h5"><i data-feather="users"></i> {% trans "Users" %}</legend>
     <div class="form-group">
       <label for="ownerbox">{% trans "Filter by user" %}</label>
       <input placeholder="{% trans 'Search' %}" id="ownerbox" type="text" class="form-control">
@@ -33,7 +33,7 @@
 {% endif %}
 
 <fieldset class="border-right border-bottom mt-2">
-  <legend class="h5"><i data-feather="tv"></i> {% trans "Types"%} <button type="submit" class="btn btn-link btn-sm float-right" title="{% trans "Send" %}"><i data-feather="send"></i></button></legend>
+  <legend class="h5"><i data-feather="tv"></i> {% trans "Types"%} </legend>
   <div id="filterType">
     <div class="form-group collapse" id="collapseFilterType">
       {% for type in TYPES %}
@@ -52,10 +52,8 @@
   </div><!-- type -->
 </fieldset>
 
-<!-- <button type="submit" class="btn btn-link">&gt;&gt;{% trans "Filter"%}</button> -->
-
 <fieldset class="border-right border-bottom mt-2">
-  <legend class="h5"><i data-feather="book"></i> {% trans "Disciplines"%} <button type="submit" class="btn btn-link btn-sm float-right" title="{% trans "Send" %}"><i data-feather="send"></i></button></legend>
+  <legend class="h5"><i data-feather="book"></i> {% trans "Disciplines"%} </legend>
   <div id="filterDiscipline">
     <div class="form-group collapse" id="collapseFilterDiscipline">
       {% for discipline in DISCIPLINES %}
@@ -74,10 +72,8 @@
   </div><!-- filterdiscipline -->
 </fieldset>
 
-<!-- <button type="submit" class="btn btn-link">&gt;&gt;{% trans "Filter"%}</button> -->
-
 <fieldset class="border-right border-bottom mt-2">
-  <legend class="h5"><i data-feather="tag"></i> {% trans "Tags"%}<button type="submit" class="btn btn-link btn-sm float-right" title="{% trans "Send" %}"><i data-feather="send"></i></button></legend>
+  <legend class="h5"><i data-feather="tag"></i> {% trans "Tags"%}</legend>
   <div id="filterTag">
     {% with tagslist=tagscloud|dictsortreversed:"count"|slice:":20" %}
     <div class="form-group collapse" id="collapseFilterTag">
@@ -101,7 +97,7 @@
 
 
 <fieldset class="border-right border-bottom mt-2">
-  <legend class="h5"><i data-feather="archive"></i> {% trans "University course"%}<button type="submit" class="btn btn-link btn-sm float-right" title="{% trans "Send" %}"><i data-feather="send"></i></button></legend>
+  <legend class="h5"><i data-feather="archive"></i> {% trans "University course"%}</legend>
   <div id="filterCursus">
     <div class="form-group collapse" id="collapseFilterCursus">
       {% for keyCursus , transCursus in cursus_list %}
@@ -119,7 +115,6 @@
     {% endif %}
   </div>
 </fieldset>
-<!-- <button type="submit" class="btn btn-link">&gt;&gt;{% trans "Filter"%}</button> -->
 </form>
 
 </div>

--- a/pod/video/templates/videos/video_list.html
+++ b/pod/video/templates/videos/video_list.html
@@ -18,3 +18,6 @@
   {% trans "Loading..." %}
 </div>
 {% endspaceless %}
+<script type="text/javascript">
+var countVideos = "{{ count_videos }}";
+</script>

--- a/pod/video/templates/videos/videos.html
+++ b/pod/video/templates/videos/videos.html
@@ -3,35 +3,39 @@
 {% load staticfiles %}
 
 {% block opengraph %}{% load video_filters %}
-  <meta name="description" content="{{ DESC_SITE }} &mdash; {% blocktrans count counter=videos.paginator.count %}{{ counter }} video found{% plural %}{{ counter }} videos found{% endblocktrans %}" />
+  <meta name="description" content="{% blocktrans count counter=count_videos %}{{ counter }} video found{% plural %}{{ counter }} videos found{% endblocktrans %}" />
   <!-- Open Graph data -->
   <meta property="og:title" content="{% trans 'Videos' %}" />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="{{ request.build_absolute_uri }}" />
   <meta property="og:image" content="//{{ request.META.HTTP_HOST }}{% static LOGO_SITE %}" />
-  <meta property="og:description" content="{{ DESC_SITE }} - {% blocktrans count counter=videos.paginator.count %}{{ counter }} video found{% plural %}{{ counter }} videos found{% endblocktrans %}" />
+  <meta property="og:description" content="{{ DESC_SITE }} - {% blocktrans count counter=count_videos %}{{ counter }} video found{% plural %}{{ counter }} videos found{% endblocktrans %}" />
   <meta property="og:site_name" content="{{ TITLE_SITE }}" />
 {% endblock %}
 
 
 {% block breadcrumbs %}{{ block.super }} <li class="breadcrumb-item active" aria-current="page">{% trans "Videos" %}</li>{% endblock %}
 
-{% block page_title %}{% blocktrans count counter=videos.paginator.count %}{{ counter }} video found{% plural %}{{ counter }} videos found{% endblocktrans %}{% endblock %}
+{% block page_title %}{% blocktrans count counter=count_videos %}{{ counter }} video found{% plural %}{{ counter }} videos found{% endblocktrans %}{% endblock %}
 
 
 {% block page_content %}
 
-  <h1>{% blocktrans count counter=videos.paginator.count %}{{ counter }} video found{% plural %}{{ counter }} videos found{% endblocktrans %}
-    <span class="float-right">
-    	{% if USE_STATS_VIEW %}
-        <a href="{% url "video_stats_view" 'videos'  %}" title="{% trans 'Show view statistics for all videos' %}" target="_blank" rel="noopener" class="btn btn-outline-primary btn-sm"> {% trans "Statistics views" %}</a>
-      {% endif %}
-      <a href="feed://{{ request.META.HTTP_HOST }}{% url "rss-video"%}?{{request.GET.urlencode}}" title="{% trans 'subscribe to the video feed'%}" target="_blank" class="btn btn btn-outline-primary btn-sm">
-        <i data-feather="rss"></i>&nbsp;Video</a>
-      <a href="feed://{{ request.META.HTTP_HOST }}{% url "rss-audio"%}?{{request.GET.urlencode}}" title="{% trans 'subscribe to the audio feed'%}" target="_blank" class="btn btn btn-outline-primary btn-sm">
-        <i data-feather="rss"></i>&nbsp;Audio</a>
-    </span>
-  </h1>
+  <div class="row">
+    <div class="col">
+      <h1 id="video_count">{% blocktrans count counter=count_videos %}{{ counter }} video found{% plural %}{{ counter }} videos found{% endblocktrans %}</h1>
+    </div>
+      <span class="float-left col">
+        <a href="feed://{{ request.META.HTTP_HOST }}{% url 'rss-audio'%}?{{request.GET.urlencode}}" title="{% trans 'subscribe to the audio feed'%}" target="_blank" class="btn btn btn-outline-primary btn-sm float-right">
+          <i data-feather="rss"></i>&nbsp;Audio</a>
+        <a href="feed://{{ request.META.HTTP_HOST }}{% url 'rss-video'%}?{{request.GET.urlencode}}" title="{% trans 'subscribe to the video feed'%}" target="_blank" class="btn btn btn-outline-primary btn-sm float-right">
+          <i data-feather="rss"></i>&nbsp;Video</a>
+        {% if USE_STATS_VIEW %}
+          <a href="{% url 'video_stats_view' 'videos'  %}" title="{% trans 'Show view statistics for all videos' %}" target="_blank" rel="noopener" class="btn btn-outline-primary btn-sm float-right" style="height:35.8px"> {% trans "Statistics views" %}</a>
+        {% endif %}
+      </span>
+  </div>
+
   {% comment %}
   <p>
     "types": request.GET.getlist('type'),
@@ -53,9 +57,15 @@
 {% block more_script %}
 <script src="{% static 'js/jquery.waypoints.min.js' %}?ver={{VERSION}}"></script>
 <script src="{% static 'js/infinite.min.js' %}?ver={{VERSION}}"></script>
-<script>
-  var infinite = new Waypoint.Infinite({
-    element: $('.infinite-container')[0],
+<script type="text/javascript">
+var infinite_waypoint;
+var formCheckedInputs=[];
+var regExGetOnlyChars = /([\D])/g;
+
+function getInfiniteScrollWaypoint(){
+  // Return Waypoint Infinite object to init/refresh the infinite scroll
+  return new Waypoint.Infinite({
+    element: $('#videos_list')[0],
     onBeforePageLoad: function () {
       $('.infinite-loading').show();
     },
@@ -67,14 +77,67 @@
       $('footer.static-pod').attr('style','height:80px; overflow-y:auto');
       $('footer.static-pod .hidden-pod').css('display','none');
       $(window).scroll(function () {
-        if ($(window).height() + $(window).scrollTop() == $(document).height())
+        if ($(window).height() + $(window).scrollTop() === $(document).height())
         {
-           $('footer.static-pod .hidden-pod').css('display','block');
-           $('footer.static-pod').attr('style','height:auto;');
-           $('footer.static-pod').removeClass('fixed-bottom');
+          $('footer.static-pod .hidden-pod').css('display','block');
+          $('footer.static-pod').attr('style','height:auto;');
+          $('footer.static-pod').removeClass('fixed-bottom');
         }
       });
     }
   });
+}
+
+function replaceCountVideos(newCount){
+  // Replace count videos label (h1) with translation and plural
+  var transVideoCount = newCount > 1 ? 'videos found' : 'video found';
+  $('#video_count')[0].innerHTML = newCount +" "+ gettext(transVideoCount);
+}
+
+function refreshVideosSearch(formCheckedInputs){
+  // Ajax request to refresh view with filtered video list
+  return $.ajax({
+    type : 'GET',
+    crossDomain: true,
+    url: '{% url "videos" %}',
+    data:formCheckedInputs,
+    dataType : 'html',
+    headers: {
+      'X-Requested-With': 'XMLHttpRequest'
+    },
+    success: function(html, status){
+      if(infinite_waypoint){
+        infinite_waypoint.destroy();
+      }
+      $('.infinite-loading').remove();
+      $('.infinite-more-link').remove();
+      $('#videos_list').replaceWith(html);
+      replaceCountVideos(countVideos);
+      window.history.pushState({}, "", this.url);
+    },
+    error : function(result, status, error){
+      $('#videos_list').html(gettext('An Error occurred while processing '));
+    },
+  });
+}
+
+$('.form-check-input').change(function () {
+  // Filter checkboxes change triggered event
+  formCheckedInputs=[];
+  $('.infinite-loading').show();
+  $('.form-check-input input[type=checkbox]').attr('disabled','true');
+  $('#videos_list').html("");
+  $('input[type=checkbox]:checked').each(function(){
+    formCheckedInputs.push(this);
+  });
+  refreshVideosSearch(formCheckedInputs).done(function() {
+    $('.infinite-loading').hide();
+    infinite_waypoint = getInfiniteScrollWaypoint();
+    $('.form-check-input input[type=checkbox]').removeAttr('disabled');
+  });
+});
+
+// First launch of the infinite scroll
+infinite_waypoint = getInfiniteScrollWaypoint();
 </script>
 {% endblock more_script %}

--- a/pod/video/templates/videos/videos.html
+++ b/pod/video/templates/videos/videos.html
@@ -55,89 +55,10 @@
 
 
 {% block more_script %}
+<script type="text/javascript">
+const urlVideos = "{% url 'videos' %}";
+</script>
 <script src="{% static 'js/jquery.waypoints.min.js' %}?ver={{VERSION}}"></script>
 <script src="{% static 'js/infinite.min.js' %}?ver={{VERSION}}"></script>
-<script type="text/javascript">
-var infinite_waypoint;
-var formCheckedInputs=[];
-var regExGetOnlyChars = /([\D])/g;
-
-function getInfiniteScrollWaypoint(){
-  // Return Waypoint Infinite object to init/refresh the infinite scroll
-  return new Waypoint.Infinite({
-    element: $('#videos_list')[0],
-    onBeforePageLoad: function () {
-      $('.infinite-loading').show();
-    },
-    onAfterPageLoad: function ($items) {
-      $('.infinite-loading').hide();
-      feather.replace({ class: 'align-bottom'});
-      $('footer.static-pod').addClass('small');
-      $('footer.static-pod').addClass('fixed-bottom');
-      $('footer.static-pod').attr('style','height:80px; overflow-y:auto');
-      $('footer.static-pod .hidden-pod').css('display','none');
-      $(window).scroll(function () {
-        if ($(window).height() + $(window).scrollTop() === $(document).height())
-        {
-          $('footer.static-pod .hidden-pod').css('display','block');
-          $('footer.static-pod').attr('style','height:auto;');
-          $('footer.static-pod').removeClass('fixed-bottom');
-        }
-      });
-    }
-  });
-}
-
-function replaceCountVideos(newCount){
-  // Replace count videos label (h1) with translation and plural
-  var transVideoCount = newCount > 1 ? 'videos found' : 'video found';
-  $('#video_count')[0].innerHTML = newCount +" "+ gettext(transVideoCount);
-}
-
-function refreshVideosSearch(formCheckedInputs){
-  // Ajax request to refresh view with filtered video list
-  return $.ajax({
-    type : 'GET',
-    crossDomain: true,
-    url: '{% url "videos" %}',
-    data:formCheckedInputs,
-    dataType : 'html',
-    headers: {
-      'X-Requested-With': 'XMLHttpRequest'
-    },
-    success: function(html, status){
-      if(infinite_waypoint){
-        infinite_waypoint.destroy();
-      }
-      $('.infinite-loading').remove();
-      $('.infinite-more-link').remove();
-      $('#videos_list').replaceWith(html);
-      replaceCountVideos(countVideos);
-      window.history.pushState({}, "", this.url);
-    },
-    error : function(result, status, error){
-      $('#videos_list').html(gettext('An Error occurred while processing '));
-    },
-  });
-}
-
-$('.form-check-input').change(function () {
-  // Filter checkboxes change triggered event
-  formCheckedInputs=[];
-  $('.infinite-loading').show();
-  $('.form-check-input input[type=checkbox]').attr('disabled','true');
-  $('#videos_list').html("");
-  $('input[type=checkbox]:checked').each(function(){
-    formCheckedInputs.push(this);
-  });
-  refreshVideosSearch(formCheckedInputs).done(function() {
-    $('.infinite-loading').hide();
-    infinite_waypoint = getInfiniteScrollWaypoint();
-    $('.form-check-input input[type=checkbox]').removeAttr('disabled');
-  });
-});
-
-// First launch of the infinite scroll
-infinite_waypoint = getInfiniteScrollWaypoint();
-</script>
+<script src="{% static 'js/filter_aside_video_list_refresh.js' %}"></script>
 {% endblock more_script %}

--- a/pod/video/views.py
+++ b/pod/video/views.py
@@ -574,6 +574,7 @@ def get_owners_has_instances(owners):
 def videos(request):
     """Render the main list of videos."""
     videos_list = get_videos_list(request)
+    count_videos = len(videos_list)
 
     page = request.GET.get("page", 1)
     full_path = ""
@@ -598,7 +599,7 @@ def videos(request):
         return render(
             request,
             "videos/video_list.html",
-            {"videos": videos, "full_path": full_path},
+            {"videos": videos, "full_path": full_path, "count_videos": count_videos},
         )
 
     return render(
@@ -606,6 +607,7 @@ def videos(request):
         "videos/videos.html",
         {
             "videos": videos,
+            "count_videos": count_videos,
             "types": request.GET.getlist("type"),
             "owners": request.GET.getlist("owner"),
             "disciplines": request.GET.getlist("discipline"),


### PR DESCRIPTION
Improve filter aside from Videos page : refresh filtered videos list without reloading (GET form request -> GET-Type Ajax calls), update 'videos found' count with translation and plural managment and keep infinite scroll behaviour.