### PR TITLE
Update shibboleth_remoteuser repository

### DIFF
--- a/pod/authentication/tests/test_populated.py
+++ b/pod/authentication/tests/test_populated.py
@@ -406,7 +406,6 @@ class PopulatedLDAPTestCase(TestCase):
         )
 
 
-@skip("# Esup-Pod 4.0 is no more compatible with Shibb (until someone correct this)")
 class PopulatedShibTestCase(TestCase):
     def setUp(self) -> None:
         """Set up PopulatedShibTestCase create user Pod."""

--- a/pod/authentication/tests/test_populated.py
+++ b/pod/authentication/tests/test_populated.py
@@ -8,7 +8,7 @@ import random
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings, RequestFactory
-from unittest import mock, skip
+from unittest import mock
 from importlib import reload
 from ldap3 import Server, Connection, MOCK_SYNC
 
@@ -468,8 +468,12 @@ class PopulatedShibTestCase(TestCase):
         # Test if user can be staff if SHIBBOLETH_STAFF_ALLOWED_DOMAINS is None.
         settings.SHIBBOLETH_STAFF_ALLOWED_DOMAINS = None
         reload(shibmiddleware)
+
+        def get_dummy_response(request):  # pragma: no cover
+            return None
+
         shibmiddleware.ShibbMiddleware.make_profile(
-            shibmiddleware.ShibbMiddleware(), user, shib_meta
+            shibmiddleware.ShibbMiddleware(get_dummy_response), user, shib_meta
         )
         self.assertTrue(user.is_staff)
 
@@ -486,7 +490,7 @@ class PopulatedShibTestCase(TestCase):
         user.save()
         reload(shibmiddleware)
         shibmiddleware.ShibbMiddleware.make_profile(
-            shibmiddleware.ShibbMiddleware(), user, shib_meta
+            shibmiddleware.ShibbMiddleware(get_dummy_response), user, shib_meta
         )
         self.assertFalse(user.is_staff)
 
@@ -495,7 +499,7 @@ class PopulatedShibTestCase(TestCase):
         settings.SHIBBOLETH_STAFF_ALLOWED_DOMAINS = ("univ.fr",)
         reload(shibmiddleware)
         shibmiddleware.ShibbMiddleware.make_profile(
-            shibmiddleware.ShibbMiddleware(), user, shib_meta
+            shibmiddleware.ShibbMiddleware(get_dummy_response), user, shib_meta
         )
         self.assertTrue(user.is_staff)
 
@@ -512,7 +516,7 @@ class PopulatedShibTestCase(TestCase):
             }
         )
         shibmiddleware.ShibbMiddleware.make_profile(
-            shibmiddleware.ShibbMiddleware(), user, shib_meta
+            shibmiddleware.ShibbMiddleware(get_dummy_response), user, shib_meta
         )
         self.assertTrue(user.is_staff)  # Staff status is not remove
 
@@ -532,7 +536,7 @@ class PopulatedShibTestCase(TestCase):
             }
         )
         shibmiddleware.ShibbMiddleware.make_profile(
-            shibmiddleware.ShibbMiddleware(), user, shib_meta
+            shibmiddleware.ShibbMiddleware(get_dummy_response), user, shib_meta
         )
         self.assertFalse(user.is_staff)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ sorl-thumbnail==12.11.0
 django-lti-provider==1.0.0
 django-auth-mixins==1.0.1
 pandas
-django-shibboleth-remoteuser@git+https://gitlab.uvm.edu/saa/research-storage-automation/django-shibboleth-remoteuser-uvm.git
+django-shibboleth-remoteuser@git+https://gitlab.gwdg.de/discuss-data/django-shibboleth-remoteuser
 django-chunked-upload==2.0.0
 django-select2
 django-redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ django-lti-provider==1.0.0
 django-auth-mixins==1.0.1
 pandas
 django-shibboleth-remoteuser@git+https://gitlab.gwdg.de/discuss-data/django-shibboleth-remoteuser
-django-chunked-upload==2.0.0
 django-select2
 django-redis
 chardet==5.2.0
@@ -36,3 +35,4 @@ djangorestframework-simplejwt==5.3.1
 django-pwa==2.0.1
 django-webpush==0.3.6
 defusedxml==0.7.1
+django-chunked-upload@git+https://github.com/juliomalegria/django-chunked-upload.git@master

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ sorl-thumbnail==12.11.0
 django-lti-provider==1.0.0
 django-auth-mixins==1.0.1
 pandas
-django-shibboleth-remoteuser
+django-shibboleth-remoteuser@git+https://gitlab.uvm.edu/saa/research-storage-automation/django-shibboleth-remoteuser-uvm.git
 django-chunked-upload==2.0.0
 django-select2
 django-redis


### PR DESCRIPTION
The shibboleth_remoteuser module available on the Pypi repository has not been update since 5 years.
The code (also accessible on git : https://github.com/Brown-University-Library/django-shibboleth-remoteuser) still working but some syntax are now obsolete.
This PR update the repository to https://gitlab.gwdg.de/discuss-data/django-shibboleth-remoteuser which have more recent reviews
