### PR TITLE
fix indentation on theme

### DIFF
--- a/pod/main/static/js/main.js
+++ b/pod/main/static/js/main.js
@@ -202,7 +202,7 @@ var get_list = function (
     if (count > 0 && !show_only_parent_themes) {
       list += get_list(
         child,
-        (level += 1),
+        level + 1,
         tab_selected,
         tag_type,
         li_class,


### PR DESCRIPTION
Corrige un problème d'indentation des |- dans la présentation des sous-thèmes
![theme_avant_correction](https://user-images.githubusercontent.com/7648557/161057478-ee67b457-5183-4d69-87a7-482c9a505083.png)
![theme_apres_correction](https://user-images.githubusercontent.com/7648557/161057677-191ad1ad-a5d6-49c3-ac17-3d0fb8aef1f6.png)

