### PR TITLE
[DONE] Bugfix import video and thumbnail

### DIFF
--- a/pod/import_video/views.py
+++ b/pod/import_video/views.py
@@ -906,7 +906,12 @@ def upload_peertube_recording_to_pod(request, record_id: int) -> bool:  # noqa: 
                 # Evant date (format: 2023-05-23)
                 date_evt = pt_video_created_at[0:10]
                 # Source video file
-                source_video_url = pt_video_json["files"][0]["fileDownloadUrl"]
+                if not pt_video_json["files"]:
+                    # Source video file for a playlist
+                    source_video_url = pt_video_json["streamingPlaylists"][0]["files"][0]["fileDownloadUrl"]
+                else:
+                    # Source video file for a video
+                    source_video_url = pt_video_json["files"][0]["fileDownloadUrl"]
 
         # Verify that video exists and not oversized
         verify_video_exists_and_size(source_video_url)

--- a/pod/import_video/views.py
+++ b/pod/import_video/views.py
@@ -49,7 +49,6 @@ from pytubefix.exceptions import PytubeFixError, VideoUnavailable
 from pod.main.tasks import task_start_bbb_presentation_encode_and_upload_to_pod
 from pod.main.tasks import task_start_bbb_presentation_encode_and_move_to_destination
 
-DEBUG = getattr(settings, "DEBUG", True)
 
 RESTRICT_EDIT_IMPORT_VIDEO_ACCESS_TO_STAFF_ONLY = getattr(
     settings, "RESTRICT_EDIT_IMPORT_VIDEO_ACCESS_TO_STAFF_ONLY", True

--- a/pod/import_video/views.py
+++ b/pod/import_video/views.py
@@ -2,7 +2,6 @@
 
 More information on this module at: https://www.esup-portail.org/wiki/x/BQCnSw
 """
-
 import logging
 import os
 import requests
@@ -42,14 +41,15 @@ from pod.import_video.utils import manage_download
 from pod.main.views import in_maintenance
 from pod.main.utils import secure_post_request, display_message_with_icon
 
-# For Youtube download
-from pytube import YouTube
-from pytube.exceptions import PytubeError, VideoUnavailable
+# For Youtube download, use PyTubeFix in replacement of PyTube
+from pytubefix import YouTube
+from pytubefix.exceptions import PytubeFixError, VideoUnavailable
 
 # To convert old BBB presentation
 from pod.main.tasks import task_start_bbb_presentation_encode_and_upload_to_pod
 from pod.main.tasks import task_start_bbb_presentation_encode_and_move_to_destination
 
+DEBUG = getattr(settings, "DEBUG", True)
 
 RESTRICT_EDIT_IMPORT_VIDEO_ACCESS_TO_STAFF_ONLY = getattr(
     settings, "RESTRICT_EDIT_IMPORT_VIDEO_ACCESS_TO_STAFF_ONLY", True
@@ -734,8 +734,8 @@ def get_mediacad_api_description(type_source_url: TypeSourceURL) -> str:
 def upload_youtube_recording_to_pod(request, record_id: int):
     """Upload Youtube recording to Pod.
 
-    Use PyTube with its API
-    More information: https://pytube.io/en/latest/api.html
+    Use PyTubeFix with its API
+    More information: https://pytubefix.readthedocs.io/en/latest/
     Args:
         request (Request): HTTP request
         record_id (Integer): id record in the database
@@ -750,12 +750,12 @@ def upload_youtube_recording_to_pod(request, record_id: int):
         # Manage source URL from video playback
         source_url = request.POST.get("source_url")
 
-        # Use pytube to download Youtube file
+        # Use pytubefix to download Youtube file
+        # Manage Proof of Origin Token generation
+        # See https://pytubefix.readthedocs.io/en/latest/user/po_token.html
         yt_video = YouTube(
             source_url,
-            # on_complete_callback=complete_func,
-            # use_oauth=True,
-            # allow_oauth_cache=True
+            'WEB'
         )
         # Publish date (format: 2023-05-13 00:00:00)
         # Event date (format: 2023-05-13)
@@ -799,7 +799,8 @@ def upload_youtube_recording_to_pod(request, record_id: int):
         save_video(request.user, dest_path, recording_title, description, date_evt)
         return True
 
-    except VideoUnavailable:
+    except VideoUnavailable as ptfvu:
+        log.error("upload_youtube_recording_to_pod - VideoUnavailable - %s" % ptfvu)
         msg = {}
         msg["error"] = _("YouTube error")
         msg["message"] = _(
@@ -810,9 +811,10 @@ def upload_youtube_recording_to_pod(request, record_id: int):
             "Try changing the access rights to the video directly in Youtube."
         )
         raise ValueError(msg)
-    except PytubeError as pterror:
+    except PytubeFixError as ptferror:
+        log.error("upload_youtube_recording_to_pod - PytubeFixError - %s" % ptferror)
         msg = {}
-        msg["error"] = _("YouTube error “%s”" % (mark_safe(pterror)))
+        msg["error"] = _("YouTube error “%s”" % (mark_safe(ptferror)))
         msg["message"] = "%s\n%s" % (
             _("YouTube content is inaccessible."),
             _("This content does not appear to be publicly available."),
@@ -891,7 +893,7 @@ def upload_peertube_recording_to_pod(request, record_id: int) -> bool:  # noqa: 
             else:
                 pt_video_json = json.loads(response.content.decode("utf-8"))
                 # URL
-                pt_video_url = pt_video_json["url"]
+                pt_video_url = source_url
                 # UUID, useful for the filename
                 pt_video_uuid = pt_video_json["uuid"]
                 pt_video_name = pt_video_json["name"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ qrcode
 ralph-malph==3.8.0
 pydantic==1.10.13
 bleach==6.0.0
-pytube==15.0.0
+pytubefix==8.12.0
 django-redis-sessions
 paramiko~=3.1.0
 djangorestframework-simplejwt==5.3.0


### PR DESCRIPTION
Bugfix

Modifications to the video import module:
 - Replace pytube by pytubefix library, and generate PO token (see https://pytubefix.readthedocs.io/en/latest/user/po_token.html)
 - Manage the lack of URL field in some Peertube videos
Modifications to the video module:
 - Handle exception to avoid sending an error email, for get_thumbnail function (typically when the generated thumbnail presents a problem)