### PR TITLE
Changement lib stats et améliorations (dev)

### DIFF
--- a/pod/locale/fr/LC_MESSAGES/django.po
+++ b/pod/locale/fr/LC_MESSAGES/django.po
@@ -7523,3 +7523,38 @@ msgstr "Désolé, la recherche de vidéos est limitée à 500 pages maximum."
 #: pod/video_search/views.py:261
 msgid "Search results"
 msgstr "Résultats de la recherche"
+
+
+msgid "My stats"
+msgstr "Mes statistiques"
+
+msgid "Views during the day"
+msgstr "Vues pour ce jour"
+
+msgid "Views during the month"
+msgstr "Vues pour ce mois"
+
+msgid "Views during the year"
+msgstr "Vue pour cette année"
+
+msgid "Total views from creation"
+msgstr "Vues totales depuis la création"
+
+msgid "See detail"
+msgstr "Voir détail"
+
+msgid "Detail"
+msgstr "Détail"
+
+msgid "Download as"
+msgstr "Télécharger en "
+
+msgid "Views per day"
+msgstr "Vues par jour"
+
+msgid "Cumulative views"
+msgstr "Vues cumulées"
+
+msgid "Viewcount of %s"
+msgstr "Vues of %s"
+

--- a/pod/locale/nl/LC_MESSAGES/django.po
+++ b/pod/locale/nl/LC_MESSAGES/django.po
@@ -6871,3 +6871,38 @@ msgstr ""
 #: pod/video_search/views.py:261
 msgid "Search results"
 msgstr ""
+
+
+msgid "My stats"
+msgstr ""
+
+msgid "Views during the day"
+msgstr ""
+
+msgid "Views during the month"
+msgstr ""
+
+msgid "Views during the year"
+msgstr ""
+
+msgid "Total views from creation"
+msgstr ""
+
+msgid "See detail"
+msgstr ""
+
+msgid "Detail"
+msgstr ""
+
+msgid "Download as"
+msgstr ""
+
+msgid "Views per day"
+msgstr ""
+
+msgid "Cumulative views"
+msgstr ""
+
+msgid "Viewcount of %s"
+msgstr ""
+

--- a/pod/main/templates/navbar.html
+++ b/pod/main/templates/navbar.html
@@ -204,6 +204,9 @@
                   <a class="nav-item nav-link" href="{% url 'bbb:live_list_meeting' %}"><i class="bi bi-lightning-charge pod-nav-link-icon mx-1" aria-hidden="true"></i>{% trans 'Perform a BigBlueButton live' %}</a>
                 {% endif %}
               {% endif %}
+              {% if USE_STATS_VIEW %}
+                <a class="dropdown-item" href="{% url 'stats_view' %}"><i data-feather="trending-up" class="nav-link-icone d-lg-none d-xl-inline mx-1" aria-hidden="true"></i>{% trans 'My stats' %}</a>
+              {% endif %}
               {% comment %}
                 <a class="nav-item nav-link" href="#">Gestion de mon compte</a> {% endcomment %}
               <hr class="dropdown-divider">

--- a/pod/settings.py
+++ b/pod/settings.py
@@ -229,6 +229,10 @@ SELECT2_CACHE_BACKEND = "select2"
 
 MODELTRANSLATION_FALLBACK_LANGUAGES = ("fr", "en")
 
+##
+# Stats table template
+DJANGO_TABLES2_TEMPLATE = "django_tables2/semantic.html"
+
 # MIGRATION_MODULES = {
 #     'flatpages': 'pod.db_migrations'
 # }

--- a/pod/settings.py
+++ b/pod/settings.py
@@ -43,6 +43,8 @@ INSTALLED_APPS = [
     "chunked_upload",
     "mozilla_django_oidc",
     "honeypot",
+    "django_tables2",
+    "chartjs",
     # Pod Applications
     "pod.main",
     "django.contrib.admin",  # put it here for template override

--- a/pod/video/table.py
+++ b/pod/video/table.py
@@ -1,0 +1,19 @@
+import django_tables2 as tables
+from django_tables2.export.views import ExportMixin
+from django.utils.translation import ugettext_lazy as _
+from django.utils.text import format_lazy
+
+class Stats_table(ExportMixin, tables.Table):
+    #template_name = "django_tables2/semantic.html"
+
+    export_formats = ['csv', 'xlsx', 'ods']
+
+    video_id = tables.Column(verbose_name="Id", order_by="id", orderable=True)
+    title = tables.Column(verbose_name=_("Title"), orderable=False)
+    day = tables.Column(verbose_name=_("Views during the day"), orderable=True)
+    month = tables.Column(verbose_name=_("Views during the month"), orderable=True)
+    year = tables.Column(verbose_name=_("Views during the year"), orderable=True)
+    since_created = tables.Column(verbose_name=_("Total views from creation"), orderable=True)
+    detail_link = tables.TemplateColumn(template_code=format_lazy('<button onclick="window.location.href={};">{}</button>', '\'{% url "video_stats_view" id=record.video_id %}\'', _("See detail")),
+        verbose_name=_("Detail"), orderable=False, exclude_from_export=True)
+

--- a/pod/video/templates/videos/stats_view.html
+++ b/pod/video/templates/videos/stats_view.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% load staticfiles i18n %}
+{% load render_table from django_tables2 %}
+{% load export_url from django_tables2 %}
+
+{% block opengraph %}
+  {{ block.super }}
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+{% endblock opengraph %}
+{% block page_title %}{{ title }}{% endblock page_title %}
+{% block page_extra_head %}
+  <link rel="stylesheet" href="{% static 'css/video_stats_view.css' %}?ver={{VERSION}}">
+{% endblock page_extra_head %}
+
+{% block content %}
+<div class="stats_table">
+  {% render_table table %}
+</div>
+<div class="export_stats, text-center">
+  {% for format in table.export_formats %}
+    <button onclick="window.location.href='{% export_url format %}';">
+      {% trans "Download as" %} {{ format }}
+    </button>
+  {% endfor %}
+</div>
+<br/>
+{% endblock content %}

--- a/pod/video/templates/videos/video-info.html
+++ b/pod/video/templates/videos/video-info.html
@@ -11,7 +11,7 @@
   </div>
   <div class="pod-info-video__view">
     <i class="bi bi-eye"></i> {% trans 'Number of views' %}
-    {% if USE_STATS_VIEW and not video.encoding_in_progress %}<a rel="noopener" target="_blank" title="{% trans 'Show details of view statistics' %}" href="{% url 'video:video_stats_view' video.slug %}?from=video">
+    {% if USE_STATS_VIEW and not video.encoding_in_progress %}<a rel="noopener" target="_blank" title="{% trans 'Show details of view statistics' %}" href="{% url 'video:video_stats_view' video.id %}">
       {{ video.get_viewcount }}</a>
     {% else %}
       {{ video.get_viewcount }}

--- a/pod/video/templates/videos/video_stats_view.html
+++ b/pod/video/templates/videos/video_stats_view.html
@@ -1,39 +1,45 @@
 {% extends 'base.html' %}
-{% load static i18n %}
+{% load staticfiles i18n %}
+
 {% block opengraph %}
   {{ block.super }}
   <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
 {% endblock opengraph %}
 {% block page_title %}{{ title }}{% endblock page_title %}
 {% block page_extra_head %}
-  <link type="text/css" rel="stylesheet" href="{% static 'jqGrid/css/ui.jqgrid-bootstrap5.css' %}?ver={{VERSION}}">
   <link rel="stylesheet" href="{% static 'css/video_stats_view.css' %}?ver={{VERSION}}">
 {% endblock page_extra_head %}
 
 {% block content %}
-<div class="grid-container container">
-  {% if form %}
-    {% include "videos/video-form.html" %}
-  {% else %}
-    <h1 class="page_title h2">{{ title }}</h1>
-    <div class="form-group row stat-form-group mb-1">
-      <label for="jsperiode" class="col-7 col-form-label">{% trans "Change the date" %}</label>
-      <div class="col-5 col-date">
-        <input class="form-control" type="date" name="periode" id="jsperiode">
-      </div>
-    </div>
-    <div class="table-responsive-md mb-4">
-      <table id="grid"></table>
-    </div>
-    <div id="pager"></div>
-  {% endif %}
+
+<script type="text/javascript" src="http://code.jquery.com/jquery-1.10.0.min.js"></script>
+<script type="text/javascript" src="{% static 'js/Chart.min.js' %}"></script>
+
+<div class="row, stats_graph_per_day">
+  <div class="col-sm-8 offset-sm-2 ">
+    <canvas id="chart_view_per_day"></canvas>
+    <script type="text/javascript">
+      var ctx = $("#chart_view_per_day").get(0).getContext("2d");
+      new Chart(ctx, {
+          type: 'line', data: {{ data_day|safe }},
+      });
+    </script>
+    <hr>
+  </div>
 </div>
+
+<div class="row, stats_graph_cumulated">
+  <div class="col-sm-8 offset-sm-2 ">
+    <canvas id="chart_view_cumulated"></canvas>
+    <script type="text/javascript">
+      var ctx = $("#chart_view_cumulated").get(0).getContext("2d");
+      new Chart(ctx, {
+          type: 'line', data: {{ data_cumulated|safe }},
+      });
+    </script>
+    <br/>
+  </div>
+</div>
+
 {% endblock content %}
 
-{% block more_script %}
-  <script src="{% static 'jqGrid/js/i18n/grid.locale-'|add:LANGUAGE_CODE|add:'.js' %}?ver={{VERSION}}" charset="utf-8"></script>
-  <script src="{% static 'jqGrid/js/jquery.jqGrid.min.js' %}?ver={{VERSION}}" charset="utf-8"></script>
-  <script src="{% static 'js/video_stats_view.js' %}?ver={{VERSION}}" charset="utf-8"></script>
-{% endblock %}

--- a/pod/video/urls.py
+++ b/pod/video/urls.py
@@ -15,7 +15,7 @@ from .views import get_categories, add_category
 from .views import edit_category, delete_category
 from .views import update_video_owner, filter_owners, filter_videos
 from .views import PodChunkedUploadView, PodChunkedUploadCompleteView
-from .views import stats_view
+from .views import stats_view, video_stats_view
 from .views import video_oembed
 
 from .views import get_comments, get_children_comment
@@ -107,17 +107,11 @@ if getattr(settings, "USER_VIDEO_CATEGORY", False):
 
 if getattr(settings, "USE_STATS_VIEW", False):
     urlpatterns += [
-        url(r"^stats_view/$", stats_view, name="video_stats_view"),
+        url(r"^stats_view/$", stats_view, name="stats_view"),
+        url(r"^video_stats_view/$", video_stats_view, name="video_stats_view"),
         url(
-            r"^stats_view/(?P<slug>[-\w]+)/$",
-            stats_view,
-            name="video_stats_view",
-        ),
-        url(
-            r"^stats_view/(?P<slug>[-\w]+)/(?P<slug_t>[-\w]+)/$",
-            stats_view,
-            name="video_stats_view",
-        ),
+            r"^video_stats_view/(?P<id>[-\w]+)/$",
+            video_stats_view,
     ]
 
 # COMMENT and VOTE

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,8 @@ redis==3.5.3
 mozilla_django_oidc==2.0.0
 ics==0.7.2
 django-honeypot==1.0.3
+django-tables2==2.4.1
+tablib==3.3.0
+odfpy==1.4.1
+openpyxl==3.0.10
+django-chartjs==2.3.0


### PR DESCRIPTION
Relative issue : https://github.com/EsupPortail/Esup-Pod/issues/719

J'ai changé la lib et les vues de stats avec export en csv, xlsx ou ods, ainsi que des vues en graphiques. Sans Ajax.
Testé et fonctionnel en 2.9.3, mais je n'ai pas testé en 3.x

Il faut encore jouer le manage.py makemessages et manage.py compilemessages.
Pas de test unitaires désolé.
J'ai fait quick and dirty, je vous laisse amender au besoin.