### PR TITLE
[DONE] Use maxid to get nextautoincrement

### DIFF
--- a/pod/main/models.py
+++ b/pod/main/models.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ValidationError
 from django.template.defaultfilters import slugify
 from django.dispatch import receiver
 from django.db.models.signals import post_save
-from django.db import connection
+from django.db.models import Max
 import os
 import mimetypes
 from ckeditor.fields import RichTextField
@@ -19,16 +19,11 @@ FILES_DIR = getattr(settings, "FILES_DIR", "files")
 
 
 def get_nextautoincrement(model):
-    cursor = connection.cursor()
-    cursor.execute(
-        "SELECT Auto_increment FROM information_schema.tables "
-        + 'WHERE table_name="{0}" AND table_schema=DATABASE();'.format(
-            model._meta.db_table
-        )
-    )
-    row = cursor.fetchone()
-    cursor.close()
-    return row[0]
+    """Get potential next id for the current model when an object will be created"""
+    objects = model.objects.all()
+    if objects:
+        return objects.aggregate(Max("id"))["id__max"] + 1
+    return 1
 
 
 def get_upload_path_files(instance, filename):


### PR DESCRIPTION
Having a bug using postgresql with pod I came accros the use of the key word AUTO_INCREMENT [here](https://github.com/EsupPortail/Esup-Pod/blob/df9a5d2b8477fb809e98234ed63b3ac3d8c94295/pod/main/models.py#L20) which doesn't exist in postgresql.
