### PR TITLE
[DONE] Correct bad contrast on opencast studio

### DIFF
--- a/pod/recorder/templates/recorder/opencast-studio.html
+++ b/pod/recorder/templates/recorder/opencast-studio.html
@@ -13,6 +13,7 @@
     --theme-ui-colors-gray-4: var(--pod-background-neutre2-bloc);
     --theme-ui-colors-button_bg: var(--pod-font-color);
     --theme-ui-colors-btn-hover: var(--bs-btn-hover-bg);
+    --theme-ui-colors-element_bg: var(--pod-background);
   }
 
   .pod-opencast-studio .loading-indicator > svg > circle {
@@ -38,6 +39,7 @@
     /* secondary-button::hover */
     --theme-ui-colors-gray-3: #797676;
     --theme-ui-colors-error: rgb(241, 70, 104);
+    --theme-ui-colors-element_bg: var(--pod-neutre1-bloc);
     /*--theme-ui-colors-gray-4: #737373;*/
   }
 


### PR DESCRIPTION
Correct bad contrast on opencast studio recorder when system mode is "dark" and Pod mode is "light"