### PR TITLE
[DONE] Manage django-chunked-upload for v4

### DIFF
--- a/pod/settings.py
+++ b/pod/settings.py
@@ -8,9 +8,6 @@ import os
 import sys
 import importlib.util
 
-# DEPRECATIONS HACKS
-import django
-
 # As a comment until a new version of django-chunked-upload is released on pypi
 # See requirements.txt (django-chunked-upload==2.0.0 replaced by
 # git+https://github.com/juliomalegria/django-chunked-upload.git@master)

--- a/pod/settings.py
+++ b/pod/settings.py
@@ -11,6 +11,7 @@ import importlib.util
 # As a comment until a new version of django-chunked-upload is released on pypi
 # See requirements.txt (django-chunked-upload==2.0.0 replaced by
 # git+https://github.com/juliomalegria/django-chunked-upload.git@master)
+# from django.utils.translation import gettext
 # django.utils.translation.ugettext = gettext
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))

--- a/pod/settings.py
+++ b/pod/settings.py
@@ -10,14 +10,13 @@ import importlib.util
 
 # DEPRECATIONS HACKS
 import django
-from django.utils.translation import gettext
 from urllib.parse import quote
 
 # Needed for django-cas-client==1.5.3
 django.utils.http.urlquote = quote
 
 # As a comment until a new version of django-chunked-upload is released on pypi
-# See requirements.txt (django-chunked-upload==2.0.0 replaced by 
+# See requirements.txt (django-chunked-upload==2.0.0 replaced by
 # git+https://github.com/juliomalegria/django-chunked-upload.git@master)
 # django.utils.translation.ugettext = gettext
 

--- a/pod/settings.py
+++ b/pod/settings.py
@@ -16,8 +16,10 @@ from urllib.parse import quote
 # Needed for django-cas-client==1.5.3
 django.utils.http.urlquote = quote
 
-# Needed for django-chunked-upload==2.0.0
-django.utils.translation.ugettext = gettext
+# As a comment until a new version of django-chunked-upload is released on pypi
+# See requirements.txt (django-chunked-upload==2.0.0 replaced by 
+# git+https://github.com/juliomalegria/django-chunked-upload.git@master)
+# django.utils.translation.ugettext = gettext
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # will be update in pod/main/settings.py

--- a/pod/settings.py
+++ b/pod/settings.py
@@ -11,7 +11,6 @@ import importlib.util
 # As a comment until a new version of django-chunked-upload is released on pypi
 # See requirements.txt (django-chunked-upload==2.0.0 replaced by
 # git+https://github.com/juliomalegria/django-chunked-upload.git@master)
-# from django.utils.translation import gettext
 # django.utils.translation.ugettext = gettext
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ django-lti-provider==1.0.0
 django-auth-mixins==1.0.1
 pandas
 django-shibboleth-remoteuser
-django-chunked-upload==2.0.0
 django-select2
 django-redis
 chardet==5.2.0
@@ -36,3 +35,4 @@ djangorestframework-simplejwt==5.3.1
 django-pwa==2.0.1
 django-webpush==0.3.6
 defusedxml==0.7.1
+git+https://github.com/juliomalegria/django-chunked-upload.git@master


### PR DESCRIPTION
Manage django-chunked-upload for v4:

- Replace django-chunked-upload==2.0.0 by git+https://github.com/juliomalegria/django-chunked-upload.git@master in requirements.txt (wait for a new release in pypi)
- Remove Django 4 hack for ugettext in settings.py