### PR TITLE
Accessibility Improvement: Sticky Breadcrumb Below the Main Navigation

### DIFF
--- a/pod/main/static/css/dark.css
+++ b/pod/main/static/css/dark.css
@@ -34,6 +34,7 @@
   --pod-font-color: var(--pod-font-color-dark);
   --pod-background-neutre1-bloc: var(--pod-background-neutre1-bloc-dark);
   --pod-background-neutre2-bloc: var(--pod-background-neutre2-bloc-dark);
+  --pod-navbar-breadcrumb-border: var(--pod-navbar-breadcrumb-border-dark);
   --pod-btn-text: var(--pod-btn-text-dark);
   --pod-alert: var(--pod-alert-dark);
   --pod-link-color: var(--pod-primary-lighten-dark);

--- a/pod/main/static/css/dark.css
+++ b/pod/main/static/css/dark.css
@@ -115,7 +115,7 @@
 }
 
 [data-theme="dark"] .breadcrumb-item.active {
-  color: #a8abb3;
+  color: #ffffff;
 }
 
 [data-theme="dark"] .nav-tabs .nav-item.show .nav-link,

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -296,7 +296,6 @@ a:not(.btn, .dropdown-item):focus {
 .pod-navbar-breadcrumb {
   background-color: var(--pod-background-neutre2-bloc);
   border-bottom: 1px solid var(--pod-navbar-breadcrumb-border);
-  z-index: 1020;
   padding-left: 1.5rem;
   padding-right: 1.5rem;
   margin-top: auto;
@@ -1369,7 +1368,7 @@ main {
   font-size: 1.755rem;
 }
 
-@media (max-width: 576px) {
+@media (width <= 576px) {
   .pod-navbar__brand {
     font-size: 1.25rem;
   }
@@ -1570,7 +1569,7 @@ Commented in 3.6.0
   height: auto;
 }
 
-@media (max-width: 576px) {
+@media (width <= 576px) {
   .pod-navbar__button-toggler {
     font-size: 2rem;
     margin-right: 0.5rem;

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -51,7 +51,7 @@
 
   /**** second neutral color for block background ***/
   --pod-background-neutre2-bloc: #f5f5f5;
-  --pod-background-neutre2-bloc-dark: #393e46;
+  --pod-background-neutre2-bloc-dark: #161c26;
 
   /*** breadcrumb border color ***/
   --pod-navbar-breadcrumb-border: #ced4da;

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -557,6 +557,11 @@ a.btn-outline-primary:not(:hover) svg {
     top: 0;
   }
 
+  .custom-rounded-left {
+    border-top-left-radius: var(--bs-border-radius-xl);
+    border-bottom-left-radius: var(--bs-border-radius-xl);
+  }
+   
   #s {
     border-radius: 0;
     transition: height 0.5s;

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -289,6 +289,49 @@ a:not(.btn, .dropdown-item):focus {
   padding: 0.25rem 1.25rem;
 }
 
+.pod-navbar-breadcrumb {
+  background-color: #f5f5f5;
+  border-bottom: 1px solid #cdcdcd;
+  margin-top: 4.5em;
+  z-index: 1020;
+}
+
+.pod-navbar-breadcrumb .breadcrumb {
+  margin-bottom: 0;
+}
+
+.pod-navbar .btn {
+  border-radius: var(--bs-border-radius-xl);
+  font-size: 1rem;
+  padding: 0.4rem 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.pod-navbar .btn i {
+  font-size: 1.3em;
+  display: inline-flex;
+  align-items: center;
+}
+
+@media (max-width: 576px) {
+  .pod-navbar .btn {
+    font-size: 0.9rem;
+    padding: 0.25rem 0.75rem;
+  }
+
+  .pod-navbar .btn i {
+    font-size: 1em;
+  }
+
+  .pod-navbar-breadcrumb {
+    margin-top: 3.56em;
+  }
+  
+  
+}
+
 /***
  *  video *
  ***/
@@ -488,7 +531,7 @@ a.btn-outline-primary:not(:hover) svg {
 /*** modif taille logo ***/
 @media (max-width: 576px) {
   .navbar-brand img {
-    height: 35px;
+    height: 30px;
   }
 }
 
@@ -1025,6 +1068,10 @@ body {
   background-color: var(--pod-background);
 }
 
+main {
+  padding-top: 3em;
+}
+
 /*** reinit bootstrap 5 ***/
 .nav {
   --bs-nav-link-color: var(--pod-font-color);
@@ -1212,9 +1259,7 @@ body {
 
 .pod-navbar {
   background: var(--pod-background);
-  box-shadow:
-    0 1px 3px rgb(0 0 0 / 12%),
-    0 1px 2px rgb(0 0 0 / 24%);
+  border-bottom: 1px solid #cdcdcd;
 }
 
 .pod-info-video {
@@ -1321,6 +1366,13 @@ body {
   gap: 0.5rem;
   color: var(--pod-font-color) !important;
   transition: transform 0.4s ease;
+  font-size: 1.755rem;
+}
+
+@media (max-width: 576px) {
+  .pod-navbar__brand {
+    font-size: 1.25rem;
+  }
 }
 
 .pod-navbar__brand:hover,
@@ -1384,6 +1436,7 @@ body {
 
 .pod-navbar__form {
   margin-left: auto;
+  margin-right: auto;
 }
 
 @media (width >= 992px) {
@@ -1508,13 +1561,20 @@ Commented in 3.6.0
 .pod-navbar__button-toggler {
   color: var(--pod-font-color);
   padding: 0;
-  font-size: 1.8rem;
+  font-size: 2rem;
   margin: 0;
   border: 0;
-  margin-right: 0.3rem;
+  margin-right: 1rem;
   background: none;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: auto;
+  height: auto;
+}
+
+@media (max-width: 576px) {
+  .pod-navbar__button-toggler {
+    font-size: 2rem;
+    margin-right: 0.5rem;
+  }
 }
 
 .pod-camera-video {
@@ -1679,6 +1739,9 @@ table .alert.alert-danger.btn.pod-btn-social {
 
 #mainbreadcrumb {
   margin-right: 2.7rem;
+  margin-top: auto;
+  margin-bottom: auto;
+  margin-left: 1rem;
 }
 
 div.disabled,

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -556,11 +556,6 @@ a.btn-outline-primary:not(:hover) svg {
     top: 0;
   }
 
-  .custom-rounded-left {
-    border-top-left-radius: var(--bs-border-radius-xl);
-    border-bottom-left-radius: var(--bs-border-radius-xl);
-  }
-   
   #s {
     border-radius: 0;
     transition: height 0.5s;
@@ -959,6 +954,8 @@ span[data-bs-placement] {
 .form-group .errorlist {
   margin-bottom: 0;
 }
+
+header>.alert{--bs-border-radius: 0}
 
 #base-message-alert,
 #formalertdiv {

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -1064,7 +1064,6 @@ body {
   flex-direction: column;
   justify-content: flex-start;
   min-height: 100vh;
-  padding-top: 3.1rem;
   color: var(--pod-font-color);
   background-color: var(--pod-background);
 }

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -290,8 +290,8 @@ a:not(.btn, .dropdown-item):focus {
 }
 
 .pod-navbar-breadcrumb {
-  background-color: #f5f5f5;
-  border-bottom: 1px solid #cdcdcd;
+  background-color: var(--pod-background-neutre2-bloc);
+  border-bottom: 1px solid var(--bs-gray-400);
   margin-top: 4.5em;
   z-index: 1020;
 }
@@ -1259,7 +1259,7 @@ main {
 
 .pod-navbar {
   background: var(--pod-background);
-  border-bottom: 1px solid #cdcdcd;
+  border-bottom: 1px solid var(--bs-gray-400);
 }
 
 .pod-info-video {

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -32,40 +32,40 @@
    * Esup-Pod default colors
    ***/
 
-  /*** couleur de fond du site ***/
+  /*** site background color ***/
   --pod-background: #fff;
   --pod-background-dark: #222831;
 
-  /*** couleur du texte des boutons principaux ***/
+  /*** main button text color ***/
   --pod-btn-text: #fff;
   --pod-btn-text-dark: #fff;
 
-  /**** couleur de police ****/
+  /**** font color ****/
   --pod-font-color: #000;
   --pod-font-color-dark: #f8f9fa;
 
-  /**** couleur neutre pour fond de bloc (ex jumbotron) ***/
+  /**** neutral color for block background (e.g. jumbotron) ***/
   --pod-background-neutre1-bloc: #ddd;
   --pod-background-neutre1-bloc-dark: #393e46;
   --pod-background-neutre1-bloc-hover: #e5f1fa;
 
-  /**** couleur neutre 2 pour fond de bloc ***/
+  /**** second neutral color for block background ***/
   --pod-background-neutre2-bloc: #f5f5f5;
   --pod-background-neutre2-bloc-dark: #393e46;
 
-  /*** couleur des bordures de l'ariane ***/
+  /*** breadcrumb border color ***/
   --pod-navbar-breadcrumb-border: #ced4da;
   --pod-navbar-breadcrumb-border-dark: #8e969d;
 
-  /**** couleur des liens *****/
+  /**** link colors *****/
   --pod-link-color: var(--pod-primary);
   --pod-link-color-rgb: var(--pod-primary-rgb);
   --pod-activelink-color: var(--pod-primary-darken);
 
-  /* couleur d'un élément actif (ex. : survol de bouton) */
+  /* active element color (e.g., button hover) */
   --pod-primary-focus: var(--pod-primary-darken);
 
-  /* Couleur d'alerte */
+  /* alert color */
   --pod-alert: #fc8670;
   --pod-alert-dark: #b11030;
 
@@ -314,7 +314,6 @@ a:not(.btn, .dropdown-item):focus {
 
 .pod-navbar .btn {
   border-radius: var(--bs-border-radius-xl);
-  font-size: 1rem;
   padding: 0.4rem 1.5rem;
   display: inline-flex;
   align-items: center;
@@ -322,7 +321,6 @@ a:not(.btn, .dropdown-item):focus {
 }
 
 .pod-navbar .btn i {
-  font-size: 1.3em;
   display: inline-flex;
   align-items: center;
 }
@@ -332,16 +330,6 @@ a:not(.btn, .dropdown-item):focus {
     font-size: 0.9rem;
     padding: 0.25rem 0.75rem;
   }
-
-  .pod-navbar .btn i {
-    font-size: 1em;
-  }
-
-  .pod-navbar-breadcrumb {
-    margin-top: 3.56em;
-  }
-  
-  
 }
 
 /***

--- a/pod/main/static/css/pod.css
+++ b/pod/main/static/css/pod.css
@@ -51,7 +51,11 @@
 
   /**** couleur neutre 2 pour fond de bloc ***/
   --pod-background-neutre2-bloc: #f5f5f5;
-  --pod-background-neutre2-bloc-dark: #161c26;
+  --pod-background-neutre2-bloc-dark: #393e46;
+
+  /*** couleur des bordures de l'ariane ***/
+  --pod-navbar-breadcrumb-border: #ced4da;
+  --pod-navbar-breadcrumb-border-dark: #8e969d;
 
   /**** couleur des liens *****/
   --pod-link-color: var(--pod-primary);
@@ -291,13 +295,21 @@ a:not(.btn, .dropdown-item):focus {
 
 .pod-navbar-breadcrumb {
   background-color: var(--pod-background-neutre2-bloc);
-  border-bottom: 1px solid var(--bs-gray-400);
-  margin-top: 4.5em;
+  border-bottom: 1px solid var(--pod-navbar-breadcrumb-border);
   z-index: 1020;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  margin-top: auto;
+  margin-bottom: auto;
 }
 
 .pod-navbar-breadcrumb .breadcrumb {
   margin-bottom: 0;
+}
+
+.pod-navbar {
+  background: var(--pod-background);
+  border-bottom: 1px solid var(--pod-navbar-breadcrumb-border);
 }
 
 .pod-navbar .btn {
@@ -1257,11 +1269,6 @@ main {
   }
 }
 
-.pod-navbar {
-  background: var(--pod-background);
-  border-bottom: 1px solid var(--bs-gray-400);
-}
-
 .pod-info-video {
   margin-top: 1.5rem;
 }
@@ -1735,13 +1742,6 @@ table .alert.alert-danger.btn.pod-btn-social {
 .calendarbox {
   z-index: 3000;
   background-color: var(--pod-background) !important;
-}
-
-#mainbreadcrumb {
-  margin-right: 2.7rem;
-  margin-top: auto;
-  margin-bottom: auto;
-  margin-left: 1rem;
 }
 
 div.disabled,

--- a/pod/main/templates/base.html
+++ b/pod/main/templates/base.html
@@ -62,7 +62,7 @@
 
 <body>
   {% if PRE_HEADER_TEMPLATE %}{% include PRE_HEADER_TEMPLATE %}{% endif %}
-  <header role="banner" class="fixed-top">
+  <header role="banner" class="sticky-top">
     {% if MAINTENANCE_SHEDULED %}
     <div class="alert alert-warning m-0 p-2" role="alert">
       {{ MAINTENANCE_TEXT_SHEDULED|safe }}

--- a/pod/main/templates/base.html
+++ b/pod/main/templates/base.html
@@ -62,44 +62,43 @@
 
 <body>
   {% if PRE_HEADER_TEMPLATE %}{% include PRE_HEADER_TEMPLATE %}{% endif %}
-  <header role="banner">
-      <!-- Navigation principale -->
-      <nav class="navbar pod-navbar fixed-top m-0 p-1 p-md-2" aria-label="{% trans 'Main navigation' %}">
-        {% include 'navbar.html' %}
-      </nav>
-    
-      <!-- Navigation repliée-->
-      {% include 'navbar_collapse.html' %}
-    
-      <div class="container-fluid pod-navbar-breadcrumb fixed-top">
-        {% if not request.GET.is_iframe %}
-          {% if MAINTENANCE_SHEDULED %}
-            <div class="alert alert-warning" role="alert">
-              {{ MAINTENANCE_TEXT_SHEDULED|safe }}
-            </div>
-          {% endif %}
-          
-          <!-- Fil d'Ariane -->
-          <nav aria-label="{% trans 'Breadcrumb' %}" id="mainbreadcrumb">
-            <ol class="breadcrumb d-flex">
-              {% block breadcrumbs %}
-                {% if request.path == '/' %}
-                  <li class="breadcrumb-item active" aria-current="page">
-                    {% trans 'Home' %}
-                  </li>
-                {% else %}
-                  <li class="breadcrumb-item">
-                    <a href="/" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ TITLE_SITE }} - {% trans 'Home' %}">
-                      {% trans 'Home' %}
-                    </a>
-                  </li>
-                {% endif %}
-              {% endblock breadcrumbs %}
-            </ol>
-          </nav>
+  <header role="banner" class="fixed-top">
+    <!-- Navigation principale -->
+    <nav class="navbar pod-navbar m-0 p-1 p-md-2" aria-label="{% trans 'Main navigation' %}">
+      {% include 'navbar.html' %}
+    </nav>
+
+    <!-- Navigation repliée-->
+    {% include 'navbar_collapse.html' %}
+
+    <!-- Fil d'Ariane dans le même nav avec la classe pod-navbar-breadcrumb appliquée -->
+    {% if not request.GET.is_iframe %}
+      <nav aria-label="{% trans 'Breadcrumb' %}" id="mainbreadcrumb" class="pod-navbar-breadcrumb ">
+        <ol class="breadcrumb d-flex">
+          {% block breadcrumbs %}
+            {% if request.path == '/' %}
+              <li class="breadcrumb-item active" aria-current="page">
+                {% trans 'Home' %}
+              </li>
+            {% else %}
+              <li class="breadcrumb-item">
+                <a href="/" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ TITLE_SITE }} - {% trans 'Home' %}">
+                  {% trans 'Home' %}
+                </a>
+              </li>
+            {% endif %}
+          {% endblock breadcrumbs %}
+        </ol>
+
+        {% if MAINTENANCE_SHEDULED %}
+          <div class="alert alert-warning" role="alert">
+            {{ MAINTENANCE_TEXT_SHEDULED|safe }}
+          </div>
         {% endif %}
-      </div>
+      </nav>
+    {% endif %}
   </header>
+
   {% block content %}
   {% if request.path in "/,/authentication_login/,/accounts/login/" and MAINTENANCE_MODE %}
     {% get_maintenance_welcome as maintenance_text %}

--- a/pod/main/templates/base.html
+++ b/pod/main/templates/base.html
@@ -62,11 +62,43 @@
 
 <body>
   {% if PRE_HEADER_TEMPLATE %}{% include PRE_HEADER_TEMPLATE %}{% endif %}
-  <header>
-    <nav class="pod-navbar navbar fixed-top m-0 p-1 p-md-2">
-      {% include 'navbar.html' %}
-    </nav>
-    {% include 'navbar_collapse.html' %}
+  <header role="banner">
+      <!-- Navigation principale -->
+      <nav class="navbar pod-navbar fixed-top m-0 p-1 p-md-2" aria-label="{% trans 'Main navigation' %}">
+        {% include 'navbar.html' %}
+      </nav>
+    
+      <!-- Navigation repliée-->
+      {% include 'navbar_collapse.html' %}
+    
+      <div class="container-fluid pod-navbar-breadcrumb fixed-top">
+        {% if not request.GET.is_iframe %}
+          {% if MAINTENANCE_SHEDULED %}
+            <div class="alert alert-warning" role="alert">
+              {{ MAINTENANCE_TEXT_SHEDULED|safe }}
+            </div>
+          {% endif %}
+          
+          <!-- Fil d'Ariane -->
+          <nav aria-label="{% trans 'Breadcrumb' %}" id="mainbreadcrumb">
+            <ol class="breadcrumb d-flex">
+              {% block breadcrumbs %}
+                {% if request.path == '/' %}
+                  <li class="breadcrumb-item active" aria-current="page">
+                    {% trans 'Home' %}
+                  </li>
+                {% else %}
+                  <li class="breadcrumb-item">
+                    <a href="/" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ TITLE_SITE }} - {% trans 'Home' %}">
+                      {% trans 'Home' %}
+                    </a>
+                  </li>
+                {% endif %}
+              {% endblock breadcrumbs %}
+            </ol>
+          </nav>
+        {% endif %}
+      </div>
   </header>
   {% block content %}
   {% if request.path in "/,/authentication_login/,/accounts/login/" and MAINTENANCE_MODE %}
@@ -98,28 +130,6 @@
           </aside>
         {% endif %}
         <div class="pod-mainContent mt-2" id="pod-mainContent">
-          {% if not request.GET.is_iframe %}
-            {% if MAINTENANCE_SHEDULED %}
-              <div class="alert alert-warning" role="alert">{{MAINTENANCE_TEXT_SHEDULED|safe}}</div>
-            {% endif %}
-            <nav aria-label="{% trans 'Breadcrumb' %}" class="breadcrumb d-flex justify-content-between pb-2" id="mainbreadcrumb">
-              <ol class="breadcrumb p-0 mb-0">
-                {% block breadcrumbs %}
-                  {% if request.path == '/' %}
-                    <li class="breadcrumb-item active" aria-current="page">
-                      {% trans 'Home' %}
-                    </li>
-                  {% else %}
-                    <li class="breadcrumb-item">
-                      <a href="/" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ TITLE_SITE }} - {% trans 'Home' %}">
-                        {% trans 'Home' %}
-                      </a>
-                    </li>
-                  {% endif %}
-                {% endblock breadcrumbs %}
-              </ol>
-            </nav>
-          {% endif %}
           <div class="container">
             <div class="pod-first-content">
               {% block main_page_title %}

--- a/pod/main/templates/base.html
+++ b/pod/main/templates/base.html
@@ -63,6 +63,12 @@
 <body>
   {% if PRE_HEADER_TEMPLATE %}{% include PRE_HEADER_TEMPLATE %}{% endif %}
   <header role="banner" class="fixed-top">
+    {% if MAINTENANCE_SHEDULED %}
+    <div class="alert alert-warning m-0 p-2" role="alert">
+      {{ MAINTENANCE_TEXT_SHEDULED|safe }}
+    </div>
+    {% endif %}
+
     <!-- Main navigation -->
     <nav class="navbar pod-navbar m-0 p-1 p-md-2" aria-label="{% trans 'Main navigation' %}">
       {% include 'navbar.html' %}
@@ -89,12 +95,6 @@
             {% endif %}
           {% endblock breadcrumbs %}
         </ol>
-
-        {% if MAINTENANCE_SHEDULED %}
-          <div class="alert alert-warning" role="alert">
-            {{ MAINTENANCE_TEXT_SHEDULED|safe }}
-          </div>
-        {% endif %}
       </nav>
     {% endif %}
   </header>

--- a/pod/main/templates/base.html
+++ b/pod/main/templates/base.html
@@ -63,15 +63,15 @@
 <body>
   {% if PRE_HEADER_TEMPLATE %}{% include PRE_HEADER_TEMPLATE %}{% endif %}
   <header role="banner" class="fixed-top">
-    <!-- Navigation principale -->
+    <!-- Main navigation -->
     <nav class="navbar pod-navbar m-0 p-1 p-md-2" aria-label="{% trans 'Main navigation' %}">
       {% include 'navbar.html' %}
     </nav>
 
-    <!-- Navigation repliée-->
+    <!-- Collapsed navigation -->
     {% include 'navbar_collapse.html' %}
 
-    <!-- Fil d'Ariane dans le même nav avec la classe pod-navbar-breadcrumb appliquée -->
+    <!-- Breadcrumb navigation -->
     {% if not request.GET.is_iframe %}
       <nav aria-label="{% trans 'Breadcrumb' %}" id="mainbreadcrumb" class="pod-navbar-breadcrumb ">
         <ol class="breadcrumb d-flex">

--- a/pod/main/templates/navbar.html
+++ b/pod/main/templates/navbar.html
@@ -87,7 +87,7 @@
       <span class="visually-hidden">{% trans 'Search for a media on' %} {{ TITLE_SITE }}</span>
     </label>
     <div class="input-group me-sm-2 pod-navbar-search">
-      <input class="form-control form-control-md hide-search-input custom-rounded-left" id="s"
+      <input class="rounded-start-4 form-control form-control-md hide-search-input" id="s"
              placeholder="{% trans 'Search a media' %}" type="search" name="q"
              data-bs-toggle="tooltip"
              title="{% blocktrans %}Type keyword here to search a media on {{ TITLE_SITE }}{% endblocktrans %}">
@@ -96,7 +96,7 @@
         <i class="bi bi-search" aria-hidden="true"></i>
       </button>
     </div>
-  </form>  
+  </form>
 
   <ul class="navbar-nav flex-row align-items-center" id="nav-useraction">
     {% if user.is_authenticated %}

--- a/pod/main/templates/navbar.html
+++ b/pod/main/templates/navbar.html
@@ -112,13 +112,13 @@
           {% show_video_buttons as video_buttons %}
           {% if video_buttons %}
             <li class="nav-item pod-navbar__nav-item" id="nav-addvideo">
-              <a class="btn btn-primary btn-sm" href="{% url 'video:video_add' %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Add a new video on' %} {{ TITLE_SITE }}">
+              <a class="btn btn-primary " href="{% url 'video:video_add' %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Add a new video on' %} {{ TITLE_SITE }}">
                 <i class="bi bi-plus pod-add" aria-hidden="true"></i>
                 <span class="ms-1 d-none d-md-inline">{% trans 'Add a video' %}</span>
               </a>
             </li>
             <li class="nav-item pod-navbar__nav-item ms-2 ms-md-4" id="nav-myvideos">
-              <a class="btn btn-primary btn-sm" href="{% url 'video:dashboard' %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Show all my videos on' %} {{ TITLE_SITE }}">
+              <a class="btn btn-primary " href="{% url 'video:dashboard' %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Show all my videos on' %} {{ TITLE_SITE }}">
                 <i class="bi bi-film pod-nav-link-icon mx-1" aria-hidden="true"></i>
                 <span class="ms-1 d-none d-md-inline">{% trans 'Dashboard' %}</span>
               </a>
@@ -127,7 +127,7 @@
           {% show_meeting_button as meeting_button %}
           {% if meeting_button %}
             <li class="nav-item pod-navbar__nav-item ms-2 ms-md-4" id="nav-mymeetings">
-              <a class="btn btn-primary btn-sm" href="{% url 'meeting:my_meetings' %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Show all my meetings on' %} {{ TITLE_SITE }}">
+              <a class="btn btn-primary " href="{% url 'meeting:my_meetings' %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Show all my meetings on' %} {{ TITLE_SITE }}">
                 <i class="bi bi-person-video pod-add" aria-hidden="true"></i>
                 <span class="ms-1 d-none d-md-inline">{% trans 'My meetings' %}</span>
               </a>
@@ -223,7 +223,7 @@
 
     {% if user.is_authenticated %}
       <li class="nav-item ms-2 ms-sm-3" id="nav-usermenu">
-        <button class="btn btn-sm nav-item {% if not request.user.owner.userpicture  %}initials btn btn-primary {% else %} nav-link{% endif %} d-flex justify-content-center align-items-center" type="button" data-bs-toggle="offcanvas" data-bs-target="#pod-navbar__menuuser" aria-controls="pod-navbar__menuuser" title="{% trans 'Toggle user menu' %}"
+        <button class="btn btn-primary nav-item {% if not request.user.owner.userpicture  %}initials {% else %} nav-link{% endif %} d-flex justify-content-center align-items-center" type="button" data-bs-toggle="offcanvas" data-bs-target="#pod-navbar__menuuser" aria-controls="pod-navbar__menuuser" title="{% trans 'Toggle user menu' %}"
          data-pod-tooltip="true">
           {% if request.user.owner.userpicture %}
             <img src="{{ user.owner.userpicture.file.url }}" class="userpicture rounded" alt="{{ user }}" loading="lazy">
@@ -398,7 +398,7 @@
         {% if request.path != LOGIN_URL %}
          <li class="nav-item dropdown login m-2" id="nav-authentication">
            {% get_url_referrer request as url_referrer %}
-           <a class="btn btn-primary btn-sm ps-2 pe-2 d-flex" href="{% url 'authentication:authentication_login' %}{{ url_referrer }}" title="{% trans 'Open login page' %}" data-bs-toggle="tooltip">
+           <a class="btn btn-primary  ps-2 pe-2 d-flex" href="{% url 'authentication:authentication_login' %}{{ url_referrer }}" title="{% trans 'Open login page' %}" data-bs-toggle="tooltip">
              <i class="bi bi-person-circle" aria-hidden="true"></i> <span class="ms-1 d-none d-lg-block">{% trans 'Log in' %}</span>
             </a>
           </li>

--- a/pod/main/templates/navbar.html
+++ b/pod/main/templates/navbar.html
@@ -16,7 +16,7 @@
     <i class="bi bi-list" aria-hidden="true"></i>
   </button>
   <a class="navbar-brand pod-navbar__brand me-0 me-sm-1" href="/" title="{{ TITLE_SITE }} - {% trans 'Home' %}" {% if request.path == '/' %}aria-current="page"{% endif %} data-bs-toggle="tooltip" data-bs-placement="bottom">
-    <img src="{% static LOGO_SITE %}" height="25" alt="" loading="lazy"><strong>{{ TITLE_SITE }}</strong>
+    <img src="{% static LOGO_SITE %}" height="40" alt="" loading="lazy"><strong>{{ TITLE_SITE }}</strong>
   </a>
   <!-- off canvas -->
   <div class="offcanvas offcanvas-start pod-offcanvas" tabindex="-1" id="pod-navbar__menu" aria-labelledby="pod-navbar__menuLabel">
@@ -89,7 +89,8 @@
       <input class="form-control form-control-sm hide-search-input" id="s"
              placeholder="{% trans 'Search a media' %}" type="search" name="q"
              data-bs-toggle="tooltip"
-             title="{% blocktrans %}Type keyword here to search a media on {{ TITLE_SITE }}{% endblocktrans %}">
+             title="{% blocktrans %}Type keyword here to search a media on {{ TITLE_SITE }}{% endblocktrans %}"
+             style="border-top-left-radius: var(--bs-border-radius-xl); border-bottom-left-radius: var(--bs-border-radius-xl);">
       <button id="search-button" type="submit" class="btn btn-primary"
         data-bs-toggle="tooltip" title="{% trans 'Do the media search' %}">
         <i class="bi bi-search" aria-hidden="true"></i>
@@ -100,7 +101,7 @@
   <ul class="navbar-nav flex-row align-items-center" id="nav-useraction">
     {% if user.is_authenticated %}
         {% if MAINTENANCE_MODE %}
-          <li class="d-none d-md-block nav-item pod-navbar__nav-item mx-2" id="nav-addvideo">
+          <li class="d-none d-md-block nav-item pod-navbar__nav-item" id="nav-addvideo">
             <span class="badge bg-danger">
               {{MAINTENANCE_REASON}}<br>
               <i class="bi bi-exclamation-triangle" aria-hidden="true"></i>
@@ -110,13 +111,13 @@
         {% else %}
           {% show_video_buttons as video_buttons %}
           {% if video_buttons %}
-            <li class="nav-item pod-navbar__nav-item mx-1" id="nav-addvideo">
+            <li class="nav-item pod-navbar__nav-item" id="nav-addvideo">
               <a class="btn btn-primary btn-sm" href="{% url 'video:video_add' %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Add a new video on' %} {{ TITLE_SITE }}">
                 <i class="bi bi-plus pod-add" aria-hidden="true"></i>
                 <span class="ms-1 d-none d-md-inline">{% trans 'Add a video' %}</span>
               </a>
             </li>
-            <li class="nav-item pod-navbar__nav-item mx-1" id="nav-myvideos">
+            <li class="nav-item pod-navbar__nav-item ms-2 ms-md-4" id="nav-myvideos">
               <a class="btn btn-primary btn-sm" href="{% url 'video:dashboard' %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Show all my videos on' %} {{ TITLE_SITE }}">
                 <i class="bi bi-film pod-nav-link-icon mx-1" aria-hidden="true"></i>
                 <span class="ms-1 d-none d-md-inline">{% trans 'Dashboard' %}</span>
@@ -125,7 +126,7 @@
           {% endif %}
           {% show_meeting_button as meeting_button %}
           {% if meeting_button %}
-            <li class="nav-item pod-navbar__nav-item mx-1" id="nav-mymeetings">
+            <li class="nav-item pod-navbar__nav-item ms-2 ms-md-4" id="nav-mymeetings">
               <a class="btn btn-primary btn-sm" href="{% url 'meeting:my_meetings' %}" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{% trans 'Show all my meetings on' %} {{ TITLE_SITE }}">
                 <i class="bi bi-person-video pod-add" aria-hidden="true"></i>
                 <span class="ms-1 d-none d-md-inline">{% trans 'My meetings' %}</span>
@@ -135,7 +136,7 @@
         {% endif %}
     {% endif %}
     <!--  Add configuration panel buttons -->
-    <li class="nav-item pod-params pod-navbar__nav-item" id="pod-param-buttons">
+    <li class="nav-item pod-params pod-navbar__nav-item ms-0.5 ms-md-2" id="pod-param-buttons">
       <button class="btn btn-link pod-params-button px-1"
         type="button" id="pod-param-buttons__button"
         data-bs-toggle="offcanvas" data-bs-target="#pod-navbar__menusettings"
@@ -221,7 +222,7 @@
     </li>
 
     {% if user.is_authenticated %}
-      <li class="nav-item" id="nav-usermenu">
+      <li class="nav-item ms-2 ms-sm-3" id="nav-usermenu">
         <button class="btn btn-sm nav-item {% if not request.user.owner.userpicture  %}initials btn btn-primary {% else %} nav-link{% endif %} d-flex justify-content-center align-items-center" type="button" data-bs-toggle="offcanvas" data-bs-target="#pod-navbar__menuuser" aria-controls="pod-navbar__menuuser" title="{% trans 'Toggle user menu' %}"
          data-pod-tooltip="true">
           {% if request.user.owner.userpicture %}
@@ -395,7 +396,7 @@
       {% if not WEBTV_MODE %}
         {% get_setting "LOGIN_URL" "/authentication_login/" as LOGIN_URL %}
         {% if request.path != LOGIN_URL %}
-         <li class="nav-item dropdown login me-2" id="nav-authentication">
+         <li class="nav-item dropdown login m-2" id="nav-authentication">
            {% get_url_referrer request as url_referrer %}
            <a class="btn btn-primary btn-sm ps-2 pe-2 d-flex" href="{% url 'authentication:authentication_login' %}{{ url_referrer }}" title="{% trans 'Open login page' %}" data-bs-toggle="tooltip">
              <i class="bi bi-person-circle" aria-hidden="true"></i> <span class="ms-1 d-none d-lg-block">{% trans 'Log in' %}</span>

--- a/pod/main/templates/navbar.html
+++ b/pod/main/templates/navbar.html
@@ -81,22 +81,22 @@
     </div>
   </div>
 
-  <form class="pod-navbar__form my-2 my-lg-0" action='{% url "video_search:search_videos" %}' id="nav-search">
+  <form class="pod-navbar__form my-2 my-lg-0" action="{% url 'video_search:search_videos' %}" id="nav-search">
     <label for="s" class="d-lg-none">
-      <i class="bi bi-search" aria-hidden="true"></i> <span class="visually-hidden">{% trans 'Search for a media on' %} {{ TITLE_SITE }}</span>
+      <i class="bi bi-search" aria-hidden="true"></i>
+      <span class="visually-hidden">{% trans 'Search for a media on' %} {{ TITLE_SITE }}</span>
     </label>
     <div class="input-group me-sm-2 pod-navbar-search">
-      <input class="form-control form-control-sm hide-search-input" id="s"
+      <input class="form-control form-control-md hide-search-input custom-rounded-left" id="s"
              placeholder="{% trans 'Search a media' %}" type="search" name="q"
              data-bs-toggle="tooltip"
-             title="{% blocktrans %}Type keyword here to search a media on {{ TITLE_SITE }}{% endblocktrans %}"
-             style="border-top-left-radius: var(--bs-border-radius-xl); border-bottom-left-radius: var(--bs-border-radius-xl);">
+             title="{% blocktrans %}Type keyword here to search a media on {{ TITLE_SITE }}{% endblocktrans %}">
       <button id="search-button" type="submit" class="btn btn-primary"
         data-bs-toggle="tooltip" title="{% trans 'Do the media search' %}">
         <i class="bi bi-search" aria-hidden="true"></i>
       </button>
     </div>
-  </form>
+  </form>  
 
   <ul class="navbar-nav flex-row align-items-center" id="nav-useraction">
     {% if user.is_authenticated %}
@@ -223,8 +223,14 @@
 
     {% if user.is_authenticated %}
       <li class="nav-item ms-2 ms-sm-3" id="nav-usermenu">
-        <button class="btn btn-primary nav-item {% if not request.user.owner.userpicture  %}initials {% else %} nav-link{% endif %} d-flex justify-content-center align-items-center" type="button" data-bs-toggle="offcanvas" data-bs-target="#pod-navbar__menuuser" aria-controls="pod-navbar__menuuser" title="{% trans 'Toggle user menu' %}"
-         data-pod-tooltip="true">
+        <button
+          class="nav-item d-flex justify-content-center align-items-center {% if not request.user.owner.userpicture %}btn btn-primary initials{% else %}nav-link{% endif %}"
+          type="button"
+          data-bs-toggle="offcanvas"
+          data-bs-target="#pod-navbar__menuuser"
+          aria-controls="pod-navbar__menuuser"
+          title="{% trans 'Toggle user menu' %}"
+          data-pod-tooltip="true">
           {% if request.user.owner.userpicture %}
             <img src="{{ user.owner.userpicture.file.url }}" class="userpicture rounded" alt="{{ user }}" loading="lazy">
           {% endif %}


### PR DESCRIPTION
## Accessibility Improvement: Sticky Breadcrumb Below the Main Navigation

### Goal

This pull request aims to enhance both **accessibility** and the overall **user experience**.

An accessibility audit highlighted that the breadcrumb component could be better integrated. With this update, the breadcrumb remains visible and accessible even when users scroll down the page. This makes navigation easier and improves the overall ergonomics of the interface.

Additionally, I’ve applied some visual refinements to modernize the UI.


### Changes Introduced

- Moved the **breadcrumb** below the main navigation bar, now positioned with `fixed-top`.
- **Rounded button borders** for a more modern look.
- **Centered navigation bar content** for improved visual balance and clarity.

### Screenshots Demonstrating the Changes

#### Mobile View  
![Mobile view](https://github.com/user-attachments/assets/8eea19b2-9e68-4e35-a60f-6f167f710bbc)

#### Desktop – Logged-in User  
![PC – Logged-in user](https://github.com/user-attachments/assets/e95ca5e0-a2a1-4be5-bedb-a05239438928)

#### Desktop – Guest User  
![PC – Guest user](https://github.com/user-attachments/assets/312e3637-8b6e-4a47-8eb5-db0515d24b9e)


### To Review Before Merge

- [x] You’ve read the [[contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md)](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md)  
- [x] All CI checks are passing  
- [x] The layout is responsive and works across major browsers  