### PR TITLE
[DONE] Update Github workflows

### DIFF
--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Check for modified files
         id: prettier-git-check
-        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+        run: echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
 
       - name: Push changes
         if: steps.prettier-git-check.outputs.modified == 'true'
@@ -34,7 +34,7 @@ jobs:
 
       - name: Check for modified files
         id: black-git-check
-        run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+        run: echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
 
       - name: Commit changes
         if: steps.black-git-check.outputs.modified == 'true'

--- a/.github/workflows/pod.yml
+++ b/.github/workflows/pod.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9] # , 3.10.6
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure sysctl limits (for ES)
         run: |
@@ -25,7 +25,7 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
* Replace deprecated set-output by >> $GITHUB_OUTPUT
 (see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ )
* Upgrade actions/checkout to @V3 and actions/setup-python to @v4 (see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ )
