### PR TITLE
[DONE] fix live_event save for many_to_many fields

### DIFF
--- a/pod/live/views.py
+++ b/pod/live/views.py
@@ -588,11 +588,7 @@ def update_event(form):
         d_fin = timezone.make_aware(d_fin)
         evt.end_date = d_fin
         evt.save()
-        # need to manually set many-to-many data because of a side effect of commit=False on save
-        if form.cleaned_data.get("additional_owners"):
-            evt.additional_owners.set(form.cleaned_data["additional_owners"])
-        if form.cleaned_data.get("restrict_access_to_groups"):
-            evt.restrict_access_to_groups.set(form.cleaned_data["restrict_access_to_groups"])
+        form.save_m2m()
         return evt
 
 

--- a/pod/live/views.py
+++ b/pod/live/views.py
@@ -588,6 +588,11 @@ def update_event(form):
         d_fin = timezone.make_aware(d_fin)
         evt.end_date = d_fin
         evt.save()
+        # need to manually set many-to-many data because of a side effect of commit=False on save
+        if form.cleaned_data.get("additional_owners"):
+            evt.additional_owners.set(form.cleaned_data["additional_owners"])
+        if form.cleaned_data.get("restrict_access_to_groups"):
+            evt.restrict_access_to_groups.set(form.cleaned_data["restrict_access_to_groups"])
         return evt
 
 


### PR DESCRIPTION
When not admin saving live_event discard many_to_many fields.
This is because form.save(commit=False) is used.
Fields have to be manually set after Event is saved or methode save_m2m() has to be called.
[see django doc here ](https://docs.djangoproject.com/en/3.2/topics/forms/modelforms/#the-save-method)

Pour tester :

- se connecter avec un compte non admin ayant les droits de créer un évènement.
- en créer un avec des restrictions sur un groupe et ajouter un propriétaire additionnel.

Avant l'évènement était bien enregistré mais sans le(s) groupe(s), ni propriétaire(s).
La PR doit résoudre ce cas