### PR TITLE
[DONE] Fix "Add any video in user channel" in Administration module

### DIFF
--- a/pod/video/forms.py
+++ b/pod/video/forms.py
@@ -687,20 +687,24 @@ class VideoForm(forms.ModelForm):
 
     def clean_channel(self):
         """Merge channels of a video."""
-        users_groups = self.current_user.owner.accessgroup_set.all()
-        if self.is_superuser:
-            user_channels = Channel.objects.all()
+        if self.current_user is not None:
+            users_groups = self.current_user.owner.accessgroup_set.all()
+            if self.is_superuser:
+                user_channels = Channel.objects.all()
+            else:
+                user_channels = (
+                    self.current_user.owners_channels.all()
+                    | self.current_user.users_channels.all()
+                    | Channel.objects.filter(allow_to_groups__in=users_groups)
+                ).distinct()
+
+            user_channels.filter(site=get_current_site(None))
+            channels_to_keep = Video.objects.get(pk=self.instance.id).channel.exclude(
+                pk__in=[c.id for c in user_channels]
+            )
+            return self.cleaned_data["channel"].union(channels_to_keep)
         else:
-            user_channels = (
-                self.current_user.owners_channels.all()
-                | self.current_user.users_channels.all()
-                | Channel.objects.filter(allow_to_groups__in=users_groups)
-            ).distinct()
-        user_channels.filter(site=get_current_site(None))
-        channels_to_keep = Video.objects.get(pk=self.instance.id).channel.exclude(
-            pk__in=[c.id for c in user_channels]
-        )
-        return self.cleaned_data["channel"].union(channels_to_keep)
+            return self.cleaned_data["channel"]
 
     def __init__(self, *args, **kwargs):
         self.is_staff = (


### PR DESCRIPTION
This PR fix a bug in the administration module which, when editing a video, caused the following error: 
'NoneType' object has no attribute 'owner'

I modified the clean_channel function (created in PR #864) to manage None value.