### PR TITLE
[WIP] Update chunked_upload repository

### DIFF
--- a/pod/settings.py
+++ b/pod/settings.py
@@ -8,13 +8,6 @@ import os
 import sys
 import importlib.util
 
-# DEPRECATIONS HACKS
-import django
-from django.utils.translation import gettext
-
-# Needed for django-chunked-upload==2.0.0
-django.utils.translation.ugettext = gettext
-
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # will be update in pod/main/settings.py
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-lti-provider==1.0.0
 django-auth-mixins==1.0.1
 pandas
 django-shibboleth-remoteuser
-django-chunked-upload==2.0.0
+django-chunked-upload@git+https://github.com/juliomalegria/django-chunked-upload.git
 django-select2
 django-redis
 chardet==5.2.0


### PR DESCRIPTION
The pypi repository still have an old version of the code (using ugettext instead of gettext in the 'constant.py' file).
A request has been done to the author to actualyse Pypi repository but actualy the only way to get the last version of the module is to use the author git repository
https://github.com/juliomalegria/django-chunked-upload.git

This change allow to remove the "DEPRECATIONS HACKS" in 'pod/settings.py'
