### PR TITLE
[DONE] BlockAdmin: ajout infos dans la liste

### DIFF
--- a/pod/main/admin.py
+++ b/pod/main/admin.py
@@ -127,9 +127,11 @@ class BlockAdmin(TranslationAdmin):
 
     list_display = (
         "title",
+        "order",
         "page",
         "type",
         "data_type",
+        "visible",
     )
 
     def get_form(self, request, obj=None, **kwargs):


### PR DESCRIPTION
**BlockAdmin**  
Ajout de l'affichage des informations `order` et `visible` dans l'admin

Avant:

> ![adminBlock](https://github.com/user-attachments/assets/b1746dc2-b0c8-463f-9ed4-e0ee864768cd)

Après : 

> ![adminBlock_after](https://github.com/user-attachments/assets/ed126e3c-10cc-4b81-bc5e-3038f66d4380)
