### PR TITLE
Correction de l'enregistrement de la préférence de notification

### DIFF
--- a/pod/progressive_web_app/static/js/notification-toast.js
+++ b/pod/progressive_web_app/static/js/notification-toast.js
@@ -35,9 +35,8 @@ async function setPushPreference(notificationSettingUrl) {
   notificationButton.disabled = true;
 
   let afterBrowserNotificationPermissionChanged = async function (
-    subscription,
+    subscription, acceptsNotifications=true,
   ) {
-    acceptsNotifications = subscription != null;
     let response = await postNotificationPreference(
       acceptsNotifications,
       notificationSettingUrl,
@@ -74,7 +73,7 @@ async function setPushPreference(notificationSettingUrl) {
     subscribe(registration, afterBrowserNotificationPermissionChanged);
   } else if (permissionState == "granted" && subscription) {
     subscription.unsubscribe().then(() => {
-      afterBrowserNotificationPermissionChanged(subscription);
+      afterBrowserNotificationPermissionChanged(subscription, false);
     });
   }
 }


### PR DESCRIPTION
Je viens de voir une coquille dans #937, l'enregistrement de la préférence globale de notification était toujours à `true`, cette PR règle le problème.