### PR TITLE
Multiples instances de pods dans l'environnement Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ pod/main/static/custom/img
 !pod/custom/settings_local.py.example
 settings_local.py
 transcription/*
+.*initialized
 
 # Unit test utilities #
 #######################

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,10 @@ upgrade:
 
 # Création des données initiales dans la BDD SQLite intégrée
 createDB:
-	find . -path "*/migrations/*.py" -not -name "__init__.py" -delete
-	find . -path "*/migrations/*.pyc" -delete
+	find . -path "*/migrations/*.py" -not -name "__init__.py" -exec rm --force "{}" +
+	find . -path "*/migrations/*.pyc" -exec rm --force "{}" +
 	make updatedb
 	make migrate
-	python3 manage.py loaddata initial_data
 
 # Mise à jour des fichiers de langue
 lang:
@@ -78,7 +77,7 @@ pystyle:
 statics:
 	cd pod; yarn install; yarn upgrade
 	# --clear Clear the existing files before trying to copy or link the original file.
-	python3 manage.py collectstatic --clear
+	python3 manage.py collectstatic --clear --verbosity 0
 
 # Generate configuration docs in .MD format
 createconfigs:
@@ -171,6 +170,6 @@ endif
 	sudo rm -rf ./pod/static
 	sudo rm -rf ./pod/node_modules
 	sudo rm -rf ./pod/db_migrations
-	sudo rm -rf ./pod/db.sqlite3
-	sudo rm -rf ./pod/db_remote.sqlite3
+	sudo rm -rf ./pod/*.sqlite3
+	sudo rm -rf ./pod/.*initialized
 	sudo rm -rf ./pod/media

--- a/docker-compose-dev-with-volumes.yml
+++ b/docker-compose-dev-with-volumes.yml
@@ -31,6 +31,7 @@ services:
     ports:
       - 9200:9200
     environment:
+      - logger.level=WARN
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms2g -Xmx2g"

--- a/docker-compose-full-dev-with-volumes-test.yml
+++ b/docker-compose-full-dev-with-volumes-test.yml
@@ -70,6 +70,7 @@ services:
     ports:
       - 9200:9200
     environment:
+      - logger.level=WARN
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms2g -Xmx2g"

--- a/docker-compose-full-dev-with-volumes.yml
+++ b/docker-compose-full-dev-with-volumes.yml
@@ -70,6 +70,7 @@ services:
     ports:
       - 9200:9200
     environment:
+      - logger.level=WARN
       - discovery.type=single-node
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms2g -Xmx2g"

--- a/dockerfile-dev-with-volumes/README.adoc
+++ b/dockerfile-dev-with-volumes/README.adoc
@@ -61,6 +61,8 @@ DOCKER_ENV=light
 Renseignez le fichier pod/custom/settings_local.py comme ceci :
 [source,python]
 ----
+import os
+INSTANCE = os.getenv("POD_INSTANCE", "pod")
 
 USE_PODFILE = True
 EMAIL_ON_ENCODING_COMPLETION = False
@@ -69,6 +71,7 @@ DEBUG = True
 # on précise ici qu'on utilise ES version 8
 ES_VERSION = 8
 ES_URL = ['http://elasticsearch.localhost:9200/']
+ES_INDEX = INSTANCE
 
 
 CACHES = {
@@ -78,7 +81,7 @@ CACHES = {
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
-        "KEY_PREFIX": "pod"
+        "KEY_PREFIX": INSTANCE
     },
     "select2": {
         "BACKEND": "django_redis.cache.RedisCache",
@@ -86,6 +89,7 @@ CACHES = {
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },
+        "KEY_PREFIX": INSTANCE
     },
 }
 SESSION_ENGINE = "redis_sessions.session"
@@ -93,7 +97,7 @@ SESSION_REDIS = {
     "host": "redis.localhost",
     "port": 6379,
     "db": 4,
-    "prefix": "session",
+    "prefix": f"session-{INSTANCE}",
     "socket_timeout": 1,
     "retry_on_timeout": False,
 }
@@ -148,7 +152,8 @@ Vous devriez obtenir ce message une fois esup-pod lancé
 ----
 $ pod-dev-with-volumes        | Superuser created successfully.
 ----
-L'application esup-pod est dès lors disponible via cette URL : localhost:8000
+L'application esup-pod est dès lors disponible via cette URL : pod.localhost:8000
+Différentes instances peuvent être lancées, sur différents ports, en utilisant les variables d'environnement ``POD_INSTANCE`` et ``POD_PORT``.
 
 === Arrêt de la stack
 $ CTRL+C dans la fenetre depuis laquelle l'application esup-pod a été lancée

--- a/dockerfile-dev-with-volumes/pod-back/my-entrypoint-back.sh
+++ b/dockerfile-dev-with-volumes/pod-back/my-entrypoint-back.sh
@@ -1,28 +1,31 @@
 #!/bin/sh
-echo "Launching commands into pod-dev"
+INSTANCE="${POD_INSTANCE:-pod}"
+PORT="${POD_PORT:-8000}"
+echo "Launching commands into ${INSTANCE}-dev"
 mkdir -p pod/node_modules
 mkdir -p pod/db_migrations && touch pod/db_migrations/__init__.py
 ln -fs /tmp/node_modules/* pod/node_modules
 # Mise en route
 # Base de données SQLite intégrée
-BDD_FILE=/usr/src/app/pod/db.sqlite3
-if test ! -f "$BDD_FILE"; then
-    echo "$BDD_FILE does not exist."
+INIT_FILE="/usr/src/app/pod/.${INSTANCE}.initialized"
+if test ! -f "$INIT_FILE"; then
+    echo "$INIT_FILE does not exist."
     python3 manage.py create_pod_index
-    curl -XGET "elasticsearch:9200/pod/_search"
+    curl -XGET "elasticsearch.localhost:9200/${INSTANCE}/_search"
     # Deployez les fichiers statiques
-    python3 manage.py collectstatic --no-input --clear
+    python3 manage.py collectstatic --no-input --clear --verbosity 0
     # Lancez le script présent à la racine afin de créer les fichiers de migration, puis de les lancer pour créer la base de données SQLite intégrée.
     make createDB
     # SuperUtilisateur
     # Il faut créer un premier utilisateur qui aura tous les pouvoirs sur votre instance.
     python3 manage.py createsuperuser --noinput
+    touch "$INIT_FILE"
 else
-    echo "$BDD_FILE exist."
+    echo "$INIT_FILE exist."
 fi
 # Serveur de développement
 # Le serveur de développement permet de tester vos futures modifications facilement.
 # N'hésitez pas à lancer le serveur de développement pour vérifier vos modifications au fur et à mesure.
 # À ce niveau, vous devriez avoir le site en français et en anglais et voir l'ensemble de la page d'accueil.
-python3 manage.py runserver 0.0.0.0:8000 --insecure
+python3 manage.py runserver "0.0.0.0:${PORT}" --insecure
 sleep infinity

--- a/dockerfile-dev-with-volumes/pod/my-entrypoint.sh
+++ b/dockerfile-dev-with-volumes/pod/my-entrypoint.sh
@@ -1,28 +1,31 @@
 #!/bin/sh
-echo "Launching commands into pod-dev"
+INSTANCE="${POD_INSTANCE:-pod}"
+PORT="${POD_PORT:-8000}"
+echo "Launching commands into ${INSTANCE}-dev"
 mkdir -p pod/node_modules
 mkdir -p pod/db_migrations && touch pod/db_migrations/__init__.py
 ln -fs /tmp/node_modules/* pod/node_modules
 # Mise en route
 # Base de données SQLite intégrée
-BDD_FILE=/usr/src/app/pod/db.sqlite3
-if test ! -f "$BDD_FILE"; then
-    echo "$BDD_FILE does not exist."
+INIT_FILE="/usr/src/app/pod/.${INSTANCE}.initialized"
+if test ! -f "$INIT_FILE"; then
+    echo "$INIT_FILE does not exist."
     python3 manage.py create_pod_index
-    curl -XGET "elasticsearch.localhost:9200/pod/_search"
+    curl -XGET "elasticsearch.localhost:9200/${INSTANCE}/_search"
     # Deployez les fichiers statiques
-    python3 manage.py collectstatic --no-input --clear
+    python3 manage.py collectstatic --no-input --clear --verbosity 0
     # Lancez le script présent à la racine afin de créer les fichiers de migration, puis de les lancer pour créer la base de données SQLite intégrée.
     make createDB
     # SuperUtilisateur
     # Il faut créer un premier utilisateur qui aura tous les pouvoirs sur votre instance.
     python3 manage.py createsuperuser --noinput
+    touch "$INIT_FILE"
 else
-    echo "$BDD_FILE exist."
+    echo "$INIT_FILE exist."
 fi
 # Serveur de développement
 # Le serveur de développement permet de tester vos futures modifications facilement.
 # N'hésitez pas à lancer le serveur de développement pour vérifier vos modifications au fur et à mesure.
 # À ce niveau, vous devriez avoir le site en français et en anglais et voir l'ensemble de la page d'accueil.
-python3 manage.py runserver 0.0.0.0:8000 --insecure
+python3 manage.py runserver "0.0.0.0:${PORT}" --insecure
 sleep infinity

--- a/pod/dressing/tests/test_utils.py
+++ b/pod/dressing/tests/test_utils.py
@@ -4,6 +4,8 @@ import os
 import unittest
 from unittest.mock import patch
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
+from django.conf import settings
 from pod.authentication.models import AccessGroup
 from pod.dressing.utils import get_dressings, get_dressing_input
 from pod.dressing.models import Dressing
@@ -11,6 +13,13 @@ from pod.dressing.models import Dressing
 
 class DressingUtilitiesTests(unittest.TestCase):
     """TestCase for Esup-Pod dressing utilities."""
+
+    def setUp(self):
+        """Set up test data."""
+        Site.objects.get_or_create(
+            id=getattr(settings, 'SITE_ID', 1),
+            defaults={'domain': 'localhost:8000', 'name': 'localhost:8000'}
+        )
 
     def test_get_dressing_input(self) -> None:
         """Test for the get_dressing_input function."""

--- a/pod/main/apps.py
+++ b/pod/main/apps.py
@@ -1,11 +1,33 @@
 """Esup-pod Main applications."""
 
+import os
+
 from django.apps import AppConfig
 from django.db.models.signals import post_migrate
 from django.utils.translation import gettext_lazy as _
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.management import call_command
 
 import json
+
+SITE_ID = getattr(settings, "SITE_ID", 1)
+INSTANCE = os.getenv("POD_INSTANCE", "pod")
+PORT = os.getenv("POD_PORT", 8000)
+
+
+def load_data(sender, **kwargs):
+    """Load the initial_data fixture and create a Site object if needed."""
+    from django.contrib.sites.models import Site
+
+    call_command("loaddata", "initial_data.json")
+
+    site, created = Site.objects.get_or_create(id=SITE_ID)
+    if created:
+        domain = f"{INSTANCE}.localhost:{PORT}"
+        site.domain = domain
+        site.name = domain
+        site.save()
 
 
 def create_missing_pages(sender, **kwargs) -> None:
@@ -72,6 +94,7 @@ def create_missing_conf(sender, **kwargs) -> None:
 
     print("---> Creating missing configurations...")
     json_data = []
+
     with open("./pod/main/fixtures/initial_data.json", encoding="utf-8") as data_file:
         json_data = json.loads(data_file.read())
 
@@ -157,3 +180,4 @@ class MainConfig(AppConfig):
         post_migrate.connect(create_missing_conf, sender=self)
         post_migrate.connect(create_missing_pages, sender=self)
         post_migrate.connect(create_first_block, sender=self)
+        post_migrate.connect(load_data, sender=self)

--- a/pod/main/celery.py
+++ b/pod/main/celery.py
@@ -6,6 +6,13 @@ from celery import Celery
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pod.settings")
 
+try:
+    from pod.custom import settings_local
+except ImportError:
+    from pod import settings as settings_local
+
+INSTANCE = getattr(settings_local, "INSTANCE", None)
+
 app = Celery("pod_project")
 
 # Using a string here means the worker doesn't have to serialize
@@ -20,6 +27,8 @@ app.conf.task_routes = {
     "pod.main.tasks.*": {"queue": "celery"},
     "pod.main.celery.*": {"queue": "celery"},
 }
+if INSTANCE:
+    app.conf.broker_transport_options = {"global_keyprefix": INSTANCE}
 
 
 @app.task(bind=True)

--- a/pod/main/fixtures/initial_data.json
+++ b/pod/main/fixtures/initial_data.json
@@ -1,13 +1,5 @@
 [
   {
-    "model": "sites.site",
-    "pk": 1,
-    "fields": {
-      "domain": "pod.localhost:8000",
-      "name": "pod.localhost:8000"
-    }
-  },
-  {
     "pk": 1,
     "model": "main.configuration",
     "fields": {

--- a/pod/main/settings.py
+++ b/pod/main/settings.py
@@ -5,6 +5,7 @@ Django version: 3.2.
 """
 
 import os
+INSTANCE = os.getenv("POD_INSTANCE", None)
 
 ##
 # flatpages
@@ -49,6 +50,8 @@ USE_DEBUG_TOOLBAR = True
 #
 # https://docs.djangoproject.com/en/3.2/ref/settings/#allowed-hosts
 ALLOWED_HOSTS = ["pod.localhost"]
+if INSTANCE:
+    ALLOWED_HOSTS.append(f"{INSTANCE}.localhost")
 
 ##
 # Session settings
@@ -80,10 +83,11 @@ MANAGERS = []
 # to be used with Django.
 #
 # https://docs.djangoproject.com/en/3.2/ref/settings/#databases
+default_db = f"db.{INSTANCE}.sqlite3" if INSTANCE else "db.sqlite3"
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+        "NAME": os.path.join(BASE_DIR, default_db),
     }
 }
 

--- a/pod/video/tests/test_models.py
+++ b/pod/video/tests/test_models.py
@@ -10,6 +10,7 @@ from django.db.models.fields.files import ImageFieldFile
 from django.db.utils import IntegrityError
 from django.template.defaultfilters import slugify
 from django.contrib.auth.models import User
+from django.contrib.sites.models import Site
 from django.utils.translation import ugettext_lazy as _
 from django.urls import reverse
 from django.conf import settings
@@ -218,7 +219,8 @@ class TypeTestCase(TestCase):
     def test_delete_object(self) -> None:
         """Test delete object."""
         Type.objects.get(id=1).delete()
-        self.assertEqual(Type.objects.all().count(), 0)
+        with self.assertRaises(Type.DoesNotExist):
+            Type.objects.get(id=1)
         print("   --->  test_delete_object of TypeTestCase: OK!")
 
 
@@ -582,7 +584,8 @@ class VideoRenditionTestCase(TestCase):
     def test_delete_object(self) -> None:
         self.create_video_rendition(resolution="640x365")
         VideoRendition.objects.get(id=1).delete()
-        self.assertEqual(VideoRendition.objects.all().count(), 0)
+        with self.assertRaises(VideoRendition.DoesNotExist):
+            VideoRendition.objects.get(id=1)
 
         print("   --->  test_delete_object of VideoRenditionTestCase: OK!")
 
@@ -593,6 +596,10 @@ class EncodingVideoTestCase(TestCase):
     # fixtures = ['initial_data.json', ]
 
     def setUp(self) -> None:
+        Site.objects.get_or_create(
+            id=getattr(settings, 'SITE_ID', 1),
+            defaults={'domain': 'localhost:8000', 'name': 'localhost:8000'}
+        )
         user = User.objects.create(username="pod", password=PWD)
         Type.objects.create(title="test")
         Video.objects.create(

--- a/pod/video_encode_transcript/encoding_tasks.py
+++ b/pod/video_encode_transcript/encoding_tasks.py
@@ -18,6 +18,7 @@ EMAIL_HOST = getattr(settings_local, "EMAIL_HOST", "")
 DEFAULT_FROM_EMAIL = getattr(settings_local, "DEFAULT_FROM_EMAIL", "")
 ADMINS = getattr(settings_local, "ADMINS", ())
 DEBUG = getattr(settings_local, "DEBUG", True)
+INSTANCE = getattr(settings_local, "INSTANCE", None)
 TEST_REMOTE_ENCODE = getattr(settings_local, "TEST_REMOTE_ENCODE", False)
 
 admins_email = [ad[1] for ad in ADMINS]
@@ -44,6 +45,8 @@ encoding_app = Celery("encoding_tasks", broker=ENCODING_TRANSCODING_CELERY_BROKE
 encoding_app.conf.task_routes = {
     "pod.video_encode_transcript.encoding_tasks.*": {"queue": "encoding"}
 }
+if INSTANCE:
+    encoding_app.conf.broker_transport_options = {"global_keyprefix": INSTANCE}
 
 
 # celery -A pod.video_encode_transcript.encoding_tasks worker -l INFO -Q encoding

--- a/pod/video_encode_transcript/transcripting_tasks.py
+++ b/pod/video_encode_transcript/transcripting_tasks.py
@@ -22,6 +22,7 @@ EMAIL_HOST = getattr(settings_local, "EMAIL_HOST", "")
 DEFAULT_FROM_EMAIL = getattr(settings_local, "DEFAULT_FROM_EMAIL", "")
 ADMINS = getattr(settings_local, "ADMINS", ())
 DEBUG = getattr(settings_local, "DEBUG", True)
+INSTANCE = getattr(settings_local, "INSTANCE", None)
 TEST_REMOTE_ENCODE = getattr(settings_local, "TEST_REMOTE_ENCODE", False)
 
 admins_email = [ad[1] for ad in ADMINS]
@@ -51,6 +52,8 @@ transcripting_app = Celery(
 transcripting_app.conf.task_routes = {
     "pod.video_encode_transcript.transcripting_tasks.*": {"queue": "transcripting"}
 }
+if INSTANCE:
+    transcripting_app.conf.broker_transport_options = {"global_keyprefix": INSTANCE}
 transcripting_app.autodiscover_tasks(packages=None, related_name="", force=False)
 
 

--- a/pod/xapi/xapi_tasks.py
+++ b/pod/xapi/xapi_tasks.py
@@ -18,9 +18,12 @@ XAPI_LRS_URL = getattr(settings_local, "XAPI_LRS_URL", "")
 XAPI_LRS_LOGIN = getattr(settings_local, "XAPI_LRS_LOGIN", "")
 XAPI_LRS_PWD = getattr(settings_local, "XAPI_LRS_PWD", "")
 XAPI_CELERY_BROKER_URL = getattr(settings_local, "XAPI_CELERY_BROKER_URL", "")
+INSTANCE = getattr(settings_local, "INSTANCE", None)
 
 xapi_app = Celery("xapi_tasks", broker=XAPI_CELERY_BROKER_URL)
 xapi_app.conf.task_routes = {"pod.xapi.xapi_tasks.*": {"queue": "xapi"}}
+if INSTANCE:
+    xapi_app.conf.broker_transport_options = {"global_keyprefix": INSTANCE}
 
 
 @xapi_app.task


### PR DESCRIPTION
Bonjour,

Ceci est une dernière PR en préparation à #1170

Elle introduit divers changements au niveau de la configuration, afin qu'un même dockerfile puisse lancer deux instances distinctes de Pod, utilisant les même services (ElasticSearch, Redis) sans conflit. C'est une étape nécessaire pour pouvoir ensuite tester la fédération entre les deux instances avec ActivityPub. Je mets les modifications dans cette PR afin de rendre la relecture de l'autre plus simple, et plus orientée vers le métier d'ActivityPub.

Aucun changement n'est cassant. Cette PR est juste une mise en place, les modifications apportées sont utilisées ensuite par #1170

Si la PR est acceptée j'en ouvrirai une nouvelle visant la branche `main`.

Les modifications apportées sont :

- quelques modifications pour rendre les logs moins verbeux, ça m'a aidé pour débugguer : 
  - rajout d'une option `quiet` à la commande `collectstatic`
  - passage du niveau de log de l'image ElasticSearch à `WARN`
- les étapes de nettoyage de fichiers de `make createDb` sont tolérantes aux erreurs (et donc la commande peut être lancée en parallèle par deux instances Pod sur une même base de code)
- Introduction de deux variables d'environnement facultatives `POD_INSTANCE` et `POD_PORT`. `POD_INSTANCE` peut être le nom d'une instance pod (par exemple `pod-a`, `pod-b` etc), `POD_PORT` est le port sur lequel sera lancée l'instance dans le conteneur Docker.
  - dans les `entrypoint.sh` de l'application Django, le marqueur pour vérifier que l'application a été initialisée n'est plus la détection du fichier .sqlite, mais un fichier `.initialized` construit à partir de `POD_INSTANCE`
  - dans les `entrypoint.sh` de l'application Django, `POD_PORT` est utilisé pour déterminer sur quel port lancer l'application
  - l'objet `Site` initial n'est plus initialisé statiquement à partir de `initial_data.json` mais dynamiquement dans `main/apps.py`, à partir de `POD_INSTANCE` et `POD_PORT`
  - si `POD_INSTANCE` est défini, la base de données par défaut prendra son nom plutôt que `db.sqlite3`
  - les queues celery utilisent `POD_INSTANCE` comme préfix (pour avoir un namespace dédié pour chaque instance de pod)
  - la doc par défaut a été mise à jour pour suggérer l'utilisation de `POD_INSTANCE` comme namespace pour les caches, les sessions redis, et l'index ElasticSearch `ES_INDEX`

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [ ] Your PR targets the `dev_v4` branch.
* [ ] Your PR status is in `draft` if it's still a work in progress.
