### PR TITLE
[DONE] Hide video player when video is in encoding

### DIFF
--- a/pod/video/templates/videos/video.html
+++ b/pod/video/templates/videos/video.html
@@ -184,7 +184,11 @@
 {% if form %}
     {% include 'videos/video-form.html' %}
 {% else %}
-  {% include 'videos/video-element.html' %}
+  {% if video.get_encoding_step == "" or video.encoding_in_progress %}
+    {% comment %} Hide player {% endcomment %}
+  {% else %}
+    {% include 'videos/video-element.html' %}
+  {% endif %}
   <div id="info-video" class="pod-info-video">{% include 'videos/video-all-info.html' %}</div>
 {% endif %}
 {% endblock video-element %}


### PR DESCRIPTION
Des utilisateurs se plaignent que le player video leur indique un message d'erreur quand la vidéo est en cours d'encodage. J'ai masqué le player lorsque la vidéo est en encodage.