### PR TITLE
[DONE] Correct CSS for Django 3 Admin pages

### DIFF
--- a/pod/completion/admin.py
+++ b/pod/completion/admin.py
@@ -1,3 +1,4 @@
+"""Admin pages for Esup-Pod Completion items."""
 from django.conf import settings
 from django.contrib import admin
 from pod.completion.models import Contributor
@@ -89,9 +90,10 @@ class DocumentAdmin(admin.ModelAdmin):
         return super().formfield_for_foreignkey(db_field, request, **kwargs)
 
     class Media:
+        USE_THEME = getattr(settings, "USE_THEME", "default")
         css = {
             "all": (
-                "bootstrap-4/css/bootstrap.min.css",
+                "bootstrap-4/css/bootstrap-%s.min.css" % USE_THEME,
                 "bootstrap-4/css/bootstrap-grid.css",
                 "css/pod.css",
             )

--- a/pod/custom/settings_local.py.example
+++ b/pod/custom/settings_local.py.example
@@ -399,7 +399,7 @@ TEMPLATE_VISIBLE_SETTINGS = {
     # Vous pouvez créer un template dans votre application custom et
     #  indiquer son chemin dans cette variable pour que ce code html,
     # ce template soit affiché en haut de votre page, le code est ajouté
-    #  juste après la balise body.(Or iframe)
+    #  juste après la balise body.(Hors iframe)
     # Si le fichier créé est
     # '/opt/django_projects/podv2/pod/custom/templates/custom/preheader.html'
     # alors la variable doit prendre la valeur 'custom/preheader.html'
@@ -1223,10 +1223,9 @@ BBB_VERSION_IS_23 = False
 USER_VIDEO_CATEGORY = False
 
 """
-# gestion de l'oboslesence des vidéos
+# gestion de l'obsolesence des vidéos
 """
-USE_OBSOLESCENCE = True
-
+USE_OBSOLESCENCE = False
 WARN_DEADLINES = [60, 30, 7]
 
 """
@@ -1320,3 +1319,18 @@ COOKIE_LEARN_MORE = ""
 #     'TRACKING_TEMPLATE': 'custom/tracking.html',
 """
 USE_VIDEO_EVENT_TRACKING = False
+
+"""CACHE configurations."""
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+    # Persistent cache setup for select2 (NOT DummyCache or LocMemCache).
+    "select2": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/2",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        }
+    }
+}

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -28,6 +28,9 @@
   --light: #f8f9fa;
   --dark: #343a40;
   --color-formfields: #f1f1f1;
+
+  /* Use system font */
+  --font-family-sans-serif : -apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Verdana,sans-serif;
 }
 
 /* copy "alert-danger" style from Bootstrap 4 */
@@ -682,3 +685,42 @@ input.select2-input {
   margin: 0 !important;
 }
 
+/** Django 3 Admin pages
+ *  (must be set after Bootsrap to reset Django defaults)
+ **/
+body[data-admin-utc-offset] {
+  --primary:  #79aec8;
+  --breadcrumbs-bg: var(--primary);
+  --button-bg: var(--primary);
+}
+body[data-admin-utc-offset] caption{
+  caption-side: top;
+}
+
+body[data-admin-utc-offset] h1{ font-size: 20px;}
+body[data-admin-utc-offset] h2{ font-size: 18px;}
+body[data-admin-utc-offset] h3{ font-size: 16px;}
+
+body[data-admin-utc-offset] .hidden{
+  display: none;
+}
+body[data-admin-utc-offset] .btn-outline-primary{
+  color: var(--link-fg);
+}
+body[data-admin-utc-offset] .btn-outline-primary:hover,
+body[data-admin-utc-offset] .btn-outline-primary:focus{
+  background-color: var(--primary);
+  color: var(--light);
+}
+body[data-admin-utc-offset] .form-row.errors{
+  display: block;
+}
+/* System/browser dark mode */
+@media (prefers-color-scheme: dark) {
+  body[data-admin-utc-offset] {
+    --primary:  #264b5d;
+    --secondary: #417690;
+    --font-color: #eeeeee;
+    --bg-color:  #121212;
+  }
+}

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -30,7 +30,7 @@
   --color-formfields: #f1f1f1;
 
   /* Use system font */
-  --font-family-sans-serif : -apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Verdana,sans-serif;
+  --font-family-sans-serif : -apple-system,system-ui,BlinkMacSystemFont,"Segoe UI",Roboto,Verdana,sans-serif;
 }
 
 /* copy "alert-danger" style from Bootstrap 4 */
@@ -136,17 +136,8 @@ a.btn-outline-primary svg.feather {
   height: 35px;
 }
 
-.select2-container {
-  position: static !important;
-  height:auto;
-}
-
 tr,.rowl {
   display: table-row !important;
-}
-
-body[data-admin-utc-offset] {
-  padding-top: 0;
 }
 
 body {
@@ -642,11 +633,6 @@ footer a:hover {
   font-size: 1.2em;
 }
 
-/*** Useful for additional owners ***/
-input.select2-input {
-  width: 100% !important;
-}
-
 #view-counter-icon {
   color: var(--primary);
 }
@@ -688,6 +674,10 @@ input.select2-input {
 /** Django 3 Admin pages
  *  (must be set after Bootsrap to reset Django defaults)
  **/
+body[data-admin-utc-offset] {
+  padding-top: 0;
+}
+
 body[data-admin-utc-offset] {
   --primary:  #79aec8;
   --breadcrumbs-bg: var(--primary);

--- a/pod/main/templates/admin/base_site.html
+++ b/pod/main/templates/admin/base_site.html
@@ -1,8 +1,11 @@
 {% extends "admin/base.html" %}
 {% load i18n static %}
 {% block extrastyle %}
-<script src="{% static 'js/jquery-3.3.1.min.js' %}"></script>
-<script> var max_duration_date_delete = {{max_duration_date_delete}};</script>
+  <script src="{% static 'js/jquery-3.3.1.min.js' %}"></script>
+  <script src="{% static 'js/js.cookie.js' %}?ver={{VERSION}}"></script>
+  {% if max_duration_date_delete %}
+    <script> var max_duration_date_delete = {{max_duration_date_delete}};</script>
+  {% endif %}
 {% endblock %}
 
 {% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}

--- a/pod/main/views.py
+++ b/pod/main/views.py
@@ -316,6 +316,7 @@ def remove_accents(input_str):
 
 @login_required(redirect_field_name="referrer")
 def user_autocomplete(request):
+    """Search for users with partial names, for autocompletion."""
     if request.is_ajax():
         additional_filters = {
             "video__is_draft": False,

--- a/pod/settings.py
+++ b/pod/settings.py
@@ -205,10 +205,11 @@ LOGGING = {
 }
 
 CACHES = {
+    # … default cache config and others
     'default': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     },
-    # … default cache config and others
+    # Persistent cache setup for select2 (NOT DummyCache or LocMemCache).
     "select2": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": "redis://127.0.0.1:6379/2",
@@ -217,7 +218,6 @@ CACHES = {
         }
     }
 }
-
 
 # Tell select2 which cache configuration to use:
 SELECT2_CACHE_BACKEND = "select2"

--- a/pod/video/admin.py
+++ b/pod/video/admin.py
@@ -1,3 +1,4 @@
+"""Admin pages for Esup-Pod Video items."""
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.auth.models import User
@@ -245,11 +246,12 @@ class VideoAdmin(admin.ModelAdmin):
             obj.save()
 
     class Media:
+        USE_THEME = getattr(settings, "USE_THEME", "default")
         css = {
             "all": (
-                "css/pod.css",
-                "bootstrap-4/css/bootstrap.min.css",
+                "bootstrap-4/css/bootstrap-%s.min.css" % USE_THEME,
                 "bootstrap-4/css/bootstrap-grid.css",
+                "css/pod.css",
             )
         }
         js = (
@@ -272,7 +274,8 @@ class updateOwnerAdmin(admin.ModelAdmin):
 
     def has_add_permission(self, request, obj=None):
         """Manage create new instance link from admin interface.
-        if return False no add link
+
+        if return False, no add link
 
         Args:
             request (Request): Http request


### PR DESCRIPTION
* Add CSS in pod.css to reset django defaults
* Use bootstrap-THEME.css instead of default one
* Call pod.css AFTER bootsrap.css on admin pages

* [JS] set max_duration_date_delete only when necessary to avoid js error.
* Call js.cookie.js in admin base.html to avoid a js error "Undefined Cookies".