### PR TITLE
Fix launch_encode_video_studio fct with name of parameter input_video

### DIFF
--- a/pod/video/encoding_studio.py
+++ b/pod/video/encoding_studio.py
@@ -162,7 +162,7 @@ def launch_encode_video_studio(input_video, subtime, subcmd, video_output):
     msg = ""
     partial_command = FFMPEG_STUDIO_COMMAND % {
         "nb_threads": FFMPEG_NB_THREADS,
-        "input": input,
+        "input": input_video,
         "subtime": subtime,
         "crf": FFMPEG_CRF,
     }


### PR DESCRIPTION
Fix an error with the name of the first parameter of launch_encode_video_studio