### PR TITLE
[DONE] Dont use auto increment for postgresql

### DIFF
--- a/pod/main/models.py
+++ b/pod/main/models.py
@@ -19,6 +19,8 @@ FILES_DIR = getattr(settings, "FILES_DIR", "files")
 
 
 def get_nextautoincrement(model):
+    if connection.vendor == "postgresql":
+        raise Exception
     cursor = connection.cursor()
     cursor.execute(
         "SELECT Auto_increment FROM information_schema.tables "


### PR DESCRIPTION
Having a bug using postgresql with pod I came accros the use of the key word AUTO_INCREMENT [here](https://github.com/EsupPortail/Esup-Pod/blob/df9a5d2b8477fb809e98234ed63b3ac3d8c94295/pod/main/models.py#L20) which doesn't exist in postgresql.

Yet it seems that there is a race condition concerning the reason of the use get_nextautoincrement which I try to deal with in pull request #1110

For now I just want to fix the postgresql issue.

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `develop` branch.
* [x] The title of your PR starts with `[WIP]` or `[DONE]`.
