### PR TITLE
Change minimum characters for Discipline and Channel select2 in video edit

### DIFF
--- a/pod/video/forms.py
+++ b/pod/video/forms.py
@@ -982,8 +982,8 @@ class VideoForm(forms.ModelForm):
         widgets = {
             "owner": OwnerWidget,
             "additional_owners": AddOwnerWidget,
-            "channel": ChannelWidget,
-            "discipline": DisciplineWidget,
+            "channel": ChannelWidget(attrs={'data-minimum-input-length': 0}),
+            "discipline": DisciplineWidget(attrs={'data-minimum-input-length': 0}),
             "date_evt": widgets.AdminDateWidget,
             "restrict_access_to_groups": AddAccessGroupWidget,
             "video": CustomClearableFileInput,

--- a/pod/video/static/js/video_edit.js
+++ b/pod/video/static/js/video_edit.js
@@ -13,6 +13,8 @@ document.addEventListener(
     selector.addEventListener("change", function () {
       display_option_desc(this, helpContainer);
     });
+
+
   },
   false,
 );

--- a/pod/video/static/js/video_edit.js
+++ b/pod/video/static/js/video_edit.js
@@ -13,8 +13,6 @@ document.addEventListener(
     selector.addEventListener("change", function () {
       display_option_desc(this, helpContainer);
     });
-
-
   },
   false,
 );


### PR DESCRIPTION
Comme cela m'a été remonté, il n'est pas vraiment pratique pour un enseignant de choisir une Discipline ou un Chaine lors de l'édition de vidéo puisqu'il est nécessaire de taper 2 caractères au minimum pour les trouver, ce qui implique de devoir connaitre le nom des disciplines et/ou des chaines à l'avance. Ici , le minimum est abaissé à 0 ce qui permet de voir quelques résultats par un simple clic dans le champ, on garde quand même la logique du select2 pour le cache qu'il apporte, la fonction de recherche et si jamais la liste des chaines ou des disciplines est assez volumineuse. 

![Capture d’écran 2024-02-02 155913](https://github.com/EsupPortail/Esup-Pod/assets/36987491/f9914d6d-20f4-42be-85a1-776ed402861b)

