### PR TITLE
:bug: [FIX] Normalize malformed referrer URLs missing double slash

### DIFF
--- a/pod/authentication/views.py
+++ b/pod/authentication/views.py
@@ -23,6 +23,12 @@ OIDC_NAME = getattr(settings, "OIDC_NAME", "OpenID Connect")
 def authentication_login(request):
     """Handle authentication login attempt."""
     referrer = request.GET["referrer"] if request.GET.get("referrer") else "/"
+
+    if referrer.startswith("https:/") and not referrer.startswith("https://"):
+        referrer = "https://" + referrer[len("https:/"):]
+    elif referrer.startswith("http:/") and not referrer.startswith("http://"):
+        referrer = "http://" + referrer[len("http:/"):]
+
     host = (
         "https://%s" % request.get_host()
         if (request.is_secure())


### PR DESCRIPTION
# :bug: [FIX] Normalize malformed referrer URLs missing double slash

Some external requests send a malformed `referrer` such as:

* `http:/pod.univ-lille.fr/...`
* `https:/pod.univ-lille.fr/...`

These URLs have a missing slash after the scheme (`:/` instead of `://`), and Pod never generates them internally.
They currently trigger `SuspiciousOperation("referrer is not internal")`, causing unnecessary admin error emails.

This PR adds a **minimal and safe normalization**:

* `https:/…` → `https://…`
* `http:/…` → `http://…`

Nothing else is changed.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v4` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.