### PR TITLE
[DONE] In the Rest API, add a video and role filter for contributors

### DIFF
--- a/pod/completion/rest_views.py
+++ b/pod/completion/rest_views.py
@@ -60,13 +60,16 @@ class ContributorViewSet(viewsets.ModelViewSet):
 class DocumentViewSet(viewsets.ModelViewSet):
     queryset = Document.objects.all()
     serializer_class = DocumentSerializer
+    filterset_fields = ['video',]
 
 
 class TrackViewSet(viewsets.ModelViewSet):
     queryset = Track.objects.all()
     serializer_class = TrackSerializer
+    filterset_fields = ['video',]
 
 
 class OverlayViewSet(viewsets.ModelViewSet):
     queryset = Overlay.objects.all()
     serializer_class = OverlaySerializer
+    filterset_fields = ['video',]

--- a/pod/completion/rest_views.py
+++ b/pod/completion/rest_views.py
@@ -54,6 +54,7 @@ class OverlaySerializer(serializers.HyperlinkedModelSerializer):
 class ContributorViewSet(viewsets.ModelViewSet):
     queryset = Contributor.objects.all()
     serializer_class = ContributorSerializer
+    filterset_fields = ['video', 'role',]
 
 
 class DocumentViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
In the Rest API, add a video and role filter for contributors.

**Use case examples**:

curl -H 'Content-Type: application/json' -H 'Authorization: Token xxxxx' -X GET https://pod.univ.fr/rest/contributors/?video=xxxx

or

curl -H 'Content-Type: application/json' -H 'Authorization: Token xxxxx' -X GET https://pod.univ.fr/rest/contributors/?role=xxx