### PR TITLE
bypass mp4 service worker

### DIFF
--- a/pod/progressive_web_app/static/js/serviceworker.js
+++ b/pod/progressive_web_app/static/js/serviceworker.js
@@ -32,6 +32,12 @@ self.addEventListener("activate", (event) => {
 
 // Serve from Cache
 self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+
+  if (event.request.destination === "video" || url.pathname.endsWith(".mp4")) {
+    return;
+  }
+
   event.respondWith(
     caches
       .match(event.request)

--- a/pod/progressive_web_app/static/js/serviceworker.js
+++ b/pod/progressive_web_app/static/js/serviceworker.js
@@ -33,7 +33,7 @@ self.addEventListener("activate", (event) => {
 // Serve from Cache
 self.addEventListener("fetch", (event) => {
   const url = new URL(event.request.url);
-
+  // In the context of using the recordings to be claimed, it allows bypassing mp4 video files
   if (event.request.destination === "video" || url.pathname.endsWith(".mp4")) {
     return;
   }


### PR DESCRIPTION
Lorsque que l'on souhaite prévisualiser une vidéo dans la liste "revendiquer un enregistrement", et si la vidéo est un peu volumineuse, la prévisualisation ne démarre pas. Le service worker empêche de démarrer la lecture avec un rechargement partiel.

Solution : empêcher le cache du service worker sur les fichier mp4

# Before sending your pull request, make sure the following are done

* [ ] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v4` branch.
* [ ] Your PR status is in `draft` if it’s still a work in progress.
