### PR TITLE
[DONE] Utilisation de l'adresse `pod.localhost` pour le développement

### DIFF
--- a/CONFIGURATION_FR.md
+++ b/CONFIGURATION_FR.md
@@ -359,7 +359,7 @@ Il faudra pour cela créer un fichier de langue et traduire chaque entrée.<br>
   >>     # },
   >>     "default": {
   >>         "BACKEND": "django_redis.cache.RedisCache",
-  >>         "LOCATION": "redis://127.0.0.1:6379/1",
+  >>         "LOCATION": "redis://redis.localhost:6379/1",
   >>         "OPTIONS": {
   >>             "CLIENT_CLASS": "django_redis.client.DefaultClient",
   >>         },
@@ -367,7 +367,7 @@ Il faudra pour cela créer un fichier de langue et traduire chaque entrée.<br>
   >>     # Persistent cache setup for select2 (NOT DummyCache or LocMemCache).
   >>     "select2": {
   >>         "BACKEND": "django_redis.cache.RedisCache",
-  >>         "LOCATION": "redis://127.0.0.1:6379/2",
+  >>         "LOCATION": "redis://redis.localhost:6379/2",
   >>         "OPTIONS": {
   >>             "CLIENT_CLASS": "django_redis.client.DefaultClient",
   >>         },
@@ -1934,7 +1934,7 @@ Il est possible d’encoder en local ou en distant.<br>
 Attention, il faut configurer Celery pour l’envoi des instructions pour l’encodage distant.<br>
 
 * `CELERY_BROKER_URL`
-  > valeur par défaut : `redis://127.0.0.1:6379/5`
+  > valeur par défaut : `redis://redis.localhost:6379/5`
   >> URL du courtier de messages où Celery stocke les ordres d’encodage et de transcription.<br>
 * `CELERY_TO_ENCODE`
   > valeur par défaut : `False`
@@ -1976,7 +1976,7 @@ Attention, il faut configurer Celery pour l’envoi des instructions pour l’en
   >>
   >> Il faut renseigner l’url du redis sur lequel Celery<br>
   >> va chercher les ordres d’encodage et de transcription<br>
-  >> par exemple : "redis://redis:6379/7"<br>
+  >> par exemple : "redis://redis.localhost:6379/7"<br>
 * `FORMAT_CHOICES`
   > valeur par défaut : `()`
   >> Format d’encodage réalisé sur la plateforme.<br>
@@ -2057,7 +2057,7 @@ Attention, il faut configurer Celery pour l’envoi des instructions pour l’en
   > valeur par défaut : `30`
   >> Valeur de timeout pour ElasticSearch.<br>
 * `ES_URL`
-  > valeur par défaut : `["http://127.0.0.1:9200/"]`
+  > valeur par défaut : `["http://elasticsearch.localhost:9200/"]`
   >> Adresse du ou des instances d’Elasticsearch utilisées pour<br>
   >> l’indexation et la recherche de vidéo.<br>
 * `ES_VERSION`

--- a/CONFIGURATION_FR.md
+++ b/CONFIGURATION_FR.md
@@ -340,7 +340,7 @@ Il faudra pour cela créer un fichier de langue et traduire chaque entrée.<br>
   >> d’encodage ou de flux RSS si la variable `CONTACT_US_EMAIL` n’est pas renseignée.<br><br>
   >> _ref : [docs.djangoproject.com](https://docs.djangoproject.com/fr/3.2/ref/settings/#admins)_<br>
 * `ALLOWED_HOSTS`
-  > valeur par défaut : `['localhost']`
+  > valeur par défaut : `['pod.localhost']`
   >> Une liste de chaînes représentant des noms de domaine/d’hôte que ce site Django peut servir.<br><br>
   >> C’est une mesure de sécurité pour empêcher les attaques d’en-tête Host HTTP,<br>
   >> qui sont possibles même avec bien des configurations de serveur Web apparemment sécurisées.<br><br>

--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,16 @@ help:
 
 # Démarre le serveur de test
 start:
-	(sleep 15 ; open http://localhost:8000) &
-	python3 manage.py runserver localhost:8000 --insecure
+	(sleep 15 ; open http://pod.localhost:8000) &
+	python3 manage.py runserver pod.localhost:8000 --insecure
 	# --insecure let serve static files even when DEBUG=False
 
 # Démarre le serveur de test en https auto-signé
 starts:
 	# nécessite les django-extensions
 	# cf https://timonweb.com/django/https-django-development-server-ssl-certificate/
-	(sleep 15 ; open https://localhost:8000) &
-	python3 manage.py runserver_plus localhost:8000 --cert-file cert.pem --key-file key.pem
+	(sleep 15 ; open https://pod.localhost:8000) &
+	python3 manage.py runserver_plus pod.localhost:8000 --cert-file cert.pem --key-file key.pem
 
 # Première installation de pod (BDD SQLite intégrée)
 install:

--- a/docker-compose-dev-with-volumes.yml
+++ b/docker-compose-dev-with-volumes.yml
@@ -9,6 +9,7 @@ version: '3.7'
 services:
   pod:
     container_name: pod-dev-with-volumes
+    hostname: pod.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/pod/Dockerfile

--- a/docker-compose-dev-with-volumes.yml
+++ b/docker-compose-dev-with-volumes.yml
@@ -24,6 +24,7 @@ services:
 
   elasticsearch:
     container_name: elasticsearch-with-volumes
+    hostname: elasticsearch.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/elasticsearch/dockerfile-elasticsearch-dev
@@ -37,6 +38,7 @@ services:
 
   redis:
     container_name: redis-with-volumes
+    hostname: redis.localhost
     image: ${REDIS_TAG}
     env_file:
       - ./.env.dev
@@ -45,7 +47,7 @@ services:
 
 #  redis-commander:
 #    container_name: redis-commander
-#    hostname: redis-commander
+#    hostname: redis-commander.localhost
 #    image: rediscommander/redis-commander:latest
 #    restart: always
 #    environment:

--- a/docker-compose-full-dev-with-volumes-test.yml
+++ b/docker-compose-full-dev-with-volumes-test.yml
@@ -9,6 +9,7 @@ version: '3.7'
 services:
   pod-back:
     container_name: pod-back-with-volumes
+    hostname: pod.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/pod-back/Dockerfile

--- a/docker-compose-full-dev-with-volumes-test.yml
+++ b/docker-compose-full-dev-with-volumes-test.yml
@@ -24,6 +24,7 @@ services:
 
   pod-encode:
     container_name: pod-encode-with-volumes
+    hostname: pod-encode.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/pod-encode/Dockerfile
@@ -35,6 +36,7 @@ services:
 
   pod-transcript:
     container_name: pod-transcript-with-volumes
+    hostname: pod-transcript.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/pod-transcript/Dockerfile
@@ -46,6 +48,7 @@ services:
 
   pod-xapi:
     container_name: pod-xapi-with-volumes
+    hostname: pod-xapi.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/pod-xapi/Dockerfile
@@ -57,6 +60,7 @@ services:
 
   elasticsearch:
     container_name: elasticsearch-with-volumes
+    hostname: elasticsearch.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/elasticsearch/dockerfile-elasticsearch-dev
@@ -70,6 +74,7 @@ services:
 
   redis:
     container_name: redis-with-volumes
+    hostname: redis.localhost
     image: ${REDIS_TAG}
     env_file:
       - ./.env.dev
@@ -87,7 +92,7 @@ services:
 
 #  redis-commander:
 #    container_name: redis-commander
-#    hostname: redis-commander
+#    hostname: redis-commander.localhost
 #    image: rediscommander/redis-commander:latest
 #    restart: always
 #    environment:

--- a/docker-compose-full-dev-with-volumes.yml
+++ b/docker-compose-full-dev-with-volumes.yml
@@ -9,6 +9,7 @@ version: '3.7'
 services:
   pod-back:
     container_name: pod-back-with-volumes
+    hostname: pod.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/pod-back/Dockerfile

--- a/docker-compose-full-dev-with-volumes.yml
+++ b/docker-compose-full-dev-with-volumes.yml
@@ -24,6 +24,7 @@ services:
 
   pod-encode:
     container_name: pod-encode-with-volumes
+    hostname: pod-encode.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/pod-encode/Dockerfile
@@ -35,6 +36,7 @@ services:
 
   pod-transcript:
     container_name: pod-transcript-with-volumes
+    hostname: pod-transcript.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/pod-transcript/Dockerfile
@@ -46,6 +48,7 @@ services:
 
   pod-xapi:
     container_name: pod-xapi-with-volumes
+    hostname: pod-xapi.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/pod-xapi/Dockerfile
@@ -57,6 +60,7 @@ services:
 
   elasticsearch:
     container_name: elasticsearch-with-volumes
+    hostname: elasticsearch.localhost
     build:
       context: .
       dockerfile: dockerfile-dev-with-volumes/elasticsearch/dockerfile-elasticsearch-dev
@@ -70,6 +74,7 @@ services:
 
   redis:
     container_name: redis-with-volumes
+    hostname: redis.localhost
     image: ${REDIS_TAG}
     env_file:
       - ./.env.dev
@@ -78,7 +83,7 @@ services:
 
 #  redis-commander:
 #    container_name: redis-commander
-#    hostname: redis-commander
+#    hostname: redis-commander.localhost
 #    image: rediscommander/redis-commander:latest
 #    restart: always
 #    environment:

--- a/dockerfile-dev-with-volumes/README.adoc
+++ b/dockerfile-dev-with-volumes/README.adoc
@@ -8,7 +8,7 @@ v1.2, 2023-08-30
 == Docker / docker compose avec volumes sur la machine hôte
 
 === Conteneur ElasticSearch
-http://localhost:9200
+http://elasticsearch.localhost:9200
 
 ==== elasticsearch:8.8.1
 ===== OS/ARCH
@@ -68,13 +68,13 @@ SECRET_KEY = "A_CHANGER"
 DEBUG = True
 # on précise ici qu'on utilise ES version 8
 ES_VERSION = 8
-ES_URL = ['http://elasticsearch:9200/']
+ES_URL = ['http://elasticsearch.localhost:9200/']
 
 
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "redis://redis:6379/3",
+        "LOCATION": "redis://redis.localhost:6379/3",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
@@ -82,7 +82,7 @@ CACHES = {
     },
     "select2": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "redis://redis:6379/2",
+        "LOCATION": "redis://redis.localhost:6379/2",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
@@ -90,7 +90,7 @@ CACHES = {
 }
 SESSION_ENGINE = "redis_sessions.session"
 SESSION_REDIS = {
-    "host": "redis",
+    "host": "redis.localhost",
     "port": 6379,
     "db": 4,
     "prefix": "session",
@@ -103,7 +103,7 @@ MIGRATION_MODULES = {'flatpages': 'pod.db_migrations'}
 
 # Si DOCKER_ENV = full il faut activer l'encodage et la transcription distante
 # USE_REMOTE_ENCODING_TRANSCODING = True
-# ENCODING_TRANSCODING_CELERY_BROKER_URL = "redis://redis:6379/7"
+# ENCODING_TRANSCODING_CELERY_BROKER_URL = "redis://redis.localhost:6379/7"
 
 # pour avoir le maximum de log sur la console
 LOGGING = {}

--- a/dockerfile-dev-with-volumes/pod-back/my-entrypoint-back.sh
+++ b/dockerfile-dev-with-volumes/pod-back/my-entrypoint-back.sh
@@ -3,14 +3,14 @@ echo "Launching commands into pod-dev"
 mkdir -p pod/node_modules
 mkdir -p pod/db_migrations && touch pod/db_migrations/__init__.py
 ln -fs /tmp/node_modules/* pod/node_modules
-until nc -z elasticsearch 9200; do echo waiting for elasticsearch; sleep 10; done;
+until nc -z elasticsearch.localhost 9200; do echo waiting for elasticsearch; sleep 10; done;
 # Mise en route
 # Base de données SQLite intégrée
 BDD_FILE=/usr/src/app/pod/db.sqlite3
 if test ! -f "$BDD_FILE"; then
     echo "$BDD_FILE does not exist."
     python3 manage.py create_pod_index
-    curl -XGET "elasticsearch:9200/pod/_search"
+    curl -XGET "elasticsearch.localhost:9200/pod/_search"
     # Deployez les fichiers statiques
     python3 manage.py collectstatic --no-input --clear
     # Lancez le script présent à la racine afin de créer les fichiers de migration, puis de les lancer pour créer la base de données SQLite intégrée.

--- a/dockerfile-dev-with-volumes/pod-encode/my-entrypoint-encode.sh
+++ b/dockerfile-dev-with-volumes/pod-encode/my-entrypoint-encode.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "Launching commands into pod-dev"
-until nc -z pod-back 8000; do echo waiting for pod-back; sleep 10; done;
+until nc -z pod.localhost 8000; do echo waiting for pod-back; sleep 10; done;
 # Serveur d'encodage
 celery -A pod.video_encode_transcript.encoding_tasks worker -l INFO -Q encoding --concurrency 1 -n encode
 sleep infinity

--- a/dockerfile-dev-with-volumes/pod-transcript/my-entrypoint-transcript.sh
+++ b/dockerfile-dev-with-volumes/pod-transcript/my-entrypoint-transcript.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "Launching commands into pod-dev"
-until nc -z pod-back 8000; do echo waiting for pod-back; sleep 10; done;
+until nc -z pod.localhost 8000; do echo waiting for pod-back; sleep 10; done;
 # Serveur d'encodage
 celery -A pod.video_encode_transcript.transcripting_tasks worker -l INFO -Q transcripting --concurrency 1 -n transcript
 sleep infinity

--- a/dockerfile-dev-with-volumes/pod-xapi/my-entrypoint-xapi.sh
+++ b/dockerfile-dev-with-volumes/pod-xapi/my-entrypoint-xapi.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "Launching commands into pod-dev"
-until nc -z pod-back 8000; do echo waiting for pod-back; sleep 10; done;
+until nc -z pod.localhost 8000; do echo waiting for pod-back; sleep 10; done;
 # Serveur xAPI
 celery -A pod.xapi.xapi_tasks worker -l INFO -Q xapi --concurrency 1 -n xapi
 sleep infinity

--- a/dockerfile-dev-with-volumes/pod/my-entrypoint.sh
+++ b/dockerfile-dev-with-volumes/pod/my-entrypoint.sh
@@ -10,7 +10,7 @@ BDD_FILE=/usr/src/app/pod/db.sqlite3
 if test ! -f "$BDD_FILE"; then
     echo "$BDD_FILE does not exist."
     python3 manage.py create_pod_index
-    curl -XGET "elasticsearch:9200/pod/_search"
+    curl -XGET "elasticsearch.localhost:9200/pod/_search"
     # Deployez les fichiers statiques
     python3 manage.py collectstatic --no-input --clear
     # Lancez le script présent à la racine afin de créer les fichiers de migration, puis de les lancer pour créer la base de données SQLite intégrée.

--- a/pod/custom/settings_local_docker_full_test.py
+++ b/pod/custom/settings_local_docker_full_test.py
@@ -60,7 +60,7 @@ MIGRATION_MODULES = {'flatpages': 'pod.db_migrations'}
 # If DOCKER_ENV = full: activate encoding, transcription and remote xapi
 USE_REMOTE_ENCODING_TRANSCODING = True
 ENCODING_TRANSCODING_CELERY_BROKER_URL = 'redis://redis:6379/7'
-POD_API_URL = "http://pod-back:8000/rest"
+POD_API_URL = "http://pod.localhost:8000/rest"
 POD_API_TOKEN = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 USE_TRANSCRIPTION = True

--- a/pod/custom/settings_local_docker_full_test.py
+++ b/pod/custom/settings_local_docker_full_test.py
@@ -26,11 +26,11 @@ SECRET_KEY = 'A_CHANGER'
 
 # We specify here that we're using ES version 7\n
 ES_VERSION = 7
-ES_URL = ['http://elasticsearch:9200/']
+ES_URL = ['http://elasticsearch.localhost:9200/']
 CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': 'redis://redis:6379/3',
+        'LOCATION': 'redis://redis.localhost:6379/3',
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
         },
@@ -38,7 +38,7 @@ CACHES = {
     },
     'select2': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': 'redis://redis:6379/2',
+        'LOCATION': 'redis://redis.localhost:6379/2',
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
         },
@@ -46,7 +46,7 @@ CACHES = {
 }
 SESSION_ENGINE = 'redis_sessions.session'
 SESSION_REDIS = {
-    'host': 'redis',
+    'host': 'redis.localhost',
     'port': 6379,
     'db': 4,
     'prefix': 'session',
@@ -59,7 +59,7 @@ MIGRATION_MODULES = {'flatpages': 'pod.db_migrations'}
 
 # If DOCKER_ENV = full: activate encoding, transcription and remote xapi
 USE_REMOTE_ENCODING_TRANSCODING = True
-ENCODING_TRANSCODING_CELERY_BROKER_URL = 'redis://redis:6379/7'
+ENCODING_TRANSCODING_CELERY_BROKER_URL = 'redis://redis.localhost:6379/7'
 POD_API_URL = "http://pod.localhost:8000/rest"
 POD_API_TOKEN = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
@@ -79,7 +79,7 @@ TRANSCRIPTION_MODEL_PARAM = {
 }
 
 USE_XAPI_VIDEO = False
-XAPI_CELERY_BROKER_URL = "redis://redis:6379/6"
+XAPI_CELERY_BROKER_URL = "redis://redis.localhost:6379/6"
 
 # for maximum console logging\n
 LOGGING = {}

--- a/pod/live/tests/test_models.py
+++ b/pod/live/tests/test_models.py
@@ -290,7 +290,7 @@ class EventTestCase(TestCase):
         event.id = None
         self.assertEqual(event.__str__(), "None")
         self.assertEqual(event.get_thumbnail_card(), "/static/img/default-event.svg")
-        self.assertEqual(event.get_full_url(), "//localhost:8000/live/event/0001-event1/")
+        self.assertEqual(event.get_full_url(), "//pod.localhost:8000/live/event/0001-event1/")
         print(" --->  test_attributs of EventTestCase: OK!")
 
     def test_add_thumbnail(self):

--- a/pod/main/configuration.json
+++ b/pod/main/configuration.json
@@ -3126,7 +3126,7 @@
                     },
                     "settings": {
                         "CELERY_BROKER_URL": {
-                            "default_value": "redis://127.0.0.1:6379/5",
+                            "default_value": "redis://redis.localhost:6379/5",
                             "description": {
                                 "en": [
                                     ""
@@ -3251,7 +3251,7 @@
                                     "",
                                     "Il faut renseigner l’url du redis sur lequel Celery",
                                     "va chercher les ordres d’encodage et de transcription",
-                                    "par exemple : \"redis://redis:6379/7\""
+                                    "par exemple : \"redis://redis.localhost:6379/7\""
                                 ]
                             },
                             "pod_version_end": "",
@@ -3421,7 +3421,7 @@
                             "pod_version_init": "3.1.0"
                         },
                         "ES_URL": {
-                            "default_value": "[\"http://127.0.0.1:9200/\"]",
+                            "default_value": "[\"http://elasticsearch.localhost:9200/\"]",
                             "description": {
                                 "en": [
                                     ""
@@ -4351,7 +4351,7 @@
                                     "    # },",
                                     "    \"default\": {",
                                     "        \"BACKEND\": \"django_redis.cache.RedisCache\",",
-                                    "        \"LOCATION\": \"redis://127.0.0.1:6379/1\",",
+                                    "        \"LOCATION\": \"redis://redis.localhost:6379/1\",",
                                     "        \"OPTIONS\": {",
                                     "            \"CLIENT_CLASS\": \"django_redis.client.DefaultClient\",",
                                     "        },",
@@ -4359,7 +4359,7 @@
                                     "    # Persistent cache setup for select2 (NOT DummyCache or LocMemCache).",
                                     "    \"select2\": {",
                                     "        \"BACKEND\": \"django_redis.cache.RedisCache\",",
-                                    "        \"LOCATION\": \"redis://127.0.0.1:6379/2\",",
+                                    "        \"LOCATION\": \"redis://redis.localhost:6379/2\",",
                                     "        \"OPTIONS\": {",
                                     "            \"CLIENT_CLASS\": \"django_redis.client.DefaultClient\",",
                                     "        },",

--- a/pod/main/configuration.json
+++ b/pod/main/configuration.json
@@ -4308,7 +4308,7 @@
                             "pod_version_init": "3.1"
                         },
                         "ALLOWED_HOSTS": {
-                            "default_value": "['localhost']",
+                            "default_value": "['pod.localhost']",
                             "description": {
                                 "en": [
                                     ""

--- a/pod/main/fixtures/initial_data.json
+++ b/pod/main/fixtures/initial_data.json
@@ -3,8 +3,8 @@
     "model": "sites.site",
     "pk": 1,
     "fields": {
-      "domain": "localhost:8000",
-      "name": "localhost:8000"
+      "domain": "pod.localhost:8000",
+      "name": "pod.localhost:8000"
     }
   },
   {

--- a/pod/main/settings.py
+++ b/pod/main/settings.py
@@ -48,7 +48,7 @@ USE_DEBUG_TOOLBAR = True
 # that this Django site is allowed to serve.
 #
 # https://docs.djangoproject.com/en/3.2/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ["localhost"]
+ALLOWED_HOSTS = ["pod.localhost"]
 
 ##
 # Session settings

--- a/pod/main/test_settings.py
+++ b/pod/main/test_settings.py
@@ -21,12 +21,12 @@ TEMPLATES[0]["DIRS"].append(
 )
 USE_DOCKER = True
 path = "pod/custom/settings_local.py"
-ES_URL = ["http://127.0.0.1:9200/"]
+ES_URL = ["http://elasticsearch.localhost:9200/"]
 ES_VERSION = 6
 if os.path.exists(path):
     _temp = __import__("pod.custom", globals(), locals(), ["settings_local"])
     USE_DOCKER = getattr(_temp.settings_local, "USE_DOCKER", True)
-    ES_URL = getattr(_temp.settings_local, "ES_URL", ["http://127.0.0.1:9200/"])
+    ES_URL = getattr(_temp.settings_local, "ES_URL", ["http://elasticsearch.localhost:9200/"])
     ES_VERSION = getattr(_temp.settings_local, "ES_VERSION", 6)
 
 for application in INSTALLED_APPS:

--- a/pod/main/tests/test_views.py
+++ b/pod/main/tests/test_views.py
@@ -86,14 +86,14 @@ class MainViewsTestCase(TestCase):
                 "description": "pod",
                 "captcha_0": captcha.hashkey,
                 "captcha_1": captcha.response,
-                "url_referrer": "http://localhost:8000/",
+                "url_referrer": "http://pod.localhost:8000/",
                 "firstname": "",
             },
         )
         messages = list(response.wsgi_request._messages)
         self.assertEqual(len(messages), 1)
         self.assertEqual(str(messages[0]), _("Your message has been sent."))
-        self.assertRedirects(response, "http://localhost:8000/")
+        self.assertRedirects(response, "http://pod.localhost:8000/")
         print("   --->  test_contact_us of mainViewsTestCase: OK!")
         # Form is not valid
         #  /!\  voir fonction clean de ContactUsForm segment if

--- a/pod/settings.py
+++ b/pod/settings.py
@@ -356,7 +356,7 @@ LOGGING = {
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "redis://127.0.0.1:6379/3",
+        "LOCATION": "redis://redis.localhost:6379/3",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
@@ -364,7 +364,7 @@ CACHES = {
     },
     "select2": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "redis://127.0.0.1:6379/2",
+        "LOCATION": "redis://redis.localhost:6379/2",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
@@ -372,7 +372,7 @@ CACHES = {
 }
 SESSION_ENGINE = "redis_sessions.session"
 SESSION_REDIS = {
-    "host": "127.0.0.1",
+    "host": "redis.localhost",
     "port": 6379,
     "db": 4,
     "prefix": "session",

--- a/pod/video_search/management/commands/create_pod_index.py
+++ b/pod/video_search/management/commands/create_pod_index.py
@@ -8,7 +8,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-ES_URL = getattr(settings, "ES_URL", ["http://127.0.0.1:9200/"])
+ES_URL = getattr(settings, "ES_URL", ["http://elasticsearch.localhost:9200/"])
 
 
 class Command(BaseCommand):

--- a/pod/video_search/models.py
+++ b/pod/video_search/models.py
@@ -8,7 +8,7 @@ from django.db.models.signals import post_save, pre_delete
 
 import threading
 
-ES_URL = getattr(settings, "ES_URL", ["http://127.0.0.1:9200/"])
+ES_URL = getattr(settings, "ES_URL", ["http://elasticsearch.localhost:9200/"])
 
 # do it with contributor, overlay, chapter etc.
 

--- a/pod/video_search/readme
+++ b/pod/video_search/readme
@@ -6,10 +6,10 @@ Configuration
 $>root@Pod:/etc/elasticsearch# vim elasticsearch.yml
  - cluster.name: pod-application
  - node.name: pod-1
- - discovery.zen.ping.unicast.hosts: ["127.0.0.1"]
+ - discovery.zen.ping.unicast.hosts: ["elasticsearch.localhost"]
 ?? Use Cerebro: https://github.com/lmenezes/cerebro
 
 To create pod index:
 (django_pod) pod@Pod:~/django_projects/podv3$ python manage.py create_pod_index
 To delete pod index:
-$>curl -XDELETE 127.0.0.1:9200/pod
+$>curl -XDELETE elasticsearch.localhost:9200/pod

--- a/pod/video_search/utils.py
+++ b/pod/video_search/utils.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 DEBUG = getattr(settings, "DEBUG", False)
 
-ES_URL = getattr(settings, "ES_URL", ["http://127.0.0.1:9200/"])
+ES_URL = getattr(settings, "ES_URL", ["http://elasticsearch.localhost:9200/"])
 ES_INDEX = getattr(settings, "ES_INDEX", "pod")
 ES_TIMEOUT = getattr(settings, "ES_TIMEOUT", 30)
 ES_MAX_RETRIES = getattr(settings, "ES_MAX_RETRIES", 10)

--- a/pod/video_search/views.py
+++ b/pod/video_search/views.py
@@ -11,7 +11,7 @@ from django.utils.html import strip_tags
 
 # import json
 
-ES_URL = getattr(settings, "ES_URL", ["http://127.0.0.1:9200/"])
+ES_URL = getattr(settings, "ES_URL", ["http://elasticsearch.localhost:9200/"])
 ES_INDEX = getattr(settings, "ES_INDEX", "pod")
 ES_TIMEOUT = getattr(settings, "ES_TIMEOUT", 30)
 ES_MAX_RETRIES = getattr(settings, "ES_MAX_RETRIES", 10)


### PR DESCRIPTION
#1125 proposait d'uniformiser les ports utilisés à l'intérieur et hors des conteneurs dockers, cette PR propose la même chose pour le nom de domaine.

### motivations

La raison pour laquelle je propose ce changement est encore liée à #1058. L'implémentation d'Activitypub délègue certaines tâches à celery, et ces tâches ont besoin parfois de construire des URL absolues. Étant dans un contexte celery, on ne peut accéder à un objet *request* pour en récupérer le domaine, alors on doit se fier aux objets [Site](https://docs.djangoproject.com/en/5.0/ref/contrib/sites/#django.contrib.sites.models.Site) de Django.

Or, pour le moment `Site` est initialisé pour `localhost`:

https://github.com/EsupPortail/Esup-Pod/blob/cb5f0d5a09949e00a8730973265d61a2c07e15d7/pod/main/fixtures/initial_data.json#L2-L9

En conséquence, dans l'environnement docker on construit des URL absolues sont la forme `http://localhost:8000/...` que l'on transfère à d'autres instances sur le réseau dans le cadre d'activitypub. Hors évidemment, lorsque les autres conteneurs tentent de joindre `localhost:8000` ils essaient de se joindre eux même plutôt que l'instance Pod.

En plus de ça, Peertube rejette pour la fédération les noms de domaines sans TLD, comme `localhost`. Pour faire des tests de fédération avec Peertube dans un environnement docker, on a donc besoin d'utiliser un autre domaine.

### proposition

Je vous propose d'utiliser `pod.localhost` comme adresse de développement, en remplacement de l'adresse `pod-back` qui était utilisée dans l'environnement docker, et `localhost` hors de docker.

### compatibilité

Le serveur de développement serait donc disponible à l'adresse http://pod.localhost:8000.
Les sous-domaines de localhost sont supportés par la majorité des distributions linux sans configuration particulière ([voir les explications](https://superuser.com/questions/1653348/how-does-linux-resolve-wildcard-locahost-subdomains-e-g-ping-test-localhost/1653366#1653366)) et j'ai pu tester sur au moins Ubuntu, Debian et Archlinux.

Pour les utilisateurs de MacOS cependant, il sera nécessaire d'ajouter la ligne suivante dans `/etc/hosts` pour pouvoir accéder à l'adresse pod.localhost

```/etc/hosts
127.0.0.1 pod.localhost
```

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `develop` branch.
* [x] The title of your PR starts with `[WIP]` or `[DONE]`.
