### PR TITLE
[DONE] Correction de dépréciations d'assertions

### DIFF
--- a/pod/bbb/tests/test_models.py
+++ b/pod/bbb/tests/test_models.py
@@ -68,9 +68,9 @@ class MeetingTestCase(TestCase):
     # Test delete object
     def test_delete_object(self):
         Meeting.objects.filter(meeting_id="id1").delete()
-        self.assertEquals(Meeting.objects.all().count(), 1)
+        self.assertEqual(Meeting.objects.all().count(), 1)
         Meeting.objects.filter(meeting_id="id2").delete()
-        self.assertEquals(Meeting.objects.all().count(), 0)
+        self.assertEqual(Meeting.objects.all().count(), 0)
 
         print("   --->  test_delete_object of MeetingTestCase: OK!")
 
@@ -137,9 +137,9 @@ class AttendeeTestCase(TestCase):
     # Test delete object
     def test_delete_object(self):
         Attendee.objects.filter(id=1).delete()
-        self.assertEquals(Attendee.objects.all().count(), 1)
+        self.assertEqual(Attendee.objects.all().count(), 1)
         Attendee.objects.filter(id=2).delete()
-        self.assertEquals(Attendee.objects.all().count(), 0)
+        self.assertEqual(Attendee.objects.all().count(), 0)
 
         print("   --->  test_delete_object of AttendeeTestCase: OK!")
 
@@ -202,6 +202,6 @@ class LivestreamTestCase(TestCase):
     # Test delete object
     def test_delete_object(self):
         Livestream.objects.filter(id=1).delete()
-        self.assertEquals(Livestream.objects.all().count(), 0)
+        self.assertEqual(Livestream.objects.all().count(), 0)
 
         print("   --->  test_delete_object of LivestreamTestCase: OK!")

--- a/pod/live/tests/test_models.py
+++ b/pod/live/tests/test_models.py
@@ -316,19 +316,19 @@ class EventTestCase(TestCase):
         event = Event.objects.get(id=1)
         event.video_on_hold = video
         event.save()
-        self.assertEquals(event.video_on_hold.id, video.id)
+        self.assertEqual(event.video_on_hold.id, video.id)
         print(" --->  test_add_video_on_hold of EventTestCase: OK!")
 
     def test_add_video(self):
         event = Event.objects.get(id=1)
         event = add_video(event)
-        self.assertEquals(event.videos.count(), 1)
+        self.assertEqual(event.videos.count(), 1)
         print(" --->  test_add_video of EventTestCase: OK!")
 
     def test_delete_object(self):
         event = Event.objects.get(id=1)
         event.delete()
-        self.assertEquals(Event.objects.all().count(), 0)
+        self.assertEqual(Event.objects.all().count(), 0)
         print(" --->  test_delete_object of EventTestCase: OK!")
 
     def test_delete_object_keep_video(self):
@@ -336,7 +336,7 @@ class EventTestCase(TestCase):
         add_video(event)
         event.delete()
         # video is not deleted with event
-        self.assertEquals(Video.objects.all().count(), 1)
+        self.assertEqual(Video.objects.all().count(), 1)
         print(" --->  test_delete_object_keep_video of EventTestCase: OK!")
 
     def test_event_filters(self):

--- a/pod/live/tests/test_utils.py
+++ b/pod/live/tests/test_utils.py
@@ -36,17 +36,17 @@ class LiveTestUtils(TestCase):
         event = Event.objects.get(id=1)
 
         bcc = get_bcc(1)
-        self.assertEquals(bcc, [])
+        self.assertEqual(bcc, [])
         print(" --->  test_utils get_bcc ok")
 
         expected = ["first", "second"]
         bcc = get_bcc(expected)
-        self.assertEquals(bcc, expected)
+        self.assertEqual(bcc, expected)
         print(" --->  test_utils get_bcc liste or tuple ok")
 
         expected = "first"
         bcc = get_bcc(expected)
-        self.assertEquals(bcc, expected.split())
+        self.assertEqual(bcc, expected.split())
         print(" --->  test_utils get_bcc string ok")
 
         expected = ["emailadduser1", "emailadduser2"]
@@ -55,7 +55,7 @@ class LiveTestUtils(TestCase):
 
         event.additional_owners.set([additional_user1, additional_user2])
         cc = get_cc(event)
-        self.assertEquals(cc, expected)
+        self.assertEqual(cc, expected)
         print(" --->  test_utils get_cc ok")
 
         # TODO test this for real
@@ -66,17 +66,17 @@ class LiveTestUtils(TestCase):
         """Teste la conversion d'une chaine de caractère en nombre de secondes."""
         from pod.live.utils import date_string_to_second
 
-        self.assertEquals(0, date_string_to_second("a"))
-        self.assertEquals(0, date_string_to_second("1:1:1"))
-        self.assertEquals(0, date_string_to_second("00:00:61"))
-        self.assertEquals(0, date_string_to_second("00:61:00"))
-        self.assertEquals(0, date_string_to_second("24:00:00"))
-        self.assertEquals(0, date_string_to_second("00:00:00"))
-        self.assertEquals(1, date_string_to_second("00:00:01"))
-        self.assertEquals(60, date_string_to_second("00:01:00"))
-        self.assertEquals(3600, date_string_to_second("01:00:00"))
-        self.assertEquals(3661, date_string_to_second("01:01:01"))
-        self.assertEquals(86399, date_string_to_second("23:59:59"))
+        self.assertEqual(0, date_string_to_second("a"))
+        self.assertEqual(0, date_string_to_second("1:1:1"))
+        self.assertEqual(0, date_string_to_second("00:00:61"))
+        self.assertEqual(0, date_string_to_second("00:61:00"))
+        self.assertEqual(0, date_string_to_second("24:00:00"))
+        self.assertEqual(0, date_string_to_second("00:00:00"))
+        self.assertEqual(1, date_string_to_second("00:00:01"))
+        self.assertEqual(60, date_string_to_second("00:01:00"))
+        self.assertEqual(3600, date_string_to_second("01:00:00"))
+        self.assertEqual(3661, date_string_to_second("01:01:01"))
+        self.assertEqual(86399, date_string_to_second("23:59:59"))
         print(" --->  test_utils date_string_to_second ok")
 
     def test_get_event_id_and_broadcaster_id(self):

--- a/pod/main/tests/test_models.py
+++ b/pod/main/tests/test_models.py
@@ -110,7 +110,7 @@ class ConfigurationTestCase(TestCase):
 
     def test_delete_object(self):
         Configuration.objects.filter(key="maintenance_mode").delete()
-        self.assertEquals(Configuration.objects.filter(key="maintenance_mode").count(), 0)
+        self.assertEqual(Configuration.objects.filter(key="maintenance_mode").count(), 0)
         print("--->  test_delete_object of ConfigurationTestCase: OK!")
 
 
@@ -140,7 +140,7 @@ class AdditionalChannelTabTestCase(TestCase):
 
     def test_delete_object(self):
         AdditionalChannelTab.objects.filter(name="Tab0").delete()
-        self.assertEquals(AdditionalChannelTab.objects.filter(name="Tab0").count(), 0)
+        self.assertEqual(AdditionalChannelTab.objects.filter(name="Tab0").count(), 0)
 
         print("--->  test_delete_object of AdditionalChannelTabTestCase: OK!")
 

--- a/pod/meeting/tests/test_views.py
+++ b/pod/meeting/tests/test_views.py
@@ -68,7 +68,7 @@ class meeting_TestView(TestCase):
         self.user = User.objects.get(username="pod")
         self.client.force_login(self.user)
         response = self.client.get(url)
-        self.assertEquals(response.context["access_not_allowed"], True)
+        self.assertEqual(response.context["access_not_allowed"], True)
         self.user.is_staff = True
         self.user.save()
         response = self.client.get(url)

--- a/pod/recorder/tests/test_views.py
+++ b/pod/recorder/tests/test_views.py
@@ -236,7 +236,7 @@ class StudioPodTestView(TestCase):
         self.user = User.objects.get(username="pod")
         self.client.force_login(self.user)
         response = self.client.get(url)
-        self.assertEquals(response.context["access_not_allowed"], True)
+        self.assertEqual(response.context["access_not_allowed"], True)
         self.user.is_staff = True
         self.user.save()
         response = self.client.get(url)

--- a/pod/video/tests/test_models.py
+++ b/pod/video/tests/test_models.py
@@ -221,7 +221,7 @@ class TypeTestCase(TestCase):
     def test_delete_object(self) -> None:
         """Test delete object."""
         Type.objects.get(id=1).delete()
-        self.assertEquals(Type.objects.all().count(), 0)
+        self.assertEqual(Type.objects.all().count(), 0)
         print("   --->  test_delete_object of TypeTestCase: OK!")
 
 

--- a/pod/video/tests/test_views.py
+++ b/pod/video/tests/test_views.py
@@ -880,7 +880,7 @@ class VideoEditTestView(TestCase):
         self.assertTrue(b"The changes have been saved." in response.content)
         v = Video.objects.get(title="VideoTest1")
         p = re.compile(r"^videos/([\d\w]+)/file([_\d\w]*).mp4$")
-        self.assertRegexpMatches(v.video.name, p)
+        self.assertRegex(v.video.name, p)
         # new one
         videofile = SimpleUploadedFile(
             "file.mp4", b"file_content", content_type="video/mp4"


### PR DESCRIPTION
`assertEquals` (avec un *s*) et `assertRegexpMatches` sont dépréciés et supprimés dans python 3.12

https://docs.python.org/3.11/library/unittest.html#deprecated-aliases

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `develop` branch.
* [x] The title of your PR starts with `[WIP]` or `[DONE]`.
