### PR TITLE
oembed thumbnail_url - missing site hostname

### DIFF
--- a/pod/video/models.py
+++ b/pod/video/models.py
@@ -1027,7 +1027,13 @@ class Video(models.Model):
             # Handle exception to avoid sending an error email
             try:
                 im = get_thumbnail(self.thumbnail.file, size, crop="center", quality=80)
-                thumbnail_url = im.url
+                thumbnail_url = "".join(
+                    [
+                        "//",
+                        get_current_site(request).domain,
+                        im.url
+                    ]
+                )
             except Exception as e:
                 logger.error(
                     "An error occured during get_thumbnail_url"


### PR DESCRIPTION
la propriété thumbnail_url retournée par video/oembed/ n'incluait pas l'url du serveur, seulement le chemin du fichier. La correction ajoute l'url du serveur.
