### PR TITLE
Manage local settings for encoding

### DIFF
--- a/pod/video_encode_transcript/encoding_studio.py
+++ b/pod/video_encode_transcript/encoding_studio.py
@@ -1,5 +1,4 @@
 """This module handles studio encoding with CPU."""
-
 import time
 import subprocess
 import json
@@ -22,6 +21,18 @@ else:
         FFPROBE_GET_INFO,
         FFMPEG_STUDIO_COMMAND,
     )
+
+try:
+    from django.conf import settings
+    FFMPEG_CMD = getattr(settings, "FFMPEG_CMD", FFMPEG_CMD)
+    FFPROBE_CMD = getattr(settings, "FFPROBE_CMD", FFPROBE_CMD)
+    FFMPEG_CRF = getattr(settings, "FFMPEG_CRF", FFMPEG_CRF)
+    FFMPEG_NB_THREADS = getattr(settings, "FFMPEG_NB_THREADS", FFMPEG_NB_THREADS)
+    FFPROBE_GET_INFO = getattr(settings, "FFPROBE_GET_INFO", FFPROBE_GET_INFO)
+    FFMPEG_STUDIO_COMMAND = getattr(settings, "FFMPEG_STUDIO_COMMAND", FFMPEG_STUDIO_COMMAND)
+except ImportError:  # pragma: no cover
+    pass
+
 
 # ##########################################################################
 # ENCODE VIDEO STUDIO: MAIN ENCODE

--- a/pod/video_encode_transcript/encoding_utils.py
+++ b/pod/video_encode_transcript/encoding_utils.py
@@ -1,14 +1,21 @@
-import subprocess
-import shlex
-import json
 from collections import OrderedDict
 from timeit import default_timer as timer
+
+import json
 import os
+import shlex
+import subprocess
 
 try:
     from .encoding_settings import VIDEO_RENDITIONS
 except (ImportError, ValueError):
     from encoding_settings import VIDEO_RENDITIONS
+
+try:
+    from django.conf import settings
+    VIDEO_RENDITIONS = getattr(settings, "VIDEO_RENDITIONS", VIDEO_RENDITIONS)
+except ImportError:  # pragma: no cover
+    pass
 
 
 def sec_to_timestamp(total_seconds):


### PR DESCRIPTION
Encoding parameters defined in settings_local.py are taken into account, particularly those for the recorder.

For issue #1274 
- Manage FFMPEG_CMD, FFPROBE_CMD, FFMPEG_CRF, FFMPEG_NB_THREADS, FFPROBE_GET_INFO, FFMPEG_STUDIO_COMMAND from local settings.
- Manage VIDEO_RENDITIONS from local settings.