### PR TITLE
 [DONE] Webtv - add translation field name of AdditionalChannelTab

### DIFF
--- a/pod/main/translation.py
+++ b/pod/main/translation.py
@@ -19,8 +19,10 @@ class LinkFooterTranslationOptions(TranslationOptions):
 class ConfigurationTranslationOptions(TranslationOptions):
     fields = ("description",)
 
+
 class AdditionalChannelTabTranslationOptions(TranslationOptions):
     fields = ("name",)
+
 
 translator.register(FlatPage, FlatPageTranslationOptions)
 translator.register(LinkFooter, LinkFooterTranslationOptions)

--- a/pod/main/translation.py
+++ b/pod/main/translation.py
@@ -2,6 +2,7 @@ from modeltranslation.translator import translator, TranslationOptions
 from django.contrib.flatpages.models import FlatPage
 from pod.main.models import LinkFooter
 from pod.main.models import Configuration
+from pod.main.models import AdditionalChannelTab
 
 
 class FlatPageTranslationOptions(TranslationOptions):
@@ -18,7 +19,10 @@ class LinkFooterTranslationOptions(TranslationOptions):
 class ConfigurationTranslationOptions(TranslationOptions):
     fields = ("description",)
 
+class AdditionalChannelTabTranslationOptions(TranslationOptions):
+    fields = ("name",)
 
 translator.register(FlatPage, FlatPageTranslationOptions)
 translator.register(LinkFooter, LinkFooterTranslationOptions)
 translator.register(Configuration, ConfigurationTranslationOptions)
+translator.register(AdditionalChannelTab, AdditionalChannelTabTranslationOptions)


### PR DESCRIPTION
Permettre la traduction des menus de chaines additionnelles.

Attention, pour les utilisateurs ayant déjà des chaines additionnelles, il faudra penser à faire
`python manage.py update_translation_fields`


