### PR TITLE
[DONE] Fix : admin css

### DIFF
--- a/pod/main/static/css/pod-admin.css
+++ b/pod/main/static/css/pod-admin.css
@@ -9,6 +9,9 @@
   .select2-search__field {
     color: white !important;
   }
+  :root {
+    --pod-font-color : white;
+  }
 }
 
 /** Set the Django-admin auto dark mode

--- a/pod/main/static/css/pod-admin.css
+++ b/pod/main/static/css/pod-admin.css
@@ -50,3 +50,7 @@
 #user-tools a:hover {
   color: #000;
 }
+
+.deletelink, .cancel-link {
+  box-sizing: revert;
+}


### PR DESCRIPTION
> 
> Version 3.1
> Partie Admin
> Le bouton "supprimer" n'est pas aligné avec le label du bouton : 
> 
> ![supp_white](https://github.com/EsupPortail/Esup-Pod/assets/34771705/f49d3303-e781-45e9-bcff-6ca411db1300)
> 
> pareil avec un thème noir : 
> 
> ![supp_black](https://github.com/EsupPortail/Esup-Pod/assets/34771705/2cc376a7-0277-4f4c-8bb0-9b96b1bc1b07)
> 
> En plus dans le thème noir lorsqu'on clique sur le bouton supprimer et qu'on arrive à la partie de confirmation, tout le descriptif est invisible : 
> ![confirm_black_hidden](https://github.com/EsupPortail/Esup-Pod/assets/34771705/963e4446-daf8-48f1-a26e-1a3ae2913343)
> 
> Le texte  est de la même couleur que le fond : 
> ![confirm_black_empty](https://github.com/EsupPortail/Esup-Pod/assets/34771705/f1222231-af66-4bcb-862f-e4aa1247f625)
> 