### PR TITLE
[DONE] :bug: podfile fix pagination display

### DIFF
--- a/pod/podfile/static/podfile/js/filewidget.js
+++ b/pod/podfile/static/podfile/js/filewidget.js
@@ -800,7 +800,7 @@ if (typeof loaded == "undefined") {
         if (nextPage != -1) {
           document
             .getElementById("list_folders_sub")
-            .append(
+            .innerHTML += (
               seeMoreElement(nextPage, data.current_page + 1, data.total_pages)
             );
         }


### PR DESCRIPTION
Erreur d'affichage sur le bouton de pagination.
Dans la partie mes fichiers ( url/podfile ) lorsqu'on click sur le burger menu et qu'on va en bas de la liste de mes dossiers.
Le html est échappé donc il est rendu tel quel.
Surement dû au retrait de JQuery

![podile](https://user-images.githubusercontent.com/34771705/227168049-e988e01f-dc0f-4e7e-b5e6-7104a9f7b8a2.jpg)