### PR TITLE
API AccessGroup filters

### DIFF
--- a/pod/authentication/rest_views.py
+++ b/pod/authentication/rest_views.py
@@ -75,7 +75,7 @@ class AccessGroupSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = AccessGroup
         fields = ("id", "display_name", "code_name", "sites", "users", "sites")
-
+        filterset_fields = ["id", "display_name", "code_name"]
 
 # ViewSets define the view behavior.
 
@@ -104,7 +104,7 @@ class SiteViewSet(viewsets.ModelViewSet):
 class AccessGroupViewSet(viewsets.ModelViewSet):
     queryset = AccessGroup.objects.all()
     serializer_class = AccessGroupSerializer
-
+    filterset_fields = ["id", "display_name", "code_name"]
 
 @api_view(["POST"])
 def accessgroups_set_users_by_name(request):


### PR DESCRIPTION
Ajout des filtres de recherche sur les groupes : id, display_name et code_name

Pour pouvoir créer et peupler des groupes depuis l'API, il est nécessaire de pouvoir récupérer les informations sur le groupe.
Il est possible de le faire en récupérant la liste de tous les groupes. Mais cette récupération peut-être fastidieuse (car paginée) et gourmande en ressource inutilement.

L'ajout des filtres de recherche sur les accessgroup permettent de faire une recherche ciblée.
