### PR TITLE
Scripts to migrate from Pod v3 to Pod v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Utilitaires shell pour Esup-Pod
 
-# Ne pas oublier de lancer un `workon django_pod` avant toute commande.
+# Ne pas oublier de lancer un `workon django_pod4` avant toute commande.
 # Lancer via `make $cmd`
 # (en remplacant $cmd par une commande ci-dessous)
 
@@ -43,6 +43,7 @@ upgrade:
 createDB:
 	find . -path "*/migrations/*.py" -not -name "__init__.py" -delete
 	find . -path "*/migrations/*.pyc" -delete
+	python3 manage.py delete_flatpages_migrations
 	make updatedb
 	make migrate
 	python3 -Wd manage.py loaddata initial_data

--- a/pod/video/management/commands/delete_flatpages_migrations.py
+++ b/pod/video/management/commands/delete_flatpages_migrations.py
@@ -1,0 +1,33 @@
+import os
+from django.core.management.base import BaseCommand
+from django.contrib import flatpages
+
+
+class Command(BaseCommand):
+    help = 'Delete migration files and .pyc files of the flatpages app'
+
+    def handle(self, *args, **kwargs):
+        # Find the migrations directory of flatpages
+        flatpages_dir = os.path.dirname(flatpages.__file__)
+        migrations_dir = os.path.join(flatpages_dir, 'migrations')
+
+        # Check if the migrations directory exists
+        if os.path.isdir(migrations_dir):
+            # Delete all migration files except __init__.py
+            for filename in os.listdir(migrations_dir):
+                if filename != '__init__.py' and filename.endswith('.py'):
+                    file_path = os.path.join(migrations_dir, filename)
+                    os.remove(file_path)
+                    self.stdout.write(f"Deleted: {file_path}")
+
+            # Delete all .pyc files in the migrations directory
+            for root, dirs, files in os.walk(migrations_dir):
+                for file in files:
+                    if file.endswith('.pyc'):
+                        file_path = os.path.join(root, file)
+                        os.remove(file_path)
+                        self.stdout.write(f"Deleted: {file_path}")
+
+            self.stdout.write(self.style.SUCCESS('Flatpages migration files and .pyc files have been deleted.'))
+        else:
+            self.stdout.write(self.style.ERROR('Flatpages migrations directory not found.'))

--- a/pod/video/management/commands/export_data_from_v3_to_v4.py
+++ b/pod/video/management/commands/export_data_from_v3_to_v4.py
@@ -1,0 +1,344 @@
+"""
+Export data from Pod v3.8.x to a JSON file for Pod v4.0.x.
+
+This script is designed to export data from a Pod v3.8.x database to a JSON file, which can then be used to migrate the data to a Pod v4.0.x database.
+The script handles both MariaDB/MySQL and PostgreSQL databases, adapting SQL queries as needed.
+
+Key Features:
+- Exports specified tables from the Pod v3 database to a JSON file.
+- Handles both MariaDB/MySQL and PostgreSQL databases.
+- Creates a directory to store the exported data if it does not already exist.
+- Converts datetime, time, and date objects to JSON-serializable formats.
+- Provides detailed success and error messages using Django's management command framework.
+
+Important notes:
+- The JSON file must be found at BASE_DIR/data_from_v3_to_v4/v3_exported_tables.json
+Example: /usr/local/django_projects/data_from_v3_to_v4/v3_exported_tables.json
+ - This script can be rerun as many times as required, the JSON file is regenerated each time.
+
+Usage:
+Run the script using Django's management command:
+    python manage.py export_data_from_v3_to_v4
+
+Dependencies:
+- Django
+- Settings configured with the database connection details.
+
+Functions:
+- create_directory: Creates the directory to store the exported data.
+- get_table_names: Returns the list of tables to export.
+- check_table_existence: Checks if the specified tables exist in the database (with specific code for tags management).
+- fetch_table_data: Fetches data from a specific table.
+- fetch_tag_data: Fetches tag data with special handling for tags.
+- convert_to_json: Converts rows of data to JSON format.
+- export_tables_to_json: Exports the specified tables to a JSON file.
+- process: Main process to handle the data export.
+"""
+
+import json
+import os
+from datetime import date, datetime, time
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import connection
+from typing import List, Tuple, Dict, Any
+
+# Base directory
+BASE_DIR = getattr(settings, "BASE_DIR", "/home/pod/django_projects/podv3/pod")
+# Pod version
+VERSION = getattr(settings, "VERSION", "undefined")
+
+
+class Command(BaseCommand):
+    """Main command class."""
+
+    help = "Export data from Pod v3.8.x to Pod v4.0.x"
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        """Handle the command call."""
+
+        self.stdout.write(self.style.SUCCESS("***Start export Pod3 database tables to a JSON file***"))
+
+        # Manage Pod version
+        if VERSION[:3] == "3.8":
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f" - Pod version: {VERSION}. "
+                    "This script can be achieved with this Pod version. "
+                    "The process continues."
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"- Pod version: {VERSION}. "
+                    "This script can only be used for Pod version 3.8.x. "
+                    "Please update Pod. The process stops here!"
+                )
+            )
+            # Stop process
+            return
+
+        # Main function
+        self.process(options)
+
+    def create_directory(self, output_directory: str) -> None:
+        """Create directory to store all the data."""
+        self.stdout.write(self.style.SUCCESS(" - Create directory data if necessary"))
+        os.makedirs(os.path.join(BASE_DIR, output_directory), exist_ok=True)
+
+    def get_table_names(self) -> List[str]:
+        """Return the list of tables to export."""
+        return [
+            'ai_enhancement_aienhancement',
+            'authentication_accessgroup',
+            'authentication_accessgroup_sites',
+            'authentication_accessgroup_users',
+            'authentication_groupsite',
+            'authentication_groupsite_sites',
+            'authentication_owner',
+            'authentication_owner_accessgroups',
+            'authentication_owner_sites',
+            'authtoken_token',
+            'auth_group',
+            'auth_group_permissions',
+            'auth_permission',
+            'auth_user',
+            'auth_user_groups',
+            'auth_user_user_permissions',
+            'captcha_captchastore',
+            'chapter_chapter',
+            'chunked_upload_chunkedupload',
+            'completion_contributor',
+            'completion_document',
+            'completion_enrichmodelqueue',
+            'completion_overlay',
+            'completion_track',
+            'cut_cutvideo',
+            'django_admin_log',
+            'django_content_type',
+            'django_flatpage',
+            'django_flatpage_sites',
+            'django_site',
+            'dressing_dressing',
+            'dressing_dressing_allow_to_groups',
+            'dressing_dressing_owners',
+            'dressing_dressing_users',
+            'dressing_dressing_videos',
+            'enrichment_enrichment',
+            'enrichment_enrichmentgroup',
+            'enrichment_enrichmentgroup_groups',
+            'enrichment_enrichmentvtt',
+            'import_video_externalrecording',
+            'live_broadcaster',
+            'live_broadcaster_manage_groups',
+            'live_building',
+            'live_building_sites',
+            'live_event',
+            'live_event_additional_owners',
+            'live_event_restrict_access_to_groups',
+            'live_event_videos',
+            'live_event_viewers',
+            'live_heartbeat',
+            'live_livetranscriptrunningtask',
+            'main_additionalchanneltab',
+            'main_block',
+            'main_block_sites',
+            'main_configuration',
+            'main_customfilemodel',
+            'main_customimagemodel',
+            'main_linkfooter',
+            'main_linkfooter_sites',
+            'meeting',
+            'meeting_additional_owners',
+            'meeting_internalrecording',
+            'meeting_livegateway',
+            'meeting_livestream',
+            'meeting_meetingsessionlog',
+            'meeting_restrict_access_to_groups',
+            'playlist_playlist',
+            'playlist_playlistcontent',
+            'playlist_playlist_additional_owners',
+            'podfile_customfilemodel',
+            'podfile_customimagemodel',
+            'podfile_userfolder',
+            'podfile_userfolder_access_groups',
+            'podfile_userfolder_users',
+            'quiz_multiplechoicequestion',
+            'quiz_quiz',
+            'quiz_shortanswerquestion',
+            'quiz_singlechoicequestion',
+            'quiz_truefalsequestion',
+            'recorder_recorder',
+            'recorder_recorder_additional_users',
+            'recorder_recorder_channel',
+            'recorder_recorder_discipline',
+            'recorder_recorder_restrict_access_to_groups',
+            'recorder_recorder_sites',
+            'recorder_recorder_theme',
+            'recorder_recording',
+            'recorder_recordingfile',
+            'recorder_recordingfiletreatment',
+            'speaker_job',
+            'speaker_jobvideo',
+            'speaker_speaker',
+            'thumbnail_kvstore',
+            'video_advancednotes',
+            'video_category',
+            'video_category_video',
+            'video_channel',
+            'video_channel_add_channels_tab',
+            'video_channel_allow_to_groups',
+            'video_channel_owners',
+            'video_channel_users',
+            'video_comment',
+            'video_discipline',
+            'video_encode_transcript_encodingaudio',
+            'video_encode_transcript_encodinglog',
+            'video_encode_transcript_encodingstep',
+            'video_encode_transcript_encodingvideo',
+            'video_encode_transcript_playlistvideo',
+            'video_encode_transcript_videorendition',
+            'video_encode_transcript_videorendition_sites',
+            'video_notecomments',
+            'video_notes',
+            'video_theme',
+            'video_type',
+            'video_type_sites',
+            'video_updateowner',
+            'video_usermarkertime',
+            'video_video',
+            'video_videoaccesstoken',
+            'video_videotodelete',
+            'video_videotodelete_video',
+            'video_videoversion',
+            'video_video_additional_owners',
+            'video_video_channel',
+            'video_video_discipline',
+            'video_video_restrict_access_to_groups',
+            'video_video_sites',
+            'video_video_theme',
+            'video_viewcount',
+            'video_vote',
+            'webpush_group',
+            'webpush_pushinformation',
+            'webpush_subscriptioninfo',
+            # Specific for tags management
+            'video_tagging_tag_2_tagulous',
+            'recorder_tagging_tag_2_tagulous'
+        ]
+
+    def check_table_existence(self, cursor, table_names: List[str]) -> List[str]:
+        """Check if the tables exist in the database."""
+        cursor.execute("SHOW TABLES;")
+        tables = [row[0] for row in cursor.fetchall()]
+        # Specific for tags management
+        tables.append("video_tagging_tag_2_tagulous")
+        tables.append("recorder_tagging_tag_2_tagulous")
+        return [table for table in table_names if table in tables]
+
+    def fetch_table_data(self, cursor, table: str) -> Tuple[List[Tuple[Any, ...]], List[str]]:
+        """Fetch data from a specific table."""
+        cursor.execute(f"SELECT * FROM {table}")
+        rows = cursor.fetchall()
+        cursor.execute(f"SHOW COLUMNS FROM {table}")
+        columns = [row[0] for row in cursor.fetchall()]
+        return rows, columns
+
+    def fetch_tag_data(self, cursor, table: str, db_type: str) -> Tuple[List[Tuple[Any, ...]], List[str]]:
+        """Fetch tag data for specific management."""
+        if table == "video_tagging_tag_2_tagulous":
+            query = (
+                "SELECT tti.object_id as video_id, "
+                + (
+                    "GROUP_CONCAT(tt.name) as tag_name "
+                    if db_type == "mysql"
+                    else "STRING_AGG(tt.name, ', ') as tag_name "
+                )
+                + "FROM tagging_taggeditem tti, tagging_tag tt, django_content_type dct "
+                "WHERE tti.tag_id = tt.id AND tti.content_type_id = dct.id AND dct.model = 'video' "
+                "GROUP BY tti.object_id ORDER BY tti.object_id ASC"
+            )
+        elif table == "recorder_tagging_tag_2_tagulous":
+            query = (
+                "SELECT tti.object_id as recorder_id, "
+                + (
+                    "GROUP_CONCAT(tt.name) as tag_name "
+                    if db_type == "mysql"
+                    else "STRING_AGG(tt.name, ', ') as tag_name "
+                )
+                + "FROM tagging_taggeditem tti, tagging_tag tt, django_content_type dct "
+                "WHERE tti.tag_id = tt.id AND tti.content_type_id = dct.id AND dct.model = 'recorder' "
+                "GROUP BY tti.object_id ORDER BY tti.object_id ASC"
+            )
+        cursor.execute(query)
+        rows = cursor.fetchall()
+        columns = ["video_id", "tag_name"] if table == "video_tagging_tag_2_tagulous" else ["recorder_id", "tag_name"]
+        return rows, columns
+
+    def convert_to_json(self, rows: List[Tuple[Any, ...]], columns: List[str]) -> List[Dict[str, Any]]:
+        """Convert rows to JSON format."""
+        data = []
+        for row in rows:
+            row_dict = {}
+            for i, column in enumerate(columns):
+                value = row[i]
+                # Manage date/time format
+                if isinstance(value, datetime):
+                    row_dict[column] = value.strftime("%Y-%m-%d %H:%M:%S")
+                elif isinstance(value, time):
+                    row_dict[column] = value.strftime("%H:%M:%S")
+                elif isinstance(value, date):
+                    row_dict[column] = value.strftime("%Y-%m-%d")
+                else:
+                    row_dict[column] = value
+            data.append(row_dict)
+        return data
+
+    def export_tables_to_json(self, table_names: List[str], output_directory: str, output_file: str) -> None:
+        """Export the specified tables to a JSON file."""
+        data = {}
+        db_type = settings.DATABASES["default"]["ENGINE"].split(".")[-1]
+        with connection.cursor() as cursor:
+            existing_tables = self.check_table_existence(cursor, table_names)
+            for table in existing_tables:
+                try:
+                    if table in ["video_tagging_tag_2_tagulous", "recorder_tagging_tag_2_tagulous"]:
+                        # Management for tags
+                        rows, columns = self.fetch_tag_data(cursor, table, db_type)
+                    else:
+                        # Management for others data
+                        rows, columns = self.fetch_table_data(cursor, table)
+                    data[table] = self.convert_to_json(rows, columns)
+                    self.stdout.write(self.style.SUCCESS(f" - Table {table} has been processed."))
+                except Exception as e:
+                    self.stdout.write(self.style.ERROR(f" - Table {table} could not be processed. Error: {e}"))
+
+        # Write the JSON file
+        json_file = os.path.join(BASE_DIR, f"{output_directory}{output_file}")
+        with open(json_file, "w") as f:
+            json.dump(data, f, indent=4)
+            f.write("\n")
+
+    def process(self, options: Dict[str, Any]) -> None:
+        """Main process to export data."""
+
+        # Define directory and JSON file
+        output_directory = "../../data_from_v3_to_v4/"
+        output_json_file = "v3_exported_tables.json"
+
+        # Create data directory, if necessary
+        self.create_directory(output_directory)
+
+        # List of tables to export
+        tables_to_export = self.get_table_names()
+
+        # Export tables to JSON file
+        self.export_tables_to_json(tables_to_export, output_directory, output_json_file)
+
+        # Path of the JSON file
+        json_file = os.path.join(BASE_DIR, f"{output_directory}{output_json_file}")
+        if os.path.exists(json_file):
+            self.stdout.write(self.style.SUCCESS(f' - The JSON file {json_file} was created.'))
+        else:
+            self.stdout.write(self.style.ERROR(f' - The JSON file {json_file} was not created.'))

--- a/pod/video/management/commands/import_data_from_v3_to_v4.py
+++ b/pod/video/management/commands/import_data_from_v3_to_v4.py
@@ -1,0 +1,421 @@
+"""
+Import data from Pod v3.8.x JSON file to Pod v4.0.x.
+
+This script is designed to import data from a Pod v3.8.x JSON file into a Pod v4.0.x database.
+It supports both MariaDB/MySQL and PostgreSQL databases. The script reads data from a specified JSON file,
+processes it, and inserts it into the appropriate tables in the Pod v4 database.
+It also handles tag management using the Tagulous library.
+The script includes options for dry runs to simulate the import process without
+making any changes to the database.
+
+Key Features:
+- Import JSON file, generated with specified tables from the Pod v3 database.
+- Handles both MariaDB/MySQL and PostgreSQL databases.
+- Creates a directory to store the exported data if it does not already exist (normally useless).
+- Provides detailed success and error messages using Django's management command framework.
+- Supports tag management for videos and recorders via Tagulous.
+- Can execute Bash commands to create the database and initialize data.
+- Safe error handling and simulation mode supported.
+
+Important notes:
+ - The JSON file must be found at BASE_DIR/data_from_v3_to_v4/v3_exported_tables.json
+Example: /usr/local/django_projects/data_from_v3_to_v4/v3_exported_tables.json
+ - Set DEBUG = False to settings_local.py to avoid warnings/debug/info noise.
+ - Can be executed with a MariaDB/MySQL or Postgresql database.
+ - If you encounter an error "Too many connections" type, you can increase the value of
+the time_sleep variable. Processing will take longer, but will be able to complete without error.
+ - This script can be rerun as many times as required, the data are deleted before insertion.
+ - After this, do not forget to make Pod v3 MEDIA_ROOT accessible to Pod v4 servers.
+ - After this, do not forget to re-index all videos for Elasticsearch with: python manage.py index_videos --all
+
+Usage:
+Run the script using Django's management command:
+    python manage.py import_data_from_v3_to_v4
+Arguments:
+ --dry: Simulates what will be achieved (default=False).
+ --createDB: Execute Bash commands to create tables in the database and add initial data (see make createDB). Database must be empty. (default=False).
+ --onlytags: Processes only tags (default=False). Useful if you encounter the 'Too many connections' problem for tags management.
+
+Example: python manage.py import_data_from_v3_to_v4 --dry
+
+Functions:
+- add_arguments: Adds command-line arguments for the script.
+- handle: Main entry point for the command, handling the overall process.
+- execute_bash_commands: Executes Bash commands to create the tables of the database and add initial data.
+- process: Main function to process the JSON data and insert it into the database.
+- create_directory: Creates a directory to store data if it does not exist (normally useless).
+- verify_json_file: Checks for the existence of the JSON file and optionally displays a dry-run message.
+- display_dry_run_tables: Lists the tables that would be processed in dry-run mode.
+- import_data: Performs the actual import into the database from the JSON structure.
+- import_table_data: Deletes old data and inserts rows for a given table.
+- delete_old_tag_data: Deletes old tag data from the database.
+- reset_auto_increment: Reset auto increment for a table (manage for for Postgre or Mysql/MariaDB).
+- process_tags: Processes tags for videos and recorders.
+- process_video_tags: Processes tags specifically for videos.
+- process_recorder_tags: Processes tags specifically for recorders.
+- add_tags_to_video: Adds tags to a video.
+- add_tags_to_recorder: Adds tags to a recorder.
+- handle_exception: Handles exceptions that occur during the tagging process.
+- quote_identifier: Quotes identifiers for SQL queries based on the database type.
+"""
+import json
+import logging
+import os
+import subprocess
+import time
+import urllib3
+from typing import Any, Dict, List
+
+from contextlib import contextmanager
+from django.core.management.base import BaseCommand
+from django.db import connection, close_old_connections
+from django.db import transaction
+from django.conf import settings
+from pod.video.models import Video
+from pod.recorder.models import Recorder
+
+# Base directory
+BASE_DIR = getattr(settings, "BASE_DIR", "/home/pod/django_projects/podv3/pod")
+# Pod version
+VERSION = getattr(settings, "VERSION", "undefined")
+
+# Time sleep to avoid Too many connections error
+time_sleep = 0.3
+
+# Disable InsecureRequest warnings
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# Disable warnings
+logging.captureWarnings(True)
+logging.getLogger('urllib3').setLevel(logging.ERROR)
+
+
+@contextmanager
+def managed_cursor():
+    """Context manager to automatically close the database cursor."""
+    cursor = connection.cursor()
+    try:
+        yield cursor
+    finally:
+        cursor.close()
+
+
+class Command(BaseCommand):
+    """Main command class for importing data from Pod v3 JSON file to Pod v4 database."""
+
+    help = "Import data from Pod v3 JSON file, to Pod v4"
+
+    def add_arguments(self, parser) -> None:
+        """Allow arguments to be used with the command."""
+        parser.add_argument(
+            "--dry",
+            help="Simulates what will be achieved (default=False).",
+            action="store_true",
+            default=False,
+        )
+        parser.add_argument(
+            "--createDB",
+            help="Execute Bash commands to create tables in the database and add initial data (see make createDB). Database must be empty. (default=False).",
+            action="store_true",
+            default=False,
+        )
+        parser.add_argument(
+            "--onlytags",
+            help="Processes only tags (default=False).",
+            action="store_true",
+            default=False,
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        """Handle the command call."""
+
+        self.stdout.write(self.style.SUCCESS("***Start import Pod3 JSON file to Pod v4 database***"))
+
+        if options["dry"]:
+            self.stdout.write(
+                self.style.NOTICE(
+                    "\n----------------------------------------------------------------\n"
+                    "| Simulation mode ('dry'). No database import, only print info.|"
+                    "\n----------------------------------------------------------------\n"
+                )
+            )
+
+        # Manage Pod version
+        if VERSION[:3] == "4.0":
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f" - Pod version: {VERSION}. "
+                    "This script can be achieved with this Pod version. "
+                    "The process continues."
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.ERROR(
+                    f" - Pod version: {VERSION}. "
+                    "This script can only be used for Pod version 4.0.x. "
+                    "The process stops here!"
+                )
+            )
+            # Stop process
+            return
+
+        # Check database
+        backend = connection.vendor
+        if backend != 'mysql' and backend != 'postgresql':
+            self.stdout.write(
+                self.style.ERROR(
+                    "This script can only be used with a MariaDB, MySQL or Postgresql database. "
+                    "The process stops here!"
+                )
+            )
+            # Stop process
+            return
+
+        if options["dry"]:
+            if options["createDB"]:
+                self.stdout.write(self.style.SUCCESS(" - The command make createDB will be executed."))
+        else:
+            if options["createDB"]:
+                self.execute_bash_commands()
+
+        # Main function
+        self.process(options)
+
+    def execute_bash_commands(self) -> None:
+        """Execute Bash commands to create the tables of the database and add initial data."""
+        commands = [
+            "make createDB",
+        ]
+
+        for command in commands:
+            try:
+                subprocess.run(command, shell=True, check=True)
+                self.stdout.write(self.style.SUCCESS(f"Command executed successfully: {command}"))
+            except subprocess.CalledProcessError as e:
+                self.stdout.write(self.style.ERROR(f"Command failed: {command}. Error: {e}"))
+
+    def process(self, options: Dict[str, Any]) -> None:
+        """Main process to import data."""
+
+        # Define directory and JSON file
+        output_directory = "../../data_from_v3_to_v4/"
+        output_json_file = "v3_exported_tables.json"
+
+        # Create data directory, if necessary (normally useless)
+        self.create_directory(output_directory)
+
+        # Read the JSON file
+        json_file = os.path.join(BASE_DIR, f"{output_directory}{output_json_file}")
+
+        if not self.verify_json_file(json_file, options):
+            return
+
+        with open(json_file, 'r') as f:
+            data = json.load(f)
+
+        # Dry mode
+        if options["dry"]:
+            self.display_dry_run_tables(data, options)
+            return
+
+        # Start import data
+        self.import_data(data, json_file, options)
+
+    def create_directory(self, output_directory: str) -> None:
+        """Create directory to store all the data."""
+        self.stdout.write(self.style.SUCCESS(" - Create directory data if necessary"))
+        os.makedirs(os.path.join(BASE_DIR, output_directory), exist_ok=True)
+
+    def verify_json_file(self, json_file: str, options: Dict[str, Any]) -> bool:
+        """Verify the presence of the JSON file and optionally display a dry-run message."""
+        if options["dry"]:
+            self.stdout.write(self.style.SUCCESS(f" - The JSON file {json_file} will be processed."))
+
+        if not os.path.exists(json_file):
+            self.stdout.write(self.style.ERROR(f' - The JSON file {json_file} does not exist.'))
+            return False
+
+        return True
+
+    def display_dry_run_tables(self, data: Dict[str, Any], options: Dict[str, Any]) -> None:
+        """Display tables that would be processed in dry mode."""
+        if options["onlytags"]:
+            self.stdout.write(self.style.SUCCESS(" - Only the tables useful for tags management will be processed."))
+        else:
+            for table in data:
+                self.stdout.write(self.style.SUCCESS(f" - The table {table} will be processed."))
+
+    def import_data(self, data: Dict[str, Any], json_file: str, options: Dict[str, Any]) -> None:
+        """Import data into the database."""
+        error = False
+
+        for table, rows in data.items():
+            with connection.cursor() as cursor:
+                # Tags management: use of Tagulous
+                if table in ["video_tagging_tag_2_tagulous", "recorder_tagging_tag_2_tagulous"]:
+                    # Delete old data
+                    self.delete_old_tag_data(cursor, table)
+                    # # Process for tags
+                    self.process_tags(table, rows)
+                else:
+                    if not options["onlytags"]:
+                        try:
+                            self.import_table_data(cursor, table, rows)
+                            self.stdout.write(self.style.SUCCESS(f" - The table {table} has been processed."))
+                        except Exception as e:
+                            error = True
+                            self.stdout.write(self.style.ERROR(f" - The table {table} has not been processed. Error: {e}"))
+
+        if error:
+            self.stdout.write(self.style.ERROR(f'Not all data has been imported from {json_file}.'))
+        else:
+            self.stdout.write(self.style.SUCCESS(f'Data has been successfully imported from {json_file}.'))
+
+    def import_table_data(self, cursor, table: str, rows: List[Dict[str, Any]]) -> None:
+        """Delete old data and insert new rows into the specified table."""
+
+        # Delete existing data
+        cursor.execute(f"DELETE FROM {self.quote_identifier(table)}")
+        # Get column names
+        cursor.execute(f"SHOW COLUMNS FROM {self.quote_identifier(table)}")
+        columns = [self.quote_identifier(row[0]) for row in cursor.fetchall()]
+        # Create insert query
+        placeholders = ', '.join(['%s'] * len(columns))
+        insert_query = f"INSERT INTO {self.quote_identifier(table)} ({', '.join(columns)}) VALUES ({placeholders})"
+
+        # Execute insert queries
+        for row in rows:
+            values = []
+            for column in columns:
+                try:
+                    values.append(row[column.strip('`').strip('"')])
+                except Exception as e:
+                    # Useful if you migrate a different version than 3.8.4
+                    # 'video_video' table, 'order' column was added in 3.8.4 version
+                    values.append(None)
+                    if table != "video_video" or column.strip('`').strip('"') != 'order':
+                        # Warning: lost value
+                        self.stdout.write(
+                            self.style.WARNING(
+                                f" - Value error for table {table} column {column}. Error: {e}"
+                            )
+                        )
+            cursor.execute(insert_query, values)
+
+    def delete_old_tag_data(self, cursor, table: str) -> None:
+        """Delete old tag data for the given table."""
+        if table == "video_tagging_tag_2_tagulous":
+            self.stdout.write(self.style.SUCCESS(" - Delete old tags for videos"))
+            cursor.execute(f"DELETE FROM {self.quote_identifier('video_tagulous_video_tags')}")
+            self.reset_auto_increment(cursor, 'video_video_tags', 'id')
+            cursor.execute(f"DELETE FROM {self.quote_identifier('video_video_tags')}")
+            cursor.execute(f"ALTER TABLE {self.quote_identifier('video_video_tags')} AUTO_INCREMENT = 1")
+        elif table == "recorder_tagging_tag_2_tagulous":
+            self.stdout.write(self.style.SUCCESS(" - Delete old tags for recorders"))
+            cursor.execute(f"DELETE FROM {self.quote_identifier('recorder_tagulous_recorder_tags')}")
+            self.reset_auto_increment(cursor, 'recorder_recorder_tags', 'id')
+            cursor.execute(f"DELETE FROM {self.quote_identifier('recorder_recorder_tags')}")
+            cursor.execute(f"ALTER TABLE {self.quote_identifier('recorder_recorder_tags')} AUTO_INCREMENT = 1")
+
+    def reset_auto_increment(self, cursor, table: str, id_column: int = 'id') -> None:
+        """Reset auto increment for a table (manage for for Postgre or Mysql/MariaDB)."""
+        backend = connection.vendor
+        quoted_table = self.quote_identifier(table)
+        if backend == 'mysql':
+            cursor.execute(f"ALTER TABLE {quoted_table} AUTO_INCREMENT = 1")
+        elif backend == 'postgresql':
+            # PostgreSQL: need to reset the sequence manually
+            sequence_name = f"{table}_{id_column}_seq"
+            quoted_seq = self.quote_identifier(sequence_name)
+            cursor.execute(f"ALTER SEQUENCE {quoted_seq} RESTART WITH 1")
+
+    def process_tags(self, table: str, rows: list) -> None:
+        """Process tags for the given table and rows."""
+        try:
+            if table == 'video_tagging_tag_2_tagulous':
+                self.process_video_tags(rows)
+            else:
+                self.process_recorder_tags(rows)
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"Tag management has not been completed. Error: {e}"))
+
+    def process_video_tags(self, rows: List[Dict[str, Any]]) -> None:
+        """Process tags for videos."""
+        number_videos_processed = 0
+        self.stdout.write(self.style.SUCCESS(" - Start of tags management for videos"))
+        for row in rows:
+            number_videos_processed += 1
+            if number_videos_processed % 100 == 0:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"   * Processing, for tags, of the batch of videos {number_videos_processed-100}-{number_videos_processed} achieved"
+                    )
+                )
+            self.add_tags_to_video(row['video_id'], row['tag_name'])
+            close_old_connections()
+            connection.close()
+            time.sleep(time_sleep)
+        self.stdout.write(self.style.SUCCESS(" - End of tags management for videos"))
+
+    def process_recorder_tags(self, rows: List[Dict[str, Any]]) -> None:
+        """Process tags for recorders."""
+        self.stdout.write(self.style.SUCCESS(" - Start of tags management for recorders"))
+        for row in rows:
+            self.add_tags_to_recorder(row['recorder_id'], row['tag_name'])
+            close_old_connections()
+            connection.close()
+            time.sleep(time_sleep)
+        self.stdout.write(self.style.SUCCESS(" - End of tags management for recorders"))
+
+    def add_tags_to_video(self, video_id: int, tags: str) -> None:
+        """Add tags to video."""
+        try:
+            with transaction.atomic():
+                video = Video.objects.get(id=video_id)
+                video.tags = tags
+                video.save()
+        except Exception as e:
+            self.handle_exception(e, video_id, "video")
+        finally:
+            # Close unused connections
+            close_old_connections()
+
+    def add_tags_to_recorder(self, recorder_id: int, tags: str) -> None:
+        """Add tags to recorder."""
+        try:
+            with transaction.atomic():
+                recorder = Recorder.objects.get(id=recorder_id)
+                recorder.tags = tags
+                recorder.save()
+        except Exception as e:
+            self.handle_exception(e, recorder_id, "recorder")
+        finally:
+            # Close unused connections
+            close_old_connections()
+
+    def handle_exception(self, e: Exception, entity_id: int, entity_type: str) -> None:
+        """Handle exceptions that occur during the tagging process."""
+        if "Too many connections" in str(e):
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Error: tags error for {entity_type} {entity_id}: {e}."
+                )
+            )
+        else:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"Warning: tags error for {entity_type} {entity_id}: {e} "
+                    f"This {entity_type} had to be deleted in Pod v3, but the keywords were kept in the database."
+                )
+            )
+
+    def quote_identifier(self, identifier: str) -> str:
+        """Quote identifier for SQL queries based on the database type."""
+        backend = connection.vendor
+        if backend == 'postgresql':
+            return f'"{identifier}"'
+        elif backend == 'mysql':
+            return f'`{identifier}`'
+        else:
+            return identifier

--- a/pod/video/management/commands/import_data_from_v3_to_v4.py
+++ b/pod/video/management/commands/import_data_from_v3_to_v4.py
@@ -20,6 +20,7 @@ Key Features:
 Important notes:
  - The JSON file must be found at BASE_DIR/data_from_v3_to_v4/v3_exported_tables.json
 Example: /usr/local/django_projects/data_from_v3_to_v4/v3_exported_tables.json
+ - Elasticsearch must be installed, properly configured and running
  - Set DEBUG = False to settings_local.py to avoid warnings/debug/info noise.
  - Can be executed with a MariaDB/MySQL or Postgresql database.
  - If you encounter an error "Too many connections" type, you can increase the value of


### PR DESCRIPTION
Scripts to migrate from Pod v3 to Pod v4:

- Add a command to delete migration files and .pyc files of the flatpages app, and used it in the createDB command
- A script to migrate from Pod v3 to Pod v4: export data from Pod v3.8.x to a JSON file for Pod v4.0.x. Must be executed on Pod v3.8.x server.
- A script to migrate from Pod v3 to Pod v4: import data from Pod v3.8.x JSON file to Pod v4.0.x. Must be executed on Pod v4.0.x server.

As Pod v4 is not yet finalised, these scripts may evolve.