### PR TITLE
[DONE] run development server on port 8000

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,16 @@ help:
 
 # Démarre le serveur de test
 start:
-	(sleep 15 ; open http://localhost:9090) &
-	python3 manage.py runserver localhost:9090 --insecure
+	(sleep 15 ; open http://localhost:8000) &
+	python3 manage.py runserver localhost:8000 --insecure
 	# --insecure let serve static files even when DEBUG=False
 
 # Démarre le serveur de test en https auto-signé
 starts:
 	# nécessite les django-extensions
 	# cf https://timonweb.com/django/https-django-development-server-ssl-certificate/
-	(sleep 15 ; open https://localhost:9090) &
-	python3 manage.py runserver_plus localhost:9090 --cert-file cert.pem --key-file key.pem
+	(sleep 15 ; open https://localhost:8000) &
+	python3 manage.py runserver_plus localhost:8000 --cert-file cert.pem --key-file key.pem
 
 # Première installation de pod (BDD SQLite intégrée)
 install:

--- a/docker-compose-dev-with-volumes.yml
+++ b/docker-compose-dev-with-volumes.yml
@@ -18,7 +18,7 @@ services:
     env_file:
       - ./.env.dev
     ports:
-      - 9090:8080
+      - 8000:8000
     volumes: *pod-volumes
 
   elasticsearch:

--- a/docker-compose-full-dev-with-volumes-test.yml
+++ b/docker-compose-full-dev-with-volumes-test.yml
@@ -18,7 +18,7 @@ services:
     env_file:
       - ./.env.dev
     ports:
-      - 9090:8080
+      - 8000:8000
     volumes: *pod-volumes
 
   pod-encode:

--- a/docker-compose-full-dev-with-volumes.yml
+++ b/docker-compose-full-dev-with-volumes.yml
@@ -18,7 +18,7 @@ services:
     env_file:
       - ./.env.dev
     ports:
-      - 9090:8080
+      - 8000:8000
     volumes: *pod-volumes
 
   pod-encode:

--- a/dockerfile-dev-with-volumes/README.adoc
+++ b/dockerfile-dev-with-volumes/README.adoc
@@ -148,7 +148,7 @@ Vous devriez obtenir ce message une fois esup-pod lancé
 ----
 $ pod-dev-with-volumes        | Superuser created successfully.
 ----
-L'application esup-pod est dès lors disponible via cette URL : localhost:9090
+L'application esup-pod est dès lors disponible via cette URL : localhost:8000
 
 === Arrêt de la stack
 $ CTRL+C dans la fenetre depuis laquelle l'application esup-pod a été lancée

--- a/dockerfile-dev-with-volumes/pa11y-ci/config.json
+++ b/dockerfile-dev-with-volumes/pa11y-ci/config.json
@@ -18,10 +18,10 @@
         ]
     },
     "urls": [
-        "http://pod-back:8080/",
-        "http://pod-back:8080/accounts/login",
-        "http://pod-back:8080/videos",
-        "http://pod-back:8080/video/0001-video-test/",
-        "http://pod-back:8080/live/events/"
+        "http://pod-back:8000/",
+        "http://pod-back:8000/accounts/login",
+        "http://pod-back:8000/videos",
+        "http://pod-back:8000/video/0001-video-test/",
+        "http://pod-back:8000/live/events/"
     ]
 }

--- a/dockerfile-dev-with-volumes/pa11y-ci/config_mobile.json
+++ b/dockerfile-dev-with-volumes/pa11y-ci/config_mobile.json
@@ -19,10 +19,10 @@
         ]
     },
     "urls": [
-        "http://pod-back:8080/",
-        "http://pod-back:8080/accounts/login",
-        "http://pod-back:8080/videos",
-        "http://pod-back:8080/video/0001-video-test/",
-        "http://pod-back:8080/live/events/"
+        "http://pod-back:8000/",
+        "http://pod-back:8000/accounts/login",
+        "http://pod-back:8000/videos",
+        "http://pod-back:8000/video/0001-video-test/",
+        "http://pod-back:8000/live/events/"
     ]
 }

--- a/dockerfile-dev-with-volumes/pod-back/my-entrypoint-back.sh
+++ b/dockerfile-dev-with-volumes/pod-back/my-entrypoint-back.sh
@@ -25,5 +25,5 @@ fi
 # Le serveur de développement permet de tester vos futures modifications facilement.
 # N'hésitez pas à lancer le serveur de développement pour vérifier vos modifications au fur et à mesure.
 # À ce niveau, vous devriez avoir le site en français et en anglais et voir l'ensemble de la page d'accueil.
-python3 manage.py runserver 0.0.0.0:8080 --insecure
+python3 manage.py runserver 0.0.0.0:8000 --insecure
 sleep infinity

--- a/dockerfile-dev-with-volumes/pod-encode/my-entrypoint-encode.sh
+++ b/dockerfile-dev-with-volumes/pod-encode/my-entrypoint-encode.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "Launching commands into pod-dev"
-until nc -z pod-back 8080; do echo waiting for pod-back; sleep 10; done;
+until nc -z pod-back 8000; do echo waiting for pod-back; sleep 10; done;
 # Serveur d'encodage
 celery -A pod.video_encode_transcript.encoding_tasks worker -l INFO -Q encoding --concurrency 1 -n encode
 sleep infinity

--- a/dockerfile-dev-with-volumes/pod-transcript/my-entrypoint-transcript.sh
+++ b/dockerfile-dev-with-volumes/pod-transcript/my-entrypoint-transcript.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "Launching commands into pod-dev"
-until nc -z pod-back 8080; do echo waiting for pod-back; sleep 10; done;
+until nc -z pod-back 8000; do echo waiting for pod-back; sleep 10; done;
 # Serveur d'encodage
 celery -A pod.video_encode_transcript.transcripting_tasks worker -l INFO -Q transcripting --concurrency 1 -n transcript
 sleep infinity

--- a/dockerfile-dev-with-volumes/pod-xapi/my-entrypoint-xapi.sh
+++ b/dockerfile-dev-with-volumes/pod-xapi/my-entrypoint-xapi.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "Launching commands into pod-dev"
-until nc -z pod-back 8080; do echo waiting for pod-back; sleep 10; done;
+until nc -z pod-back 8000; do echo waiting for pod-back; sleep 10; done;
 # Serveur xAPI
 celery -A pod.xapi.xapi_tasks worker -l INFO -Q xapi --concurrency 1 -n xapi
 sleep infinity

--- a/dockerfile-dev-with-volumes/pod/my-entrypoint.sh
+++ b/dockerfile-dev-with-volumes/pod/my-entrypoint.sh
@@ -25,5 +25,5 @@ fi
 # Le serveur de développement permet de tester vos futures modifications facilement.
 # N'hésitez pas à lancer le serveur de développement pour vérifier vos modifications au fur et à mesure.
 # À ce niveau, vous devriez avoir le site en français et en anglais et voir l'ensemble de la page d'accueil.
-python3 manage.py runserver 0.0.0.0:8080 --insecure
+python3 manage.py runserver 0.0.0.0:8000 --insecure
 sleep infinity

--- a/pod/custom/settings_local_docker_full_test.py
+++ b/pod/custom/settings_local_docker_full_test.py
@@ -60,7 +60,7 @@ MIGRATION_MODULES = {'flatpages': 'pod.db_migrations'}
 # If DOCKER_ENV = full: activate encoding, transcription and remote xapi
 USE_REMOTE_ENCODING_TRANSCODING = True
 ENCODING_TRANSCODING_CELERY_BROKER_URL = 'redis://redis:6379/7'
-POD_API_URL = "http://pod-back:8080/rest"
+POD_API_URL = "http://pod-back:8000/rest"
 POD_API_TOKEN = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 USE_TRANSCRIPTION = True

--- a/pod/live/tests/test_models.py
+++ b/pod/live/tests/test_models.py
@@ -290,7 +290,7 @@ class EventTestCase(TestCase):
         event.id = None
         self.assertEqual(event.__str__(), "None")
         self.assertEqual(event.get_thumbnail_card(), "/static/img/default-event.svg")
-        self.assertEqual(event.get_full_url(), "//localhost:9090/live/event/0001-event1/")
+        self.assertEqual(event.get_full_url(), "//localhost:8000/live/event/0001-event1/")
         print(" --->  test_attributs of EventTestCase: OK!")
 
     def test_add_thumbnail(self):

--- a/pod/main/fixtures/initial_data.json
+++ b/pod/main/fixtures/initial_data.json
@@ -3,8 +3,8 @@
     "model": "sites.site",
     "pk": 1,
     "fields": {
-      "domain": "localhost:9090",
-      "name": "localhost:9090"
+      "domain": "localhost:8000",
+      "name": "localhost:8000"
     }
   },
   {


### PR DESCRIPTION
For the sake of simplicity I suggest to run the development server on port 9090 instead of 8080 inside docker containers, to align this with the exposed port. Unless this is motivated by technical reasons I ignore?

I found by working on #1058 that this is sometimes confusing to deal with different ports depending on the context. Communications among docker containers had to use the port 8080 (for instance communication between a peertube and a pod instance) whether pod had to be externally reached with the 9090 port (with my browser).

The initial data for `Site` use the 9090 port.
https://github.com/EsupPortail/Esup-Pod/blob/be947445e4bd649d6e199c9a9cbf218d79a7d498/pod/main/fixtures/initial_data.json#L2-L8
For the AP implementation we rely on `Site` to build absolute URLs. That would lead to funky situations with the peertube federation for instance, when a pod AP endpoint accessed by the 8080 port would expose a 9090 URL.

I put this changes on a separate PR than the incoming one for the AP implementation to make it easier to review. If you accept this PR I intend to submit another one that would uniformise the docker host names in the same way.

What do you think?

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `develop` branch.
* [x] The title of your PR starts with `[WIP]` or `[DONE]`.
