### PR TITLE
[DONE] Fix “Error during template rendering“ on playlist when autoplay is active

### DIFF
--- a/pod/playlist/templates/playlist/playlist_player.html
+++ b/pod/playlist/templates/playlist/playlist_player.html
@@ -33,7 +33,7 @@
   </h2>
   <div {% if videos|length > 5 %}class="scroll-container"{% endif %}>
     {% for video_in_playlist in videos %}
-      {% can_see_playlist_video video_in_playlist playlist as can_see_video %}
+      {% can_see_playlist_video video_in_playlist playlist_in_get as can_see_video %}
         <a
           {% if can_see_video %}
             href="{% with default_version_link=video_in_playlist.get_default_version_link %}{% if default_version_link %}{{ default_version_link }}{% else %}{% url 'video:video' video_in_playlist.slug %}{% endif %}{% endwith %}?playlist={{ playlist_in_get.slug }}"


### PR DESCRIPTION
When autoplay is activate on a playlist, at the end of the first video play, an ajax request is done to get the next video data.
This request call the playlist_player template wich contains a error in the use of the templatetags method “can_see_playlist_video“ : This method need 2 arguments that must be repectivlely type of a video class and type of playlist class. But the second argument send by the playlist_player template is a type of str class...
So this second argument must be replace by a variable of playlist class.
