### PR TITLE
Use config DEFAULT_TYPE_ID parameter

### DIFF
--- a/pod/video/views.py
+++ b/pod/video/views.py
@@ -156,7 +156,7 @@ TRANSCRIPT = getattr(settings, "USE_TRANSCRIPTION", False)
 VIEW_STATS_AUTH = getattr(settings, "VIEW_STATS_AUTH", False)
 ACTIVE_VIDEO_COMMENT = getattr(settings, "ACTIVE_VIDEO_COMMENT", False)
 USE_CATEGORY = getattr(settings, "USER_VIDEO_CATEGORY", False)
-
+DEFAULT_TYPE_ID = getattr(settings, "DEFAULT_TYPE_ID", 1)
 DEFAULT_RECORDER_TYPE_ID = getattr(settings, "DEFAULT_RECORDER_TYPE_ID", 1)
 
 # ############################################################################
@@ -2587,7 +2587,7 @@ class PodChunkedUploadCompleteView(ChunkedUploadCompleteView):
             video = Video.objects.create(
                 video=uploaded_file,
                 owner=request.user,
-                type=Type.objects.get(id=1),
+                type=Type.objects.get(id=DEFAULT_TYPE_ID),
                 title=uploaded_file.name,
                 transcript=(True if (transcript == "true") else False),
             )


### PR DESCRIPTION
Lors de la création d'une vidéo (en mode chunked) le type attribué par défaut est celui dont l'id est 1. Or si on a supprimé le type N°1 (Other) ça ne marche plus. Dans les settings le paramètre DEFAULT_TYPE_ID semble être là pour ça mais n'est pas utilisé. D'où cette mini-PR