### PR TITLE
[DONE] do not fail on HTTP requests with numerous/long cookies

### DIFF
--- a/pod_uwsgi.ini
+++ b/pod_uwsgi.ini
@@ -20,5 +20,7 @@ socket          = /home/pod/django_projects/podv3/podv3.sock
 chmod-socket    = 666
 # clear environment on exit
 vacuum          = true
-
-
+# In case of numerous/long cookies and/or long query string, the HTTP header may exceed default 4k.
+# When it occurs, uwsgi rejects those rejects with error "invalid request block size" and nginx returns HTTP 502.
+# Allowing 8k is a safe value that still allows weird long cookies set on .univ-xxx.fr
+buffer-size     = 8192


### PR DESCRIPTION
In case of numerous/long cookies and/or long query string, the HTTP header may exceed default 4k. When it occurs, uwsgi rejects those rejects with error "invalid request block size" and nginx returns HTTP 502. Allowing 8k is a safe value that still allows weird long cookies set on .univ-xxx.fr

