### PR TITLE
[WIP] Fix race condition getting future ID to construct slug before creating several objects

### DIFF
--- a/pod/chapter/models.py
+++ b/pod/chapter/models.py
@@ -6,7 +6,6 @@ from django.template.defaultfilters import slugify
 from django.utils.translation import ugettext as _
 
 from pod.video.models import Video
-from pod.main.models import get_nextautoincrement
 
 
 class Chapter(models.Model):
@@ -100,20 +99,8 @@ class Chapter(models.Model):
         return list()
 
     def save(self, *args, **kwargs):
-        newid = -1
-        if not self.id:
-            try:
-                newid = get_nextautoincrement(Chapter)
-            except Exception:
-                try:
-                    newid = Chapter.objects.latest("id").id
-                    newid += 1
-                except Exception:
-                    newid = 1
-        else:
-            newid = self.id
-        newid = "{0}".format(newid)
-        self.slug = "{0}-{1}".format(newid, slugify(self.title))
+        super(Chapter, self).save(*args, **kwargs)
+        self.slug = "{0}-{1}".format(self.id, slugify(self.title))
         super(Chapter, self).save(*args, **kwargs)
 
     @property

--- a/pod/completion/models.py
+++ b/pod/completion/models.py
@@ -7,7 +7,6 @@ from django.utils.translation import ugettext_lazy as _
 from django.template.defaultfilters import slugify
 from ckeditor.fields import RichTextField
 from pod.video.models import Video
-from pod.main.models import get_nextautoincrement
 from pod.main.lang_settings import ALL_LANG_CHOICES, PREF_LANG_CHOICES
 
 if getattr(settings, "USE_PODFILE", False):
@@ -430,20 +429,8 @@ class Overlay(models.Model):
         return list()
 
     def save(self, *args, **kwargs):
-        newid = -1
-        if not self.id:
-            try:
-                newid = get_nextautoincrement(Overlay)
-            except Exception:
-                try:
-                    newid = Overlay.objects.latest("id").id
-                    newid += 1
-                except Exception:
-                    newid = 1
-        else:
-            newid = self.id
-        newid = "{0}".format(newid)
-        self.slug = "{0}-{1}".format(newid, slugify(self.title))
+        super(Overlay, self).save(*args, **kwargs)
+        self.slug = "{0}-{1}".format(self.id, slugify(self.title))
         super(Overlay, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/pod/enrichment/models.py
+++ b/pod/enrichment/models.py
@@ -12,7 +12,6 @@ from tempfile import NamedTemporaryFile
 from django.contrib.auth.models import Group
 
 from pod.video.models import Video
-from pod.main.models import get_nextautoincrement
 
 import os
 import datetime
@@ -279,20 +278,8 @@ class Enrichment(models.Model):
         return list()
 
     def save(self, *args, **kwargs):
-        newid = -1
-        if not self.id:
-            try:
-                newid = get_nextautoincrement(Enrichment)
-            except Exception:
-                try:
-                    newid = Enrichment.objects.latest("id").id
-                    newid += 1
-                except Exception:
-                    newid = 1
-        else:
-            newid = self.id
-        newid = "{0}".format(newid)
-        self.slug = "{0} - {1}".format(newid, slugify(self.title))
+        super(Enrichment, self).save(*args, **kwargs)
+        self.slug = "{0} - {1}".format(self.id, slugify(self.title))
         super(Enrichment, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/pod/live/models.py
+++ b/pod/live/models.py
@@ -26,7 +26,6 @@ from pod.main.lang_settings import PREF_LANG_CHOICES as __PREF_LANG_CHOICES__
 from django.utils.translation import get_language
 from pod.main.utils import generate_qrcode
 from pod.authentication.models import AccessGroup
-from pod.main.models import get_nextautoincrement
 from pod.video.models import Video, Type
 
 SECURE_SSL_REDIRECT = getattr(settings, "SECURE_SSL_REDIRECT", False)
@@ -466,19 +465,8 @@ class Event(models.Model):
         ordering = ["start_date"]
 
     def save(self, *args, **kwargs):
-        if not self.id:
-            try:
-                new_id = get_nextautoincrement(Event)
-            except Exception:
-                try:
-                    new_id = Event.objects.latest("id").id
-                    new_id += 1
-                except Exception:
-                    new_id = 1
-        else:
-            new_id = self.id
-        new_id = "%04d" % new_id
-        self.slug = "%s-%s" % (new_id, slugify(self.title))
+        super(Event, self).save(*args, **kwargs)
+        self.slug = "%s-%s" % ("%04d" % self.id, slugify(self.title))
         super(Event, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/pod/main/models.py
+++ b/pod/main/models.py
@@ -9,12 +9,26 @@ from django.core.exceptions import ValidationError
 from django.template.defaultfilters import slugify
 from django.dispatch import receiver
 from django.db.models.signals import post_save
+from django.db import connection
 import os
 import mimetypes
 from ckeditor.fields import RichTextField
 
 
 FILES_DIR = getattr(settings, "FILES_DIR", "files")
+
+
+def get_nextautoincrement(model):
+    cursor = connection.cursor()
+    cursor.execute(
+        "SELECT Auto_increment FROM information_schema.tables "
+        + 'WHERE table_name="{0}" AND table_schema=DATABASE();'.format(
+            model._meta.db_table
+        )
+    )
+    row = cursor.fetchone()
+    cursor.close()
+    return row[0]
 
 
 def get_upload_path_files(instance, filename):

--- a/pod/main/models.py
+++ b/pod/main/models.py
@@ -9,26 +9,12 @@ from django.core.exceptions import ValidationError
 from django.template.defaultfilters import slugify
 from django.dispatch import receiver
 from django.db.models.signals import post_save
-from django.db import connection
 import os
 import mimetypes
 from ckeditor.fields import RichTextField
 
 
 FILES_DIR = getattr(settings, "FILES_DIR", "files")
-
-
-def get_nextautoincrement(model):
-    cursor = connection.cursor()
-    cursor.execute(
-        "SELECT Auto_increment FROM information_schema.tables "
-        + 'WHERE table_name="{0}" AND table_schema=DATABASE();'.format(
-            model._meta.db_table
-        )
-    )
-    row = cursor.fetchone()
-    cursor.close()
-    return row[0]
 
 
 def get_upload_path_files(instance, filename):

--- a/pod/meeting/models.py
+++ b/pod/meeting/models.py
@@ -35,7 +35,6 @@ from django.db.models import F, Q
 
 
 from pod.authentication.models import AccessGroup
-from pod.main.models import get_nextautoincrement
 from pod.live.models import Broadcaster, Event
 
 from .utils import (
@@ -516,22 +515,10 @@ class Meeting(models.Model):
     def save(self, *args, **kwargs):
         """Store a meeting object in db."""
         self.check_recurrence()
-        newid = -1
-        if not self.id:
-            try:
-                newid = get_nextautoincrement(Meeting)
-            except Exception:
-                try:
-                    newid = Meeting.objects.latest("id").id
-                    newid += 1
-                except Exception:
-                    newid = 1
-        else:
-            newid = self.id
-        newid = "%04d" % newid
-        self.meeting_id = "%s-%s" % (newid, slugify(self.name))
         if MEETING_DISABLE_RECORD:
             self.record = False
+        super(Meeting, self).save(*args, **kwargs)
+        self.meeting_id = "%s-%s" % ("%04d" % self.id, slugify(self.name))
         super(Meeting, self).save(*args, **kwargs)
 
     def get_hashkey(self):

--- a/pod/playlist/models.py
+++ b/pod/playlist/models.py
@@ -10,7 +10,6 @@ from django.utils import timezone
 from django.utils.translation import ugettext as _
 from django.template.defaultfilters import slugify
 
-from pod.main.models import get_nextautoincrement
 from pod.video.models import Video
 from pod.video.utils import sort_videos_list
 
@@ -125,19 +124,8 @@ class Playlist(models.Model):
         verbose_name_plural = _("Playlists")
 
     def save(self, *args, **kwargs) -> None:
-        newid = -1
-        if not self.id:
-            try:
-                newid = get_nextautoincrement(Playlist)
-            except Exception:
-                try:
-                    newid = Playlist.objects.latest("id").id
-                    newid += 1
-                except Exception:
-                    newid = 1
-        else:
-            newid = self.id
-        self.slug = f"{newid}-{slugify(self.name)}"
+        super().save(*args, **kwargs)
+        self.slug = f"{self.id}-{slugify(self.name)}"
         super().save(*args, **kwargs)
 
     def clean(self) -> None:

--- a/pod/playlist/models.py
+++ b/pod/playlist/models.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.utils.translation import ugettext as _
 from django.template.defaultfilters import slugify
 
+from pod.main.models import get_nextautoincrement
 from pod.video.models import Video
 from pod.video.utils import sort_videos_list
 
@@ -124,8 +125,19 @@ class Playlist(models.Model):
         verbose_name_plural = _("Playlists")
 
     def save(self, *args, **kwargs) -> None:
-        super().save(*args, **kwargs)
-        self.slug = f"{self.id}-{slugify(self.name)}"
+        newid = -1
+        if not self.id:
+            try:
+                newid = get_nextautoincrement(Playlist)
+            except Exception:
+                try:
+                    newid = Playlist.objects.latest("id").id
+                    newid += 1
+                except Exception:
+                    newid = 1
+        else:
+            newid = self.id
+        self.slug = f"{newid}-{slugify(self.name)}"
         super().save(*args, **kwargs)
 
     def clean(self) -> None:


### PR DESCRIPTION
Having a bug using postgresql with pod I came accros the use of the key word AUTO_INCREMENT [here](https://github.com/EsupPortail/Esup-Pod/blob/df9a5d2b8477fb809e98234ed63b3ac3d8c94295/pod/main/models.py#L20) which doesn't exist in postgresql. A simple workaround would have been to just raise an Exception but I realized that the initial way of doing things has a race conditions issue.

Then the fix became the removing of this race condition that could cause the creation of a slug with the same prefix number. Yet I don't know about the performance of this solution.

Before my fix:

1 select to get next auto_increment value + 1 insert

After my fix:
1 initial insert (we can now have the id) + 1 update to set the slug

Before sending your pull request, make sure the following are done :

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `develop` branch.
* [x] The title of your PR starts with `[WIP]` or `[DONE]`.
