### PR TITLE
⬆️ [DONE] Replace and remove FFmpegthumbnailer and Montage

### DIFF
--- a/dockerfile-dev-with-volumes/pod-encode/Dockerfile
+++ b/dockerfile-dev-with-volumes/pod-encode/Dockerfile
@@ -20,8 +20,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         netcat \
         ffmpeg \
-        ffmpegthumbnailer \
-        imagemagick \
     && apt-get clean\
     && rm -rf /var/lib/apt/lists/*
 

--- a/dockerfile-dev-with-volumes/pod/Dockerfile
+++ b/dockerfile-dev-with-volumes/pod/Dockerfile
@@ -23,8 +23,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         netcat \
         ffmpeg \
-        ffmpegthumbnailer \
-        imagemagick \
         gettext \
     && apt-get clean\
     && rm -rf /var/lib/apt/lists/*

--- a/pod/video_encode_transcript/encoding_settings.py
+++ b/pod/video_encode_transcript/encoding_settings.py
@@ -64,6 +64,14 @@ FFMPEG_CREATE_THUMBNAIL = (
 )
 FFMPEG_EXTRACT_SUBTITLE = '-map 0:%(index)s -f webvtt -y  "%(output)s" '
 
+FFMPEG_CREATE_OVERVIEW = (
+    " -vsync vfr -vf "
+    "'fps=fps=(%(image_count)s/%(duration)s), "
+    "scale=%(width)sx%(height)s, "
+    "tile=%(image_count)sx1' "
+    "-frames:v 1 '%(output)s' "
+)
+
 FFMPEG_DRESSING_OUTPUT = ' -c:v libx264 -y -vsync 0 "%(output)s" '
 FFMPEG_DRESSING_INPUT = ' -i "%(input)s"'
 FFMPEG_DRESSING_FILTER_COMPLEX = ' -filter_complex "%(filter)s" '


### PR DESCRIPTION
This commit replaces calls to FFmpegthumbnailer and Montage
(ImageMagick) when encoding an overview by a single call to FFmpeg.
Because FFmpegthumbnailer and Montage were not used anywhere else in
the code, it also removes them as dependencies.

Before sending your pull request, make sure the following are done:

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `develop` branch.
* [x] The title of your PR starts with `[WIP]` or `[DONE]`.
