### PR TITLE
[DONE] ajout paramètre HOMEPAGE_VIEW_VIDEOS_FROM_NON_VISIBLE_CHANNELS

### DIFF
--- a/pod/main/configuration.json
+++ b/pod/main/configuration.json
@@ -1225,7 +1225,7 @@
                                     "Display videos from non visible channels on the homepage"
                                 ],
                                 "fr": [
-                                    "Affiche les vidéos de chaines non visible sur la page d'accueil"
+                                    "Affiche les vidéos de chaines non visibles sur la page d'accueil"
                                 ]
                             },
                             "pod_version_end": "",

--- a/pod/main/configuration.json
+++ b/pod/main/configuration.json
@@ -1217,6 +1217,19 @@
                             },
                             "pod_version_end": "",
                             "pod_version_init": "3.1.0"
+                        },
+                        "HOMEPAGE_VIEW_VIDEOS_FROM_NON_VISIBLE_CHANNELS": {
+                            "default_value": false,
+                            "description": {
+                                "en": [
+                                    "Display videos from non visible channels on the homepage"
+                                ],
+                                "fr": [
+                                    "Affiche les vidéos de chaines non visible sur la page d'accueil"
+                                ]
+                            },
+                            "pod_version_end": "",
+                            "pod_version_init": "3.2.0"
                         }
                     },
                     "title": {
@@ -2304,6 +2317,17 @@
                             "pod_version_end": "",
                             "pod_version_init": "3.1.0"
                         },
+                        "USE_FAVORITES": {
+                            "default_value": true,
+                            "description": {
+                                "en": [
+                                    "Activation of favorite videos. Allows users to add videos to their favorites."
+                                ],
+                                "fr": [
+                                    "Activation des vidéos favorites. Permet aux utilisateurs d'ajouter des vidéos dans leurs favoris."
+                                ]
+                            }
+                        },
                         "USE_OBSOLESCENCE": {
                             "default_value": false,
                             "description": {
@@ -2317,17 +2341,6 @@
                             },
                             "pod_version_end": "",
                             "pod_version_init": "3.1.0"
-                        },
-                        "USE_FAVORITES": {
-                            "default_value": true,
-                            "description": {
-                                "en": [
-                                    "Activation of favorite videos. Allows users to add videos to their favorites."
-                                ],
-                                "fr": [
-                                    "Activation des vidéos favorites. Permet aux utilisateurs d'ajouter des vidéos dans leurs favoris."
-                                ]
-                            }
                         },
                         "USE_STATS_VIEW": {
                             "default_value": false,

--- a/pod/video/templatetags/video_tags.py
+++ b/pod/video/templatetags/video_tags.py
@@ -15,7 +15,7 @@ from tagging.utils import LOGARITHMIC
 
 from ..forms import VideoVersionForm
 from ..models import Video
-from ..utils import check_file
+from ..utils import check_file, get_available_videos
 
 import importlib
 import os
@@ -25,6 +25,7 @@ register = template.Library()
 HOMEPAGE_SHOWS_PASSWORDED = getattr(django_settings, "HOMEPAGE_SHOWS_PASSWORDED", True)
 HOMEPAGE_SHOWS_RESTRICTED = getattr(django_settings, "HOMEPAGE_SHOWS_RESTRICTED", True)
 HOMEPAGE_NB_VIDEOS = getattr(django_settings, "HOMEPAGE_NB_VIDEOS", 12)
+HOMEPAGE_VIEW_VIDEOS_FROM_NON_VISIBLE_CHANNELS = getattr(django_settings, "HOMEPAGE_VIEW_VIDEOS_FROM_NON_VISIBLE_CHANNELS", False)
 
 
 @register.filter(name="file_exists")
@@ -78,11 +79,12 @@ def get_version_form(video):
 @register.simple_tag(takes_context=True)
 def get_last_videos(context):
     request = context["request"]
-    videos = Video.objects.filter(
-        encoding_in_progress=False,
-        is_draft=False,
+    videos = get_available_videos().filter(
         sites=get_current_site(request),
-    ).exclude(channel__visible=0)
+    )
+
+    if not HOMEPAGE_VIEW_VIDEOS_FROM_NON_VISIBLE_CHANNELS:
+        videos = videos.exclude(channel__visible=0)
 
     if not HOMEPAGE_SHOWS_PASSWORDED:
         videos = videos.filter(Q(password="") | Q(password__isnull=True))

--- a/pod/video/templatetags/video_tags.py
+++ b/pod/video/templatetags/video_tags.py
@@ -14,7 +14,6 @@ from tagging.utils import LINEAR
 from tagging.utils import LOGARITHMIC
 
 from ..forms import VideoVersionForm
-from ..models import Video
 from ..utils import check_file, get_available_videos
 
 import importlib


### PR DESCRIPTION
Pour la résolution de l'issue #796 , ajout d'un paramètre HOMEPAGE_VIEW_VIDEOS_FROM_NON_VISIBLE_CHANNELS : si la valeur est True, les vidéos d'une chaine non visible sont affichées.