### PR TITLE
[DONE] fix clean opencast folder method

### DIFF
--- a/pod/recorder/plugins/type_studio.py
+++ b/pod/recorder/plugins/type_studio.py
@@ -8,7 +8,7 @@ from xml.dom import minidom
 
 from django.conf import settings
 
-from ..utils import add_comment, studio_clean_old_files
+from ..utils import add_comment, studio_clean_old_entries
 from pod.video.models import Video, get_storage_path_video
 from pod.video_encode_transcript import encode
 from django.template.defaultfilters import slugify
@@ -93,7 +93,7 @@ def save_basic_video(recording, video_src):
     # Rename the XML file
     # os.rename(recording.source_file, recording.source_file + "_treated")
 
-    studio_clean_old_files()
+    studio_clean_old_entries()
 
     return video
 

--- a/pod/recorder/utils.py
+++ b/pod/recorder/utils.py
@@ -1,5 +1,5 @@
 """Esup-Pod recorder utilities."""
-
+import shutil
 import time
 import os
 import uuid
@@ -20,21 +20,23 @@ def add_comment(recording_id, comment):
     recording.save()
 
 
-def studio_clean_old_files():
+def studio_clean_old_entries():
     """
-    Clean up old files in the "opencast-files" folder.
+    Clean up old entries in the opencast folder.
 
-    The function removes files that are older than 7 days
-    from the "opencast-files" folder in the media root.
+    The function removes entries that are older than 7 days
+    from the opencast folder in the media root.
     """
-    folder_to_clean = os.path.join(settings.MEDIA_ROOT, "opencast-files")
+    folder_to_clean = os.path.join(settings.MEDIA_ROOT, OPENCAST_FILES_DIR)
     now = time.time()
 
-    for f in os.listdir(folder_to_clean):
-        f = os.path.join(folder_to_clean, f)
-        if os.stat(f).st_mtime < now - 7 * 86400:
-            if os.path.isfile(f):
-                os.remove(f)
+    for entry in os.listdir(folder_to_clean):
+        entry_path = os.path.join(folder_to_clean, entry)
+        if os.stat(entry_path).st_mtime < now - 7 * 86400:
+            if os.path.isdir(entry_path):
+                shutil.rmtree(entry_path)
+            else:
+                os.remove(entry_path)
 
 
 def handle_upload_file(request, element_name, mimetype, tag_name):


### PR DESCRIPTION
La fonction de suppression des fichiers dans le répertoire OPENCAST_FILES_DIR ne fonctionne pas.
Dans ce répertoire on trouve toujours des dossiers avant de trouver des fichiers. (voir copie écran)
Je propose de changer la méthode pour supprimer fichiers + dossiers

Aussi de changer le nom du répertoire par celui qui peut être défini dans les settings 

![image](https://github.com/EsupPortail/Esup-Pod/assets/34771705/252a912e-7f5d-49cc-a7c7-7655a13c9bfd)
