### PR TITLE
[DONE] Fix wrong url of paginated sub-themes

### DIFF
--- a/pod/video/static/js/regroup_videos_by_theme.js
+++ b/pod/video/static/js/regroup_videos_by_theme.js
@@ -153,7 +153,8 @@ function run(has_more_themes, Helper) {
     );
     li.setAttribute("title", theme.title);
     const link = document.createElement("A");
-    link.setAttribute("href", `${URLPathName}${theme.slug}/`);
+    let hrefUrl = "/"+channel_slug+"/"+theme.slug+"/";
+    link.setAttribute("href", hrefUrl);
     link.setAttribute("class", "text-truncate");
     link.innerText = theme.title;
 

--- a/pod/video/templates/channel/channel.html
+++ b/pod/video/templates/channel/channel.html
@@ -210,6 +210,7 @@
     
     <script  src="{% static 'js/infinite.js' %}?ver={{VERSION}}" ></script>
    <script>
+        var channel_slug = "{{channel.slug}}";
         url = "/{{channel.slug}}/?page="
             onBeforePageLoad =  function() {
                 document.querySelector('.infinite-loading').style.display = 'block';


### PR DESCRIPTION
Fix wrong url of paginated sub-themes on page2 have /channel/theme/subtheme url which lead to 404 -> fix to /channel/subtheme