### PR TITLE
Improved moving of recording files

### DIFF
--- a/pod/live/views.py
+++ b/pod/live/views.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os.path
+import shutil
 import re
 import threading
 from datetime import datetime
@@ -1020,13 +1021,15 @@ def create_video(event_id, current_file, segment_number):
         check_size_not_changing(full_file_name)
 
         # moving the file
-        os.rename(
+        shutil.copyfile(
             full_file_name,
-            dest_file,
+            dest_file
         )
 
         # verif si la taille du fichier copié ne bouge plus
         check_size_not_changing(dest_file)
+
+        os.remove(full_file_name)
 
     except Exception as exc:
         return JsonResponse(

--- a/pod/live/views.py
+++ b/pod/live/views.py
@@ -1020,7 +1020,8 @@ def create_video(event_id, current_file, segment_number):
         # verif si la taille du fichier d'origine ne bouge plus
         check_size_not_changing(full_file_name)
 
-        # moving the file
+        # Copy puis suppression plutôt qu'un rename qui ne fonctionne pas sous
+        # des systèmes de fichiers différents (env. conteneurisés et volumes persistants)
         shutil.copyfile(
             full_file_name,
             dest_file


### PR DESCRIPTION
Le "rename" du fichier ne fonctionne pas lorsque le système de fichier source n'est pas le même que celui de destination ce qui est le cas dans des environnements conteneurisés utilisant des volumes persistés.
On doit donc passer par une copie suivie d'une suppression
