### PR TITLE
[DONE] Improve the guidance towards valid pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+Before sending your pull request, make sure the following are done :
+
+* [ ] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
+* [ ] Your PR targets the `develop` branch.
+* [ ] The title of your PR starts with `[WIP]` or `[DONE]`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,11 @@ The process described here has several goals:
 Please follow these steps to have your contribution considered by the maintainers:
 
 0. Follow the [styleguides](#styleguides) below.
-1. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
+1. Make sure that your pull request targets the `develop` branch.
+2. Prefix the title of your pull request with one of the following :
+  * `[WIP]` if your pull request is still a work in progress.
+  * `[DONE]` if you are done with your patch.
+3. After you submit your pull request, verify that all [status checks](https://help.github.com/articles/about-status-checks/) are passing <details><summary>What if the status checks are failing?</summary>If a status check is failing, and you believe that the failure is unrelated to your change, please leave a comment on the pull request explaining why you believe the failure is unrelated. A maintainer will re-run the status check for you. If we conclude that the failure was a false positive, then we will open an issue to track that problem with our status check suite.</details>
 
 While the prerequisites above must be satisfied prior to having your pull request reviewed, the reviewer(s) may ask you to complete additional design work, tests, or other changes before your pull request can be ultimately accepted.
 


### PR DESCRIPTION
Re-bonjour,

Suite au PR #877, ajout des instructions en ce qui concerne la branche cible et le titre des PR dans le fichier `CONTRIBUTING` et ajout d'un template pour rendre ces informations plus visibles aux nouveaux contributeurs.

Bonne fin d'après-midi.