### PR TITLE
[DONE] Manage video_search module for v4

### DIFF
--- a/pod/video_search/management/commands/index_videos.py
+++ b/pod/video_search/management/commands/index_videos.py
@@ -62,6 +62,6 @@ class Command(BaseCommand):
                     self.style.SUCCESS('Successfully index Video "%s"' % video_id)
                 )
             else:
-                delete_es(video)
+                delete_es(video.id)
         except Video.DoesNotExist:
             self.stdout.write(self.style.ERROR('Video "%s" does not exist' % video_id))

--- a/pod/video_search/models.py
+++ b/pod/video_search/models.py
@@ -30,7 +30,7 @@ def index_video(video) -> None:  # pragma: no cover
     if video.is_draft is False and video.encoding_in_progress is False:
         index_es(video)
     else:
-        delete_es(video)
+        delete_es(video.id)
 
 
 @receiver(pre_delete, sender=Video)
@@ -41,6 +41,6 @@ def delete_video_index(
     if ES_URL is None:
         return
     # delete_es(instance)
-    t = threading.Thread(target=delete_es, args=[instance])
+    t = threading.Thread(target=delete_es, args=[instance.id])
     t.daemon = True
     t.start()

--- a/pod/video_search/search_template_fr.json
+++ b/pod/video_search/search_template_fr.json
@@ -19,6 +19,9 @@
           }
         },
         "analyzer": {
+          "default": {
+            "type": "standard"
+          },
           "icu_french": {
             "tokenizer": "icu_tokenizer",
             "filter": [

--- a/pod/video_search/tests/test_utils.py
+++ b/pod/video_search/tests/test_utils.py
@@ -32,7 +32,7 @@ class VideoSearchTestUtils(TestCase):
         res = index_es(self.v)
         self.assertTrue(res["result"] in ["created", "updated"])
         self.assertEqual(res["_id"], str(self.v.id))
-        delete = delete_es(self.v)
+        delete = delete_es(self.v.id)
         self.assertEqual(delete["result"], "deleted")
         self.assertEqual(delete["_id"], str(self.v.id))
         print("--> test_index_and_delete_es ok! ")

--- a/pod/video_search/utils.py
+++ b/pod/video_search/utils.py
@@ -51,8 +51,8 @@ def index_es(video):
     translation.deactivate()
 
 
-def delete_es(video):
-    """Delete an Elasticsearch video entry."""
+def delete_es(video_id):
+    """Delete an Elasticsearch video entry by video id."""
     es = Elasticsearch(
         ES_URL,
         request_timeout=ES_TIMEOUT,
@@ -65,7 +65,7 @@ def delete_es(video):
             # Pass transport options to elasticsearch
             es = es.options(ignore_status=[400, 404])
             # Do the deletion
-            delete = es.delete(index=ES_INDEX, id=video.id, refresh=True)
+            delete = es.delete(index=ES_INDEX, id=video_id, refresh=True)
             if DEBUG:
                 logger.info(delete)
             return delete

--- a/pod/video_search/views.py
+++ b/pod/video_search/views.py
@@ -238,7 +238,10 @@ def search_videos(request):
     list_videos_id = [hit["_id"] for hit in result["hits"]["hits"]]
     videos = Video.objects.filter(id__in=list_videos_id)
     num_result = 0
-    num_result = result["hits"]["total"]["value"]
+    # In case of desynchronization with Elasticsearch, this result could be false.
+    # num_result = result["hits"]["total"]["value"]
+    # With this code, the result is always correct
+    num_result = len(videos)
     videos.has_next = ((page + 1) * size) < num_result
     videos.next_page_number = page + 1
 


### PR DESCRIPTION
Manage video_search module for v4:

- [x] Use video id parameter for delete_es() function: video could be deleted before the delete in Elasticsearch.

- [x] Modifty template to avoid error in ES 8:
_Fielddata is disabled on [cursus] in [pod]. Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead_

- [x] Change in calculation of number of results(useful in case of desynchronization with Elasticsearch)