### PR TITLE
Enhance dashboard filtering and runner manager administration with i18n updates

### DIFF
--- a/pod/locale/fr/LC_MESSAGES/django.po
+++ b/pod/locale/fr/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-13 09:52+0100\n"
+"POT-Creation-Date: 2026-02-27 14:05+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: obado <bado@unice.fr>\n"
 "Language-Team: Pod Team cotech-esup-pod@esup-portail.org\n"
@@ -193,7 +193,8 @@ msgstr "Enrichissements AI"
 #: pod/quiz/templates/quiz/create_edit_quiz.html
 #: pod/quiz/templates/quiz/video_quiz.html pod/recorder/models.py
 #: pod/video/models.py pod/video/templates/channel/channel.html
-#: pod/video/templates/videos/videos.html pod/video_encode_transcript/models.py
+#: pod/video/templates/videos/videos.html pod/video_encode_transcript/admin.py
+#: pod/video_encode_transcript/models.py
 msgid "Video"
 msgstr "Vidéo"
 
@@ -234,8 +235,8 @@ msgid "Enter the ID of the enhancement in Aristote"
 msgstr "Entrez l’identifiant de l’enrichissement dans Aristote"
 
 #: pod/ai_enhancement/templates/choose_video_element.html
-#: pod/dressing/models.py pod/video/apps.py pod/video/models.py
-#: pod/video/templates/videos/video_breadcrumbs.html
+#: pod/dressing/models.py pod/video/admin.py pod/video/apps.py
+#: pod/video/models.py pod/video/templates/videos/video_breadcrumbs.html
 #: pod/video/templates/videos/videos.html
 msgid "Videos"
 msgstr "Vidéos"
@@ -433,9 +434,9 @@ msgid ""
 "Something went wrong with AI improvement on “%(content_title)s”. Suggestions "
 "for improvement can’t be available on %(site_title)s."
 msgstr ""
-"Une erreur s’est produite sur le traitement par l’IA de « %(content_title)s "
-"». Les suggestions d’amélioration ne peuvent pas être disponibles sur "
-"%(site_title)s."
+"Une erreur s’est produite sur le traitement par l’IA de "
+"« %(content_title)s ». Les suggestions d’amélioration ne peuvent pas être "
+"disponibles sur %(site_title)s."
 
 #: pod/ai_enhancement/utils.py
 #, python-format
@@ -457,8 +458,8 @@ msgid ""
 "Something went wrong with AI improvement on “%(content_title)s”  on "
 "%(site_title)s."
 msgstr ""
-"Une erreur s’est produite sur l’amélioration par l’IA de « %(content_title)s "
-"» sur %(site_title)s."
+"Une erreur s’est produite sur l’amélioration par l’IA de "
+"« %(content_title)s » sur %(site_title)s."
 
 #: pod/ai_enhancement/utils.py pod/live/utils.py pod/meeting/utils.py
 #: pod/video_encode_transcript/utils.py
@@ -759,8 +760,8 @@ msgid "The file must be in VTT format."
 msgstr "Le fichier doit être au format VTT."
 
 #: pod/chapter/models.py pod/completion/models.py pod/enrichment/models.py
-#: pod/playlist/templates/playlist/playlist_card.html pod/video/models.py
-#: pod/video_encode_transcript/utils.py
+#: pod/playlist/templates/playlist/playlist_card.html pod/video/admin.py
+#: pod/video/models.py pod/video_encode_transcript/utils.py
 msgid "video"
 msgstr "vidéo"
 
@@ -1355,7 +1356,8 @@ msgstr ""
 #: pod/completion/permissions/video.py
 #, python-brace-format
 msgid "{func.__name__}: Permission denied for user {current_user.pk}."
-msgstr "{func.__name__} : Permission refusée pour l’utilisateur {current_user.pk}."
+msgstr ""
+"{func.__name__} : Permission refusée pour l’utilisateur {current_user.pk}."
 
 #: pod/completion/templates/contributor/form_contributor.html
 #: pod/completion/templates/document/form_document.html
@@ -6048,7 +6050,7 @@ msgstr "Journal des sessions des réunions"
 msgid "Meeting session logs"
 msgstr "Journaux des sessions des réunions"
 
-#: pod/meeting/models.py
+#: pod/meeting/models.py pod/video_encode_transcript/admin.py
 msgid "Recording ID"
 msgstr "Identifiant de l’enregistrement"
 
@@ -6191,6 +6193,7 @@ msgstr ""
 "Pour supprimer la réunion, veuillez cocher la case et cliquer sur supprimer."
 
 #: pod/meeting/templates/meeting/filter_aside.html pod/video/views.py
+#: pod/video_encode_transcript/admin.py
 msgid "Status"
 msgstr "Statut"
 
@@ -6408,7 +6411,8 @@ msgstr "La réunion n’a pas encore commencé."
 msgid ""
 "It is scheduled for <strong>%(start_date)s</strong> at <i>%(start_time)s</i>."
 msgstr ""
-"Elle est planifiée le <strong>%(start_date)s</strong> à <i>%(start_time)s</i>."
+"Elle est planifiée le <strong>%(start_date)s</strong> à <i>%(start_time)s</"
+"i>."
 
 #: pod/meeting/templates/meeting/join.html
 msgid "You will be redirected right after the meeting starts."
@@ -6583,7 +6587,7 @@ msgid "Has user joined?"
 msgstr "Utilisateurs connectés ?"
 
 #: pod/meeting/views.py pod/recorder/models.py
-#: pod/video_encode_transcript/models.py
+#: pod/video_encode_transcript/admin.py pod/video_encode_transcript/models.py
 msgid "Recording"
 msgstr "Enregistrement"
 
@@ -9914,6 +9918,7 @@ msgid "Clear all filters"
 msgstr "Effacer tous les filtres"
 
 #: pod/video/templates/videos/dashboard.html
+#: pod/video/templates/videos/filter_aside_category.html
 msgid "Clear filters"
 msgstr "Effacer les filtres"
 
@@ -10629,6 +10634,7 @@ msgstr "La fiche ne contient pas de vidéo."
 msgid "Queue rank:"
 msgstr "Rang dans la file d’attente :"
 
+#: pod/video/templates/videos/video_queue_runner_manager.html
 msgid "Total number of videos in the queue:"
 msgstr "Nombre total de vidéos dans la file d’attente :"
 
@@ -10994,6 +11000,23 @@ msgstr "Erreur serveur lors du traitement du filtre."
 msgid "resolution"
 msgstr "résolution"
 
+#: pod/video_encode_transcript/admin.py pod/video_encode_transcript/models.py
+msgid "Active"
+msgstr "Actif"
+
+#: pod/video_encode_transcript/admin.py
+msgid "Inactive"
+msgstr "Inactif"
+
+#: pod/video_encode_transcript/admin.py
+#: pod/video_encode_transcript/templates/admin_test_connection.html
+msgid "Runner administration"
+msgstr "Administration des runners"
+
+#: pod/video_encode_transcript/admin.py
+msgid "Open runner administration"
+msgstr "Ouvrir l’administration des runners"
+
 #: pod/video_encode_transcript/admin.py
 msgid "Runner manager not found."
 msgstr "Runner manager non trouvé."
@@ -11013,8 +11036,8 @@ msgid ""
 "Runner manager '%(name)s' responded but rejected authentication (HTTP "
 "%(status)s). Check the bearer token."
 msgstr ""
-"Le runner manager « %(name)s » a répondu mais a rejeté l’authentification (HTTP "
-"%(status)s). Vérifiez le jeton porteur."
+"Le runner manager « %(name)s » a répondu mais a rejeté l’authentification "
+"(HTTP %(status)s). Vérifiez le jeton porteur."
 
 #: pod/video_encode_transcript/admin.py
 #, python-format
@@ -11027,8 +11050,8 @@ msgid ""
 "Runner manager '%(name)s' is reachable but endpoint %(url)s was not found "
 "(HTTP 404). Check the configured URL."
 msgstr ""
-"Le runner manager « %(name)s » est accessible, mais le point de terminaison %(url)s est introuvable "
-"(HTTP 404). Vérifiez l’URL configurée."
+"Le runner manager « %(name)s » est accessible, mais le point de terminaison "
+"%(url)s est introuvable (HTTP 404). Vérifiez l’URL configurée."
 
 #: pod/video_encode_transcript/admin.py
 #, python-format
@@ -11036,8 +11059,12 @@ msgid ""
 "Runner manager '%(name)s' is reachable but returned an unexpected response "
 "(HTTP %(status)s)."
 msgstr ""
-"Le runner manager « %(name)s » est accessible, mais a renvoyé une réponse inattendue "
-"(HTTP %(status)s)."
+"Le runner manager « %(name)s » est accessible, mais a renvoyé une réponse "
+"inattendue (HTTP %(status)s)."
+
+#: pod/video_encode_transcript/admin.py
+msgid "Video ID"
+msgstr "Identifiant de la vidéo"
 
 #: pod/video_encode_transcript/admin.py
 msgid "Restart selected tasks"
@@ -11170,6 +11197,12 @@ msgid "Priority of the runner manager. Lower values indicate higher priority."
 msgstr ""
 "Priorité du runner manager. Les valeurs les plus basses indiquent une "
 "priorité plus élevée."
+
+#: pod/video_encode_transcript/models.py
+msgid "If checked, this runner manager can be used to process tasks."
+msgstr ""
+"Si cette option est cochée, ce runner manager peut être utilisé pour traiter "
+"des tâches."
 
 #: pod/video_encode_transcript/models.py
 msgid "URL of the runner manager"

--- a/pod/video/admin.py
+++ b/pod/video/admin.py
@@ -642,7 +642,7 @@ class VideoToDeleteAdmin(admin.ModelAdmin):
     list_filter = ["date_deletion"]
     autocomplete_fields = ["video"]
 
-    @admin.display(description="video")
+    @admin.display(description=_("video"))
     def get_videos(self, obj):
         return obj.video.count()
 
@@ -667,7 +667,7 @@ class CategoryAdmin(admin.ModelAdmin):
     readonly_fields = ("slug",)
     # list_filter = ["owner"]
 
-    @admin.display(description="Videos")
+    @admin.display(description=_("Videos"))
     def videos_count(self, obj) -> int:
         return obj.video.all().count()
 

--- a/pod/video/static/js/FilterManager.js
+++ b/pod/video/static/js/FilterManager.js
@@ -72,6 +72,7 @@ class FilterManager {
   addFilter({ name, param, searchCallback, itemLabel, itemKey }) {
     try {
       this.filters[param] = {
+        param,
         name,
         searchCallback,
         itemLabel,
@@ -201,16 +202,7 @@ class FilterManager {
    */
   removeFilter(currentFilter, key) {
     if (currentFilter) {
-      const filterElement = document.getElementById(`${slugify(key)}-tag`);
-      const closeButton = document.getElementById(
-        `remove-filter-${slugify(key)}`,
-      );
-      if (closeButton) {
-        const tooltip = bootstrap.Tooltip.getInstance(closeButton);
-        if (tooltip) tooltip.dispose();
-      }
-      const data = currentFilter.selectedItems.get(key);
-      if (filterElement) filterElement.remove();
+      this._removeFilterTag(key);
       currentFilter.selectedItems.delete(key);
       sessionStorage.setItem(
         `filter-${currentFilter.param}`,
@@ -224,10 +216,29 @@ class FilterManager {
    * Initializes the filters from the session.
    */
   async initializeFilters() {
+    let shouldRefresh = false;
+
     for (const param of Object.keys(this.filters)) {
       const filter = this.filters[param];
+      const selectedKeysFromSession = (
+        JSON.parse(sessionStorage.getItem(`filter-${param}`)) || []
+      )
+        .map((value) => slugify(String(value)))
+        .filter((value) => value !== "");
+      const selectedKeysFromUrl = this.getFilterValuesFromUrl(param).map((value) =>
+        slugify(String(value)),
+      );
       const selectedKeys =
-        JSON.parse(sessionStorage.getItem(`filter-${param}`)) || [];
+        selectedKeysFromUrl.length > 0
+          ? selectedKeysFromUrl
+          : selectedKeysFromSession;
+
+      // Refresh only when we apply filters coming from sessionStorage
+      // that are not already present in the URL/server-rendered page.
+      if (selectedKeysFromUrl.length === 0 && selectedKeys.length > 0) {
+        shouldRefresh = true;
+      }
+
       let allItems = [];
       try {
         allItems = await filter.searchCallback("");
@@ -251,7 +262,135 @@ class FilterManager {
         }
       });
     }
-    this.update();
+    this.update({ refresh: shouldRefresh });
+  }
+
+  /**
+   * Returns selected values from URL for one filter key.
+   * Supports repeated and comma-separated values.
+   * @param {string} param - Parameter key.
+   * @returns {Array<string>}
+   */
+  getFilterValuesFromUrl(param) {
+    const searchParams = new URLSearchParams(window.location.search);
+    return searchParams
+      .getAll(param)
+      .flatMap((value) => value.split(","))
+      .map((value) => value.trim())
+      .filter((value) => value !== "");
+  }
+
+  /**
+   * Synchronize one filter with an explicit list of values.
+   * @param {string} param - Parameter key.
+   * @param {Array<string | {value: string, label: string}>} values - Values to set.
+   * @param {Object} [options]
+   * @param {boolean} [options.refresh=true] - Trigger videos refresh.
+   * @param {boolean} [options.emitEvent=true] - Emit dashboard filters event.
+   * @param {boolean} [options.updateUrl=true] - Update browser URL.
+   */
+  syncFilterSelection(
+    param,
+    values = [],
+    { refresh = true, emitEvent = true, updateUrl = true } = {},
+  ) {
+    const filter = this.filters[param];
+    if (!filter) return;
+
+    Array.from(filter.selectedItems.keys()).forEach((key) => {
+      this._removeFilterTag(key);
+    });
+    filter.selectedItems.clear();
+
+    const availableItems = this.currentResults[param] || [];
+    const uniqueEntries = [];
+    const seenKeys = new Set();
+
+    values.forEach((entry) => {
+      const rawValue =
+        typeof entry === "object" && entry !== null ? entry.value : entry;
+      if (!rawValue) return;
+
+      const value = String(rawValue).trim();
+      if (!value) return;
+
+      const key = slugify(value);
+      if (seenKeys.has(key)) return;
+      seenKeys.add(key);
+
+      const providedLabel =
+        typeof entry === "object" && entry !== null ? entry.label : null;
+      const matchedItem = availableItems.find(
+        (item) => slugify(filter.itemKey(item)) === key,
+      );
+      const label =
+        providedLabel ||
+        (matchedItem ? filter.itemLabel(matchedItem) : value);
+
+      uniqueEntries.push({ key, value, label });
+    });
+
+    uniqueEntries.forEach(({ key, value, label }) => {
+      filter.selectedItems.set(key, { value, label });
+      this.renderActiveFilter(filter, key);
+    });
+
+    const listContainer = document.getElementById(
+      `collapseFilter${capitalize(param)}`,
+    );
+    if (listContainer) {
+      this.createCheckboxesForFilter(param, this.currentResults[param] || []);
+    }
+
+    this.update({ refresh, emitEvent, updateUrl });
+  }
+
+  /**
+   * Synchronize one filter from URL query values.
+   * @param {string} param - Parameter key.
+   * @param {Object} [options]
+   * @param {boolean} [options.refresh=true] - Trigger videos refresh.
+   * @param {boolean} [options.emitEvent=true] - Emit dashboard filters event.
+   * @param {boolean} [options.updateUrl=true] - Update browser URL.
+   */
+  syncFilterSelectionFromUrl(
+    param,
+    { refresh = true, emitEvent = true, updateUrl = true } = {},
+  ) {
+    this.syncFilterSelection(param, this.getFilterValuesFromUrl(param), {
+      refresh,
+      emitEvent,
+      updateUrl,
+    });
+  }
+
+  /**
+   * Returns a snapshot of selected filters.
+   * @returns {Object<string, Array<string>>}
+   */
+  getSelectedFiltersSnapshot() {
+    const selectedFilters = {};
+    Object.keys(this.filters).forEach((param) => {
+      selectedFilters[param] = Array.from(this.filters[param].selectedItems.keys());
+    });
+    return selectedFilters;
+  }
+
+  /**
+   * Removes one filter tag from active filters UI.
+   * @param {string} key - Selected key.
+   */
+  _removeFilterTag(key) {
+    const normalizedKey = slugify(key);
+    const filterElement = document.getElementById(`${normalizedKey}-tag`);
+    const closeButton = document.getElementById(
+      `remove-filter-${normalizedKey}`,
+    );
+    if (closeButton) {
+      const tooltip = bootstrap.Tooltip.getInstance(closeButton);
+      if (tooltip) tooltip.dispose();
+    }
+    if (filterElement) filterElement.remove();
   }
 
   /**
@@ -401,8 +540,8 @@ class FilterManager {
   /**
    * Updates the sessionStorage and URL with the selected filters.
    */
-  update() {
-    const query = new URLSearchParams();
+  update({ refresh = true, emitEvent = true, updateUrl = true } = {}) {
+    const query = new URLSearchParams(window.location.search);
 
     Object.keys(this.filters).forEach((param) => {
       const filter = this.filters[param];
@@ -415,10 +554,27 @@ class FilterManager {
         sessionStorage.removeItem(`filter-${param}`);
       }
     });
-    const newUrl = `${window.location.pathname}?${query.toString()}`;
-    window.history.replaceState(null, "", newUrl);
+    query.delete("page");
+    if (updateUrl) {
+      const queryString = query.toString();
+      const newUrl = queryString
+        ? `${window.location.pathname}?${queryString}`
+        : window.location.pathname;
+      window.history.replaceState(null, "", newUrl);
+    }
     this._syncResetLink();
-    refreshVideosSearch();
+    if (emitEvent) {
+      document.dispatchEvent(
+        new CustomEvent("pod:dashboard-filters-updated", {
+          detail: {
+            selectedFilters: this.getSelectedFiltersSnapshot(),
+          },
+        }),
+      );
+    }
+    if (refresh) {
+      refreshVideosSearch();
+    }
   }
 
   /**

--- a/pod/video/static/js/filter.js
+++ b/pod/video/static/js/filter.js
@@ -52,6 +52,7 @@ const filtersConfig = [
     itemKey: (categories) => categories.value,
   },
 ];
+globalThis.filtersConfig = filtersConfig;
 
 /**
  * Retrieves the list of video owners based on a search term.
@@ -89,7 +90,24 @@ const filterManager = new FilterManager({
 
 // Inject filter configuration into the manager
 filtersConfig.forEach((cfg) => filterManager.addFilter(cfg));
-filterManager.initializeFilters();
+filterManager.initializeFilters().then(() => {
+  const searchParams = new URLSearchParams(window.location.search);
+  if (searchParams.has("categories")) {
+    filterManager.syncFilterSelectionFromUrl("categories", {
+      refresh: false,
+      emitEvent: false,
+      updateUrl: false,
+    });
+  }
+});
+
+document.addEventListener("pod:aside-category-filter-updated", (event) => {
+  filterManager.syncFilterSelection("categories", event.detail?.categories || [], {
+    refresh: false,
+    emitEvent: false,
+    updateUrl: false,
+  });
+});
 
 /**
  * Initializes filters by fetching data from the statistics API and preparing
@@ -152,7 +170,7 @@ async function fetchSingleFilter(filterName, searchTerm = "") {
     // Map the received data to the { label, value } format expected by FilterManager
     return data[key].map((item) => ({
       label: item.title || item.name || item.label || "unknown",
-      value: item.id || item.slug || item.value || "unknown",
+      value: item.slug || item.id || item.value || "unknown",
     }));
   } catch (error) {
     console.error(

--- a/pod/video/static/js/filter.js
+++ b/pod/video/static/js/filter.js
@@ -90,6 +90,7 @@ const filterManager = new FilterManager({
 
 // Inject filter configuration into the manager
 filtersConfig.forEach((cfg) => filterManager.addFilter(cfg));
+// Wait for async filter initialization before applying URL params to avoid a race condition
 filterManager.initializeFilters().then(() => {
   const searchParams = new URLSearchParams(window.location.search);
   if (searchParams.has("categories")) {

--- a/pod/video/static/js/filter_aside_video_list_refresh.js
+++ b/pod/video/static/js/filter_aside_video_list_refresh.js
@@ -20,17 +20,25 @@ var infinite;
 let infiniteLoading = document.querySelector(".infinite-loading");
 
 function onBeforePageLoad() {
-  infiniteLoading.style.display = "block";
+  if (infiniteLoading) {
+    infiniteLoading.style.display = "block";
+  }
 }
 function onAfterPageLoad() {
   if (
+    typeof urlVideos !== "undefined" &&
     urlVideos === "/video/dashboard/" &&
+    typeof selectedVideos !== "undefined" &&
+    typeof videosListContainerId !== "undefined" &&
+    typeof setSelectedVideos === "function" &&
     selectedVideos[videosListContainerId] &&
     selectedVideos[videosListContainerId].length !== 0
   ) {
     setSelectedVideos(videosListContainerId);
   }
-  infiniteLoading.style.display = "none";
+  if (infiniteLoading) {
+    infiniteLoading.style.display = "none";
+  }
   let footer = document.querySelector("footer.static-pod");
   if (!footer) return;
   footer.classList.add("small");
@@ -43,12 +51,12 @@ function onAfterPageLoad() {
     document.scrollHeight,
     document.offsetHeight,
   );
-  document.querySelector("footer.static-pod .hidden-pod").style.display =
-    "none";
+  const hiddenFooter = document.querySelector("footer.static-pod .hidden-pod");
+  if (!hiddenFooter) return;
+  hiddenFooter.style.display = "none";
   window.addEventListener("scroll", function () {
-    if (window.innerHeight + window.scrollTop() === docHeight) {
-      document.querySelector("footer.static-pod .hidden-pod").style.display =
-        "block";
+    if (window.innerHeight + window.scrollY >= docHeight) {
+      hiddenFooter.style.display = "block";
       footer.setAttribute("style", "height:auto;");
       footer.classList.remove("fixed-bottom");
     }
@@ -61,6 +69,7 @@ function onAfterPageLoad() {
  * @param nextPage
  */
 function refreshInfiniteLoader(url, nextPage) {
+  if (typeof InfiniteLoader !== "function") return;
   if (infinite !== undefined) {
     infinite.removeLoader();
   }
@@ -84,8 +93,13 @@ function replaceCountVideos(newCount) {
     newCount,
   );
   videoFoundStr = interpolate(videoFoundStr, { count: newCount }, true);
-  document.getElementById("video_count").textContent = videoFoundStr;
-  resetDashboardElements();
+  const videoCount = document.getElementById("video_count");
+  if (videoCount) {
+    videoCount.textContent = videoFoundStr;
+  }
+  if (typeof resetDashboardElements === "function") {
+    resetDashboardElements();
+  }
 }
 
 /**
@@ -110,7 +124,7 @@ function handleSearch(e) {
   refreshVideosSearch();
 }
 
-document.getElementById("searchForm").addEventListener("submit", handleSearch);
+document.getElementById("searchForm")?.addEventListener("submit", handleSearch);
 
 document
   .getElementById("titleSearchBtn")
@@ -167,7 +181,11 @@ function refreshVideosSearch() {
         refreshInfiniteLoader(url, pageNext);
       }
       if (
+        typeof urlVideos !== "undefined" &&
         urlVideos === "/video/dashboard/" &&
+        typeof selectedVideos !== "undefined" &&
+        typeof videosListContainerId !== "undefined" &&
+        typeof setSelectedVideos === "function" &&
         selectedVideos[videosListContainerId] &&
         selectedVideos[videosListContainerId].length !== 0
       ) {
@@ -210,8 +228,11 @@ function getUrlForRefresh() {
   let urlParams = new URLSearchParams(window.location.search);
 
   // Normalize multi-value parameters
+  const safeFiltersConfig = Array.isArray(globalThis.filtersConfig)
+    ? globalThis.filtersConfig
+    : [];
   const multiFilters = [
-    ...new Set(filtersConfig.map((filter) => filter.param)),
+    ...new Set(safeFiltersConfig.map((filter) => filter.param)),
   ];
   urlParams = normalizeMultiValues(urlParams, multiFilters);
 
@@ -274,17 +295,23 @@ function disabledInputs(value) {
 }
 
 // First launch of the infinite scroll
-infinite = new InfiniteLoader(
-  getUrlForRefresh(),
-  onBeforePageLoad,
-  onAfterPageLoad,
-  nextPage,
-  (page = 2),
-);
+if (typeof InfiniteLoader === "function") {
+  infinite = new InfiniteLoader(
+    getUrlForRefresh(),
+    onBeforePageLoad,
+    onAfterPageLoad,
+    typeof nextPage !== "undefined" ? nextPage : true,
+    2,
+  );
+}
 
 // Check and clean url to avoid owner parameter if not authorized
 var urlParams = new URLSearchParams(window.location.search);
-if (urlParams.has("owner") && !ownerFilter) {
+if (
+  urlParams.has("owner") &&
+  typeof ownerFilter !== "undefined" &&
+  !ownerFilter
+) {
   urlParams.delete("owner");
   window.history.pushState(
     null,

--- a/pod/video/static/js/video_category.js
+++ b/pod/video/static/js/video_category.js
@@ -45,10 +45,16 @@ function manageCategoriesLinks() {
  * Manage search category input in filter aside
  */
 let searchCategoriesInput = document.getElementById("search-categories-input");
+const clearCategoryFilterButton = document.getElementById(
+  "clear-category-filter-btn",
+);
 if (searchCategoriesInput) {
   searchCategoriesInput.addEventListener("input", () => {
     manageSearchCategories(searchCategoriesInput.value.trim());
   });
+}
+if (clearCategoryFilterButton) {
+  clearCategoryFilterButton.addEventListener("click", clearCategoryFilter);
 }
 
 /**
@@ -80,8 +86,105 @@ function manageSearchCategories(search) {
  * @param {HTMLElement} el - Category link clicked
  */
 function toggleCategoryLink(el) {
-  el.parentNode.classList.toggle("active");
+  const categorySlug = el.dataset.slug;
+  // Keep category filter as a single selection from the aside list.
+  updateCategoriesQueryParam([categorySlug]);
+  syncCategoryLinksWithUrl();
+  dispatchAsideCategoryFilterUpdated([
+    {
+      value: categorySlug,
+      label: el.textContent.trim(),
+    },
+  ]);
   refreshVideosSearch();
+}
+
+/**
+ * Clear selected category filter.
+ */
+function clearCategoryFilter() {
+  updateCategoriesQueryParam([]);
+  syncCategoryLinksWithUrl();
+  dispatchAsideCategoryFilterUpdated([]);
+  refreshVideosSearch();
+}
+
+/**
+ * Notify dashboard filter manager that category selection changed from aside.
+ *
+ * @param {Array<{value: string, label: string}>} categories - Selected categories.
+ */
+function dispatchAsideCategoryFilterUpdated(categories) {
+  document.dispatchEvent(
+    new CustomEvent("pod:aside-category-filter-updated", {
+      detail: { categories },
+    }),
+  );
+}
+
+/**
+ * Return selected category slugs from current URL query.
+ * Supports repeated params and comma-separated values.
+ *
+ * @returns {Array<string>} - selected category slugs
+ */
+function getSelectedCategoriesFromUrl() {
+  const searchParams = new URLSearchParams(window.location.search);
+  return searchParams
+    .getAll("categories")
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter((value) => value !== "");
+}
+
+/**
+ * Update categories query parameter in browser URL.
+ *
+ * @param {Array<string>} selectedCategories - categories to persist in URL
+ */
+function updateCategoriesQueryParam(selectedCategories) {
+  const currentParams = new URLSearchParams(window.location.search);
+  const orderedParams = new URLSearchParams();
+
+  selectedCategories.forEach((slug) => {
+    orderedParams.append("categories", slug);
+  });
+
+  currentParams.forEach((value, key) => {
+    if (key === "categories" || key === "page") return;
+    orderedParams.append(key, value);
+  });
+
+  const queryString = orderedParams.toString();
+  const newUrl = queryString
+    ? `${window.location.pathname}?${queryString}`
+    : window.location.pathname;
+  window.history.replaceState({}, "", newUrl);
+}
+
+/**
+ * Sync active category links in aside from current URL.
+ */
+function syncCategoryLinksWithUrl() {
+  const selectedCategories = new Set(getSelectedCategoriesFromUrl());
+
+  document.querySelectorAll(".categories-list-item").forEach((item) => {
+    const button = item.querySelector(".cat-title");
+    if (!button) return;
+
+    if (selectedCategories.has(button.dataset.slug)) {
+      item.classList.add("active");
+    } else {
+      item.classList.remove("active");
+    }
+  });
+
+  if (clearCategoryFilterButton) {
+    clearCategoryFilterButton.classList.toggle(
+      "d-none",
+      selectedCategories.size === 0,
+    );
+  }
 }
 
 /**
@@ -295,6 +398,7 @@ function refreshCategoriesLinks() {
       let html = parser.parseFromString(data, "text/html").body;
       categoriesListContainer.innerHTML = html.innerHTML;
       manageCategoriesLinks();
+      syncCategoryLinksWithUrl();
     })
     .catch(() => {
       showalert(
@@ -305,5 +409,10 @@ function refreshCategoriesLinks() {
     });
 }
 
+document.addEventListener("pod:dashboard-filters-updated", () => {
+  syncCategoryLinksWithUrl();
+});
+
 // Add event listeners on categories list buttons for the first time
 manageCategoriesLinks();
+syncCategoryLinksWithUrl();

--- a/pod/video/templates/videos/dashboard.html
+++ b/pod/video/templates/videos/dashboard.html
@@ -82,8 +82,8 @@
         <option value="type">{% trans "Type" %}</option>
         {% if request.user.is_superuser %}
           <option value="owner">{% trans "Owner" %}</option>
-          <option value="additional_owners">{% trans "Additional owners" %}</option>
         {% endif %}
+        <option value="additional_owners">{% trans "Additional owners" %}</option>
         <option value="description">{% trans "Description" %}</option>
         {% if request.user.is_superuser %}
           <option value="date_added">{% trans "Date added" %}</option>

--- a/pod/video/templates/videos/filter_aside_category.html
+++ b/pod/video/templates/videos/filter_aside_category.html
@@ -13,6 +13,11 @@
       <label for="search-categories-input" class="form-label">{% trans "Search" %}</label>
       <input id="search-categories-input" type="text" class="form-control" placeholder="{% trans 'Type at least 3 chars to filter categories' %}">
     </div>
+    <div class="form-group mb-2">
+      <button type="button" id="clear-category-filter-btn" class="btn btn-link p-0 d-none">
+        {% trans "Clear filters" %}
+      </button>
+    </div>
     <div class="form-group navList categories" id="collapseFilterCategory">
       <ul id="categories-list" class="categories-list">
         {% include "videos/filter_aside_categories_list.html" %}

--- a/pod/video/tests/test_category.py
+++ b/pod/video/tests/test_category.py
@@ -289,6 +289,21 @@ class TestCategory(TestCase):
         self.assertEqual(all_categories_videos[self.cat_1.slug][0], self.video.slug)
         print(" --->  test_get_categories of TestCategory: OK!")
 
+    def test_get_categories_comma_separated(self) -> None:
+        """Dashboard must support comma-separated categories query values."""
+        self.client.force_login(self.owner_user)
+        self.cat_2.video.add(self.video_2)
+        self.cat_2.save()
+
+        url = reverse("video:dashboard")
+        categories_csv = f"{self.cat_1.slug},{self.cat_2.slug}"
+        response = self.client.get(url, {"categories": categories_csv})
+        response_data = response.context
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response_data["videos"].paginator.count, 2)
+        print(" --->  test_get_categories_comma_separated of TestCategory: OK!")
+
     def test_get_categories_aside(self) -> None:
         """Test get categories for filter aside elements."""
         self.client.force_login(self.owner_user)

--- a/pod/video/tests/test_views.py
+++ b/pod/video/tests/test_views.py
@@ -86,13 +86,17 @@ class ChannelTestView(TestCase):
         self.assertEqual(response.context["channel"], self.c)
         self.assertEqual(response.context["theme"], None)
         self.assertEqual(response.context["videos"].paginator.count, 1)
-        print("   --->  test_channel_without_theme _in_argument of ChannelTestView: OK!")
+        print(
+            "   --->  test_channel_without_theme _in_argument of ChannelTestView: OK!"
+        )
         response = self.client.get("/%s/" % self.c2.slug)
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context["channel"], self.c2)
         self.assertEqual(response.context["theme"], None)
         self.assertEqual(response.context["videos"].paginator.count, 0)
-        print("   --->  test_channel_2_without_theme_in_argument of ChannelTestView: OK!")
+        print(
+            "   --->  test_channel_2_without_theme_in_argument of ChannelTestView: OK!"
+        )
         response = self.client.get("/%s/%s/" % (self.c.slug, self.theme.slug))
         self.assertEqual(response.status_code, HTTPStatus.OK)
         print("   --->  test_channel_with_theme_in_argument of ChannelTestView: OK!")
@@ -568,6 +572,17 @@ class VideosTestView(TestCase):
         response = self.client.get(url + "?type=type2&type=type1")
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context["videos"].paginator.count, 4)
+        type1_id = Type.objects.get(slug="type1").id
+        type2_id = Type.objects.get(slug="type2").id
+        response = self.client.get(url + f"?type={type1_id}")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.context["videos"].paginator.count, 3)
+        response = self.client.get(url + f"?type={type2_id}&type={type1_id}")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.context["videos"].paginator.count, 4)
+        response = self.client.get(url + f"?type={type2_id},{type1_id}")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.context["videos"].paginator.count, 4)
         # discipline
         response = self.client.get(url + "?discipline=discipline1")
         self.assertEqual(response.status_code, HTTPStatus.OK)
@@ -575,7 +590,24 @@ class VideosTestView(TestCase):
         response = self.client.get(url + "?discipline=discipline2")
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context["videos"].paginator.count, 2)
-        response = self.client.get(url + "?discipline=discipline1&discipline=discipline2")
+        response = self.client.get(
+            url + "?discipline=discipline1&discipline=discipline2"
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.context["videos"].paginator.count, 3)
+        discipline1_id = Discipline.objects.get(slug="discipline1").id
+        discipline2_id = Discipline.objects.get(slug="discipline2").id
+        response = self.client.get(url + f"?discipline={discipline1_id}")
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.context["videos"].paginator.count, 2)
+        response = self.client.get(
+            url + f"?discipline={discipline1_id}&discipline={discipline2_id}"
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(response.context["videos"].paginator.count, 3)
+        response = self.client.get(
+            url + f"?discipline={discipline1_id},{discipline2_id}"
+        )
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.context["videos"].paginator.count, 3)
         # owner
@@ -1122,7 +1154,9 @@ class video_notesTestView(TestCase):
         self.assertEqual(note.note, "coucou")
         self.assertEqual(note.timestamp, 10)
         self.assertEqual(note.status, "0")
-        print(" --->  test_video_notesTestView_post_request of video_notesTestView: OK!")
+        print(
+            " --->  test_video_notesTestView_post_request of video_notesTestView: OK!"
+        )
 
 
 class video_countTestView(TestCase):
@@ -1161,7 +1195,9 @@ class video_countTestView(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertTrue(b"ok" in response.content)
         self.assertEqual(video.get_viewcount(), 1)
-        print(" --->  test_video_countTestView_post_request of video_countTestView: OK!")
+        print(
+            " --->  test_video_countTestView_post_request of video_countTestView: OK!"
+        )
 
 
 class VideoMarkerTestView(TestCase):
@@ -1295,7 +1331,9 @@ class VideoTestUpdateOwner(TransactionTestCase):
         # Good request
         response = self.client.post(
             url,
-            json.dumps({"videos": [video1_id, video2_id], "owner": self.simple_user.id}),
+            json.dumps(
+                {"videos": [video1_id, video2_id], "owner": self.simple_user.id}
+            ),
             content_type="application/json",
         )
 

--- a/pod/video/utils.py
+++ b/pod/video/utils.py
@@ -81,7 +81,9 @@ def pagination_data(request_path, offset, limit, total_count):
     if offset + limit < total_count and limit <= total_count:
         next_url = "{}?limit={}&offset={}".format(request_path, limit, limit + offset)
     if offset - limit >= 0 and limit <= total_count:
-        previous_url = "{}?limit={}&offset={}".format(request_path, limit, offset - limit)
+        previous_url = "{}?limit={}&offset={}".format(
+            request_path, limit, offset - limit
+        )
 
     current_page = 1 if offset <= 0 else int((offset / limit)) + 1
     total = ceil(total_count / limit)
@@ -198,13 +200,20 @@ def get_videos(
     count = videos.count()
     results = list(
         map(
-            lambda v: {"id": v.id, "title": v.title, "thumbnail": v.get_thumbnail_url()},
+            lambda v: {
+                "id": v.id,
+                "title": v.title,
+                "thumbnail": v.get_thumbnail_url(),
+            },
             videos[offset : limit + offset],
         )
     )
 
     next_url, previous_url, page_infos = pagination_data(
-        reverse("video:filter_videos", kwargs={"user_id": user_id}), offset, limit, count
+        reverse("video:filter_videos", kwargs={"user_id": user_id}),
+        offset,
+        limit,
+        count,
     )
 
     response = {
@@ -305,7 +314,9 @@ def get_storage_path_video(instance, filename) -> str:
     Video.get_storage_path_video(instance, filename)
 
 
-def verify_field_length(field, field_name: str = "title", max_length: int = 100) -> list:
+def verify_field_length(
+    field, field_name: str = "title", max_length: int = 100
+) -> list:
     """Check field length, and return message."""
     msg = list()
     if not field or field == "":
@@ -380,13 +391,15 @@ def apply_search_order_limit_for_taxonomies(
 ):
     """
     Apply the search filter (on field_name), order, and limit
-    for taxonomies returning id, field_name, and video_count.
+    for taxonomies returning id, slug, field_name, and video_count.
     """
     if search_term:
         search_filter = {f"{field_name}__icontains": search_term}
         qs = qs.filter(**search_filter)
     return list(
-        qs.order_by(order_by_field).values("id", field_name, "video_count")[:limit]
+        qs.order_by(order_by_field).values("id", "slug", field_name, "video_count")[
+            :limit
+        ]
     )
 
 
@@ -397,7 +410,7 @@ def get_filtered_categories_for_user(user, search_term=None, limit=20):
     qs = Category.objects.filter(owner=user).prefetch_related("video")
     if search_term:
         qs = qs.filter(title__icontains=search_term)
-    return list(qs.order_by("title").values("id", "title")[:limit])
+    return list(qs.order_by("title").values("id", "slug", "title")[:limit])
 
 
 def get_filtered_types_for_videos(user_videos, search_term=None, limit=20):
@@ -459,7 +472,7 @@ def get_filtered_owners_for_videos(user_videos, search_term=None, limit=20):
         )
 
     return list(
-        users_qs.order_by("username").values("id", "username", "first_name", "last_name")[
-            :limit
-        ]
+        users_qs.order_by("username").values(
+            "id", "username", "first_name", "last_name"
+        )[:limit]
     )

--- a/pod/video/views.py
+++ b/pod/video/views.py
@@ -464,7 +464,9 @@ def channel_edit(request, slug):
     if request.user not in channel.owners.all() and not (
         request.user.is_superuser or request.user.has_perm("video.change_channel")
     ):
-        messages.add_message(request, messages.ERROR, _("You cannot edit this channel."))
+        messages.add_message(
+            request, messages.ERROR, _("You cannot edit this channel.")
+        )
         raise PermissionDenied
     channel_form = ChannelForm(
         instance=channel,
@@ -511,7 +513,9 @@ def theme_edit(request, slug):
     if request.user not in channel.owners.all() and not (
         request.user.is_superuser or request.user.has_perm("video.change_theme")
     ):
-        messages.add_message(request, messages.ERROR, _("You cannot edit this channel."))
+        messages.add_message(
+            request, messages.ERROR, _("You cannot edit this channel.")
+        )
         raise PermissionDenied
 
     if is_ajax(request):
@@ -622,12 +626,17 @@ def dashboard(request):
     videos_list = get_videos_for_owner(request)
 
     if USER_VIDEO_CATEGORY:
-        categories = Category.objects.prefetch_related("video").filter(owner=request.user)
+        categories = Category.objects.prefetch_related("video").filter(
+            owner=request.user
+        )
         selected_categories = request.GET.getlist("categories")
 
         if selected_categories:
-            category_video_ids = categories.filter(
-                slug__in=selected_categories
+            category_video_ids = filter_queryset_by_ids_or_slugs(
+                categories,
+                selected_categories,
+                "id",
+                "slug",
             ).values_list("video", flat=True)
 
             videos_list = videos_list.filter(pk__in=category_video_ids)
@@ -955,6 +964,54 @@ def get_paginated_videos(paginator, page):
         return paginator.page(paginator.num_pages)
 
 
+def get_ids_and_slugs_from_query_values(selected_values):
+    """
+    Split selected GET values into IDs and slugs.
+
+    Values can be received either as repeated query params
+    (e.g. ``?type=1&type=webinar``) or as comma-separated values
+    (e.g. ``?type=1,webinar``).
+    """
+    ids = []
+    slugs = []
+
+    for raw_value in selected_values:
+        for value in str(raw_value).split(","):
+            value = value.strip()
+            if not value:
+                continue
+            if value.isdigit():
+                ids.append(int(value))
+            slugs.append(value)
+
+    return ids, slugs
+
+
+def filter_queryset_by_ids_or_slugs(
+    queryset: QuerySet, selected_values, id_lookup: str, slug_lookup: str
+) -> QuerySet:
+    """Filter a queryset from selected values that may contain IDs and/or slugs."""
+    selected_ids, selected_slugs = get_ids_and_slugs_from_query_values(selected_values)
+    lookup_filter = Q()
+
+    if selected_ids:
+        lookup_filter |= Q(**{f"{id_lookup}__in": selected_ids})
+    if selected_slugs:
+        lookup_filter |= Q(**{f"{slug_lookup}__in": selected_slugs})
+
+    if not lookup_filter.children:
+        return queryset
+
+    return queryset.filter(lookup_filter)
+
+
+def filter_queryset_by_all_tags(queryset: QuerySet, tags_selected) -> QuerySet:
+    """Apply AND filtering on tags: all selected tags must be present."""
+    for tag_slug in tags_selected:
+        queryset = queryset.filter(tags__slug=tag_slug)
+    return queryset
+
+
 def get_filtered_videos_list(request, videos_list):
     """Return filtered videos list by GET parameters using AND logic."""
     title_query = request.GET.get("title")
@@ -969,17 +1026,20 @@ def get_filtered_videos_list(request, videos_list):
             Q(title_en__icontains=title_query) | Q(title_fr__icontains=title_query)
         )
     if types_selected:
-        videos_list = videos_list.filter(type__slug__in=types_selected)
+        videos_list = filter_queryset_by_ids_or_slugs(
+            videos_list, types_selected, "type_id", "type__slug"
+        )
     if disciplines_selected:
-        videos_list = videos_list.filter(discipline__slug__in=disciplines_selected)
+        videos_list = filter_queryset_by_ids_or_slugs(
+            videos_list, disciplines_selected, "discipline__id", "discipline__slug"
+        )
     if request.user and owner_is_searchable(request.user) and owners_selected:
         videos_list = videos_list.filter(
             Q(owner__username__in=owners_selected)
             | Q(additional_owners__username__in=owners_selected)
         )
     if tags_selected:
-        for tag_slug in tags_selected:
-            videos_list = videos_list.filter(tags__slug=tag_slug)
+        videos_list = filter_queryset_by_all_tags(videos_list, tags_selected)
     if cursus_selected:
         videos_list = videos_list.filter(cursus__in=cursus_selected)
     return videos_list.distinct()
@@ -1097,7 +1157,9 @@ def get_video_access(request, video, slug_private):
         # or is_password_protected
     )
     if is_access_protected:
-        access_granted_for_private = slug_private and slug_private == video.get_hashkey()
+        access_granted_for_private = (
+            slug_private and slug_private == video.get_hashkey()
+        )
         access_granted_for_draft = request.user.is_authenticated and (
             request.user == video.owner
             or request.user.is_superuser
@@ -1180,7 +1242,9 @@ def video(request, slug, slug_c=None, slug_t=None, slug_private=None):
             raise PermissionDenied(
                 _("You cannot access this playlist because it is private.")
             )
-    return render_video(request, id, slug_c, slug_t, slug_private, template_video, params)
+    return render_video(
+        request, id, slug_c, slug_t, slug_private, template_video, params
+    )
 
 
 def toggle_render_video_user_can_see_video(
@@ -1201,7 +1265,8 @@ def toggle_render_video_user_can_see_video(
                 slug_private == video.get_hashkey()
                 or slug_private
                 in [
-                    str(tok.token) for tok in VideoAccessToken.objects.filter(video=video)
+                    str(tok.token)
+                    for tok in VideoAccessToken.objects.filter(video=video)
                 ]
             )
         )
@@ -1388,7 +1453,9 @@ def video_edit(request, slug=None):
         video
         and request.user != video.owner
         and (
-            not (request.user.is_superuser or request.user.has_perm("video.change_video"))
+            not (
+                request.user.is_superuser or request.user.has_perm("video.change_video")
+            )
         )
         and (request.user not in video.additional_owners.all())
     ):
@@ -1529,7 +1596,9 @@ def video_is_deletable(request, video) -> bool:
     if request.user != video.owner and not (
         request.user.is_superuser or request.user.has_perm("video.delete_video")
     ):
-        messages.add_message(request, messages.ERROR, _("You cannot delete this media."))
+        messages.add_message(
+            request, messages.ERROR, _("You cannot delete this media.")
+        )
         raise PermissionDenied
 
     if WEBTV_MODE:
@@ -1561,7 +1630,9 @@ def video_edit_access_tokens(request: WSGIRequest, slug: str = None):
         video
         and request.user != video.owner
         and (
-            not (request.user.is_superuser or request.user.has_perm("video.change_video"))
+            not (
+                request.user.is_superuser or request.user.has_perm("video.change_video")
+            )
         )
         and (request.user not in video.additional_owners.all())
     ):
@@ -1608,7 +1679,9 @@ def delete_token(request, video: Video, token: VideoAccessToken):
     try:
         uuid.UUID(str(token))
         VideoAccessToken.objects.get(video=video, token=token).delete()
-        messages.add_message(request, messages.SUCCESS, _("The token has been deleted."))
+        messages.add_message(
+            request, messages.SUCCESS, _("The token has been deleted.")
+        )
     except (ValueError, ObjectDoesNotExist):
         messages.add_message(request, messages.ERROR, _("Token not found."))
 
@@ -1619,7 +1692,9 @@ def update_token(request, video: Video, token: VideoAccessToken):
         Token = VideoAccessToken.objects.get(video=video, token=token)
         Token.name = request.POST.get("name")
         Token.save()
-        messages.add_message(request, messages.SUCCESS, _("The token has been updated."))
+        messages.add_message(
+            request, messages.SUCCESS, _("The token has been updated.")
+        )
     except (ValueError, ObjectDoesNotExist):
         messages.add_message(request, messages.ERROR, _("Token not found."))
 
@@ -1640,11 +1715,15 @@ def video_transcript(request, slug=None):
         video
         and request.user != video.owner
         and (
-            not (request.user.is_superuser or request.user.has_perm("video.change_video"))
+            not (
+                request.user.is_superuser or request.user.has_perm("video.change_video")
+            )
         )
         and (request.user not in video.additional_owners.all())
     ):
-        messages.add_message(request, messages.ERROR, _("You cannot manage this video."))
+        messages.add_message(
+            request, messages.ERROR, _("You cannot manage this video.")
+        )
         raise PermissionDenied
 
     if not video.encoded or video.encoding_in_progress is True:
@@ -1960,7 +2039,9 @@ def video_note_form_case(request, params):
         and idNote is not None
         and (
             (request.method == "POST" and request.POST.get("action") == "form_com_edit")
-            or (request.method == "GET" and request.GET.get("action") == "form_com_edit")
+            or (
+                request.method == "GET" and request.GET.get("action") == "form_com_edit"
+            )
         )
     ):
         can_edit_or_remove_note_or_com(request, com, "edit")
@@ -2054,7 +2135,9 @@ def video_note_save(request, slug):
         q.update({"video": video.id})
         form = AdvancedNotesForm(q)
         noteToEdit = note
-    elif request.method == "POST" and (request.POST.get("action").startswith("save_com")):
+    elif request.method == "POST" and (
+        request.POST.get("action").startswith("save_com")
+    ):
         form = NoteCommentsForm(request.POST)
         comToEdit = {
             "save_com": com,
@@ -2134,7 +2217,9 @@ def video_note_save_form_valid(request, video, params):
         com.status = request.POST.get("status")
         com.modified_on = timezone.now()
         com.save()
-        messages.add_message(request, messages.INFO, _("The comment has been modified."))
+        messages.add_message(
+            request, messages.INFO, _("The comment has been modified.")
+        )
         noteToDisplay, comToDisplay = note, get_com_tree(com)
         listNotesCom = get_adv_note_com_list(request, idNote)
         dictComments = get_com_coms_dict(request, listNotesCom)
@@ -2158,7 +2243,9 @@ def video_note_save_form_valid(request, video, params):
         dictComments = get_com_coms_dict(request, listNotesCom)
     # Saving a note after an edit
     elif (
-        idCom is None and idNote is not None and request.POST.get("action") == "save_note"
+        idCom is None
+        and idNote is not None
+        and request.POST.get("action") == "save_note"
     ):
         note.note = request.POST.get("note")
         note.status = request.POST.get("status")
@@ -2167,7 +2254,9 @@ def video_note_save_form_valid(request, video, params):
         messages.add_message(request, messages.INFO, _("Your note has been modified."))
     # Saving a new com for a note
     elif (
-        idCom is None and idNote is not None and request.POST.get("action") == "save_com"
+        idCom is None
+        and idNote is not None
+        and request.POST.get("action") == "save_com"
     ):
         com = NoteComments.objects.create(
             user=request.user,
@@ -2251,7 +2340,9 @@ def video_note_remove(request, slug):
         if idNote and request.POST.get("action") == "remove_note":
             can_edit_or_remove_note_or_com(request, note, "delete")
             note.delete()
-            messages.add_message(request, messages.INFO, _("The note has been deleted."))
+            messages.add_message(
+                request, messages.INFO, _("The note has been deleted.")
+            )
             listNotesCom, comToDisplay = None, None
         elif idNote and idCom and request.POST.get("action") == "remove_com":
             can_edit_or_remove_note_or_com(request, com, "delete")
@@ -2365,8 +2456,11 @@ def video_note_download(request, slug):
         str(_("Content")),
     ]
     response = HttpResponse(content_type="text/csv")
-    response["Content-Disposition"] = "attachment; \
-        filename=%s_notes_and_comments.csv" % slug
+    response["Content-Disposition"] = (
+        "attachment; \
+        filename=%s_notes_and_comments.csv"
+        % slug
+    )
     df.to_csv(
         path_or_buf=response,
         sep="|",
@@ -2573,7 +2667,9 @@ def get_all_views_count(v_id, date_filter=date.today()):
     all_views["year"] = count if count else 0
 
     # view count since video was created
-    count = ViewCount.objects.filter(video_id=v_id).aggregate(Sum("count"))["count__sum"]
+    count = ViewCount.objects.filter(video_id=v_id).aggregate(Sum("count"))[
+        "count__sum"
+    ]
     all_views["since_created"] = count if count else 0
 
     # playlist addition in day
@@ -2792,7 +2888,9 @@ def stats_view(request, slug=None, slug_t=None):
         )
 
         min_date = (
-            get_available_videos().aggregate(Min("date_added"))["date_added__min"].date()
+            get_available_videos()
+            .aggregate(Min("date_added"))["date_added__min"]
+            .date()
         )
         data.append({"min_date": min_date})
 
@@ -2990,7 +3088,9 @@ def get_children_comment(request, comment_id, video_slug):
         parent_comment = (
             Comment.objects.filter(video=v, id=comment_id)
             .annotate(
-                author_name=Concat("author__first_name", Value(" "), "author__last_name")
+                author_name=Concat(
+                    "author__first_name", Value(" "), "author__last_name"
+                )
             )
             .annotate(nbr_child=Count("children", distinct=True))
             .annotate(
@@ -3044,7 +3144,9 @@ def get_comments(request, video_slug):
             .order_by("added")
             .annotate(nbr_vote=Count("vote", distinct=True))
             .annotate(
-                author_name=Concat("author__first_name", Value(" "), "author__last_name")
+                author_name=Concat(
+                    "author__first_name", Value(" "), "author__last_name"
+                )
             )
             .annotate(nbr_child=Count("children", distinct=True))
             .annotate(
@@ -3097,7 +3199,9 @@ def delete_comment(request, video_slug, comment_id):
 
     if in_maintenance():
         return HttpResponseForbidden(
-            _("Sorry, you can’t delete a comment while the server is under maintenance.")
+            _(
+                "Sorry, you can’t delete a comment while the server is under maintenance."
+            )
         )
 
     if c.author == c_user or v.owner == c_user or c_user.is_superuser:
@@ -3307,7 +3411,9 @@ def add_category(request):
         data_context["videos"] = videos
 
         if request.GET.get("page"):
-            return render(request, "videos/category_modal_video_list.html", data_context)
+            return render(
+                request, "videos/category_modal_video_list.html", data_context
+            )
 
         data_context = {
             "modal_action": "add",
@@ -3490,7 +3596,9 @@ class PodChunkedUploadView(ChunkedUploadView):
     def check_permissions(self, request):
         if not request.user.is_authenticated:
             return False
-        elif RESTRICT_EDIT_VIDEO_ACCESS_TO_STAFF_ONLY and request.user.is_staff is False:
+        elif (
+            RESTRICT_EDIT_VIDEO_ACCESS_TO_STAFF_ONLY and request.user.is_staff is False
+        ):
             return False
         pass
 
@@ -3502,7 +3610,9 @@ class PodChunkedUploadCompleteView(ChunkedUploadCompleteView):
     def check_permissions(self, request):
         if not request.user.is_authenticated:
             return False
-        elif RESTRICT_EDIT_VIDEO_ACCESS_TO_STAFF_ONLY and request.user.is_staff is False:
+        elif (
+            RESTRICT_EDIT_VIDEO_ACCESS_TO_STAFF_ONLY and request.user.is_staff is False
+        ):
             return False
         pass
 
@@ -3605,7 +3715,9 @@ def filter_owners(request):
         return auth_get_owners(search, limit, offset)
 
     except Exception as err:
-        return JsonResponse({"success": False, "detail": "Syntax error: {0}".format(err)})
+        return JsonResponse(
+            {"success": False, "detail": "Syntax error: {0}".format(err)}
+        )
 
 
 @login_required(redirect_field_name="referrer")
@@ -3619,7 +3731,9 @@ def filter_videos(request, user_id):
         return video_get_videos(title, user_id, search, limit, offset)
 
     except Exception as err:
-        return JsonResponse({"success": False, "detail": "Syntax error: {0}".format(err)})
+        return JsonResponse(
+            {"success": False, "detail": "Syntax error: {0}".format(err)}
+        )
 
 
 def get_serialized_channels(request: WSGIRequest, channels: QueryDict) -> dict:
@@ -3714,7 +3828,9 @@ def get_channels_for_specific_channel_tab(request: WSGIRequest) -> JsonResponse:
     return JsonResponse(response, safe=False)
 
 
-def get_theme_list_for_specific_channel(request: WSGIRequest, slug: str) -> JsonResponse:
+def get_theme_list_for_specific_channel(
+    request: WSGIRequest, slug: str
+) -> JsonResponse:
     """
     Get the themes for a specific channel.
 
@@ -3732,7 +3848,9 @@ def get_theme_list_for_specific_channel(request: WSGIRequest, slug: str) -> Json
 def available_filters(request):
     """API endpoint to return all available video filters based on user's videos."""
     user_videos = get_videos_for_owner(request)
-    categories_qs = Category.objects.prefetch_related("video").filter(owner=request.user)
+    categories_qs = Category.objects.prefetch_related("video").filter(
+        owner=request.user
+    )
     categories = list(categories_qs.values("id", "title")[:20])
     types_qs = (
         Type.objects.filter(video__in=user_videos)
@@ -3801,7 +3919,9 @@ def available_filter_by_type(request, filter_name):
             uv, term, lim
         ),
         "tag": lambda req, uv, term, lim: get_filtered_tags_for_videos(uv, term, lim),
-        "owner": lambda req, uv, term, lim: get_filtered_owners_for_videos(uv, term, lim),
+        "owner": lambda req, uv, term, lim: get_filtered_owners_for_videos(
+            uv, term, lim
+        ),
     }
 
     try:

--- a/pod/video_encode_transcript/admin.py
+++ b/pod/video_encode_transcript/admin.py
@@ -188,14 +188,17 @@ class RunnerManagerAdmin(admin.ModelAdmin):
     list_display = (
         "id",
         "name",
+        "active_badge",
         "priority",
         "url",
+        "runner_admin_link",
         "site",
     )
     list_display_links = ("id", "name")
     ordering = ("-id", "priority")
     readonly_fields = []
     search_fields = ["id", "name", "site"]
+    list_filter = ("is_active", "site")
 
     def get_urls(self):
         """Register the custom admin endpoint used to test runner connectivity."""
@@ -228,6 +231,30 @@ class RunnerManagerAdmin(admin.ModelAdmin):
         return reverse(
             "admin:video_encode_transcript_runnermanager_change",
             args=[runner_manager.pk],
+        )
+
+    def _runner_admin_url(self, runner_manager: RunnerManager) -> str:
+        """Build runner manager admin URL, handling optional trailing slash."""
+        return f"{runner_manager.url.rstrip('/')}/admin"
+
+    @admin.display(description=_("Status"), ordering="is_active")
+    def active_badge(self, obj):
+        """Render runner manager activation status with a colored badge."""
+        if obj.is_active:
+            return format_html('<span class="badge bg-success">{}</span>', _("Active"))
+        return format_html('<span class="badge bg-secondary">{}</span>', _("Inactive"))
+
+    @admin.display(description=_("Runner administration"))
+    def runner_admin_link(self, obj):
+        """Render link to the remote runner manager administration."""
+        return format_html(
+            '<a class="runner-admin-list-link" href="{}" target="_blank" rel="noopener noreferrer" title="{}">'
+            '<i class="bi bi-box-arrow-up-right" aria-hidden="true"></i>'
+            '<span class="visually-hidden">{}</span>'
+            "</a>",
+            self._runner_admin_url(obj),
+            _("Open runner administration"),
+            _("Open runner administration"),
         )
 
     def test_connection_view(self, request, object_id):
@@ -345,7 +372,15 @@ class TaskAdmin(admin.ModelAdmin):
         "runner_manager",
         "script_output",
     )
-    search_fields = ["id", "video__id", "runner_manager__name"]
+    search_fields = [
+        "id",
+        "task_id",
+        "video__id",
+        "video__title",
+        "recording__id",
+        "recording__title",
+        "runner_manager__name",
+    ]
     actions = ["relaunch_selected_tasks"]
 
     def get_readonly_fields(self, request, obj=None):
@@ -358,35 +393,35 @@ class TaskAdmin(admin.ModelAdmin):
         """Return a short label for list display."""
         return Truncator(label).chars(50)
 
-    @admin.display(description="Video ID", ordering="video__id")
+    @admin.display(description=_("Video ID"), ordering="video__id")
     def video_id_display(self, obj):
         """Display the related video identifier, or '-' when absent."""
         if not obj.video_id:
             return "-"
         return obj.video_id
 
-    @admin.display(description="Video", ordering="video__title")
+    @admin.display(description=_("Video"), ordering="video__title")
     def video_label(self, obj):
         """Display a truncated video title, or '-' when no video is linked."""
         if not obj.video_id:
             return "-"
         return self._truncate_label(obj.video.title)
 
-    @admin.display(description="Recording ID", ordering="recording__id")
+    @admin.display(description=_("Recording ID"), ordering="recording__id")
     def recording_id_display(self, obj):
         """Display the related recording identifier, or '-' when absent."""
         if not obj.recording_id:
             return "-"
         return obj.recording_id
 
-    @admin.display(description="Recording", ordering="recording__title")
+    @admin.display(description=_("Recording"), ordering="recording__title")
     def recording_label(self, obj):
         """Display a truncated recording title, or '-' when not linked."""
         if not obj.recording_id:
             return "-"
         return self._truncate_label(obj.recording.title)
 
-    @admin.display(description="Statut", ordering="status")
+    @admin.display(description=_("Status"), ordering="status")
     def status_badge(self, obj):
         """Render task status with a colored badge in list display."""
         badge_map = {
@@ -458,7 +493,8 @@ class TaskAdmin(admin.ModelAdmin):
         refresh_pending_task_ranks()
         self.message_user(
             request,
-            _("%(count)s task(s) relaunched immediately.") % {"count": relaunched_count},
+            _("%(count)s task(s) relaunched immediately.")
+            % {"count": relaunched_count},
             level=messages.SUCCESS,
         )
         if skipped_count:

--- a/pod/video_encode_transcript/management/commands/process_tasks.py
+++ b/pod/video_encode_transcript/management/commands/process_tasks.py
@@ -18,7 +18,7 @@ Execution flow:
      (non-students first), then by submission date.
    - `studio` tasks are processed by submission date.
    - Each type is capped by `--max-tasks`.
-5. Submit tasks to available runner managers (ordered by manager priority):
+5. Submit tasks to available active runner managers (ordered by manager priority):
    - Build payload (`source_url`, `notify_url`, parameters, metadata).
    - Try each runner until one accepts the task.
    - Persist `task_id`, `runner_manager`, and returned status in Pod.
@@ -26,7 +26,7 @@ Execution flow:
    `RM_TASKS_DELETED_AFTER_DAYS`.
 
 Important behavior:
-- If no runner manager exists for the site, submission is skipped.
+- If no active runner manager exists for the site, submission is skipped.
 - Network/API errors on one runner do not stop processing; the command tries
 the next configured runner.
 - Cleanup is skipped when `RM_TASKS_DELETED_AFTER_DAYS` is missing, invalid,
@@ -192,6 +192,14 @@ class Command(BaseCommand):
                 return None
         return Site.objects.get_current()
 
+    def _get_available_runner_managers(self, site: Site) -> list[RunnerManager]:
+        """Return active runner managers for a site, ordered by priority."""
+        return list(
+            RunnerManager.objects.filter(site=site, is_active=True).order_by(
+                "priority", "id"
+            )
+        )
+
     def _check_task_status(self, task: Task) -> str | None:
         """
         Check the status of a running task from the runner manager.
@@ -204,6 +212,13 @@ class Command(BaseCommand):
         """
         if not task.runner_manager or not task.task_id:
             log.warning(f"Task {task.id} has no runner_manager or task_id")
+            return None
+        if not task.runner_manager.is_active:
+            log.warning(
+                "Task %s is linked to inactive runner manager %s, status check skipped",
+                task.id,
+                task.runner_manager.name,
+            )
             return None
 
         try:
@@ -346,7 +361,9 @@ class Command(BaseCommand):
                 self.print_log(
                     f"Processing studio task {task.id} for recording {recording.id}"
                 )
-                result = self._submit_studio_task(recording, task, site, runner_managers)
+                result = self._submit_studio_task(
+                    recording, task, site, runner_managers
+                )
                 if result:
                     success_count += 1
                     self.print_success(
@@ -514,7 +531,9 @@ class Command(BaseCommand):
             return
 
         self.print_log(f"Found {all_pending_tasks.count()} pending encoding task(s)")
-        self.print_log(f"Found {all_pending_studio_tasks.count()} pending studio task(s)")
+        self.print_log(
+            f"Found {all_pending_studio_tasks.count()} pending studio task(s)"
+        )
         self.print_log(
             f"Found {all_pending_transcription_tasks.count()} pending transcription task(s)"
         )
@@ -526,21 +545,23 @@ class Command(BaseCommand):
             all_pending_transcription_tasks, max_tasks
         )
 
-        self.print_log(f"Processing {len(pending_tasks)} task(s) after priority sorting")
-
-        # Get available runner managers for this site
-        runner_managers = list(
-            RunnerManager.objects.filter(site=site).order_by("priority")
+        self.print_log(
+            f"Processing {len(pending_tasks)} task(s) after priority sorting"
         )
+
+        # Get available active runner managers for this site
+        runner_managers = self._get_available_runner_managers(site)
 
         if not runner_managers:
             self.print_warning(
-                f"No runner manager defined for site {site.domain}. Cannot process tasks."
+                f"No active runner manager defined for site {site.domain}. Cannot process tasks."
             )
             return
 
         # Process each pending task
-        success_count_encoding = self._process_tasks(pending_tasks, site, runner_managers)
+        success_count_encoding = self._process_tasks(
+            pending_tasks, site, runner_managers
+        )
         success_count_studio = self._process_studio_tasks(
             pending_studio_tasks, site, runner_managers
         )

--- a/pod/video_encode_transcript/models.py
+++ b/pod/video_encode_transcript/models.py
@@ -136,7 +136,8 @@ class VideoRendition(models.Model):
             if not vb.isdigit():
                 msg = "Error in %s: " % _(name)
                 raise ValidationError(
-                    "%s %s" % (msg, VideoRendition._meta.get_field(field_name).help_text)
+                    "%s %s"
+                    % (msg, VideoRendition._meta.get_field(field_name).help_text)
                 )
 
     def clean_bitrate(self) -> None:
@@ -148,7 +149,9 @@ class VideoRendition(models.Model):
     def clean(self) -> None:
         """Clean the fields of the VideoRendition model."""
         if self.resolution and "x" not in self.resolution:
-            raise ValidationError(VideoRendition._meta.get_field("resolution").help_text)
+            raise ValidationError(
+                VideoRendition._meta.get_field("resolution").help_text
+            )
         else:
             res = self.resolution.replace("x", "")
             if not res.isdigit():
@@ -466,6 +469,15 @@ class RunnerManager(models.Model):
             "Priority of the runner manager. Lower values indicate higher priority."
         ),
         default=1,
+    )
+
+    # Activation status
+    is_active = models.BooleanField(
+        default=True,
+        verbose_name=_("Active"),
+        help_text=_(
+            "If checked, this runner manager can be used to process tasks."
+        ),
     )
 
     # Runner manager URL

--- a/pod/video_encode_transcript/runner_manager.py
+++ b/pod/video_encode_transcript/runner_manager.py
@@ -244,9 +244,11 @@ def _rotate_same_priority_runner_managers(
 
 
 def _get_runner_managers(site: Site) -> list[RunnerManager]:
-    """Return site runner managers ordered by priority with round-robin per priority."""
+    """Return active site runner managers ordered by priority with round-robin per priority."""
     ordered_runner_managers = list(
-        RunnerManager.objects.filter(site=site).order_by("priority", "id")
+        RunnerManager.objects.filter(site=site, is_active=True).order_by(
+            "priority", "id"
+        )
     )
     if len(ordered_runner_managers) <= 1:
         return ordered_runner_managers
@@ -438,17 +440,20 @@ def _send_task_to_runner_manager(
     """
 
     try:
+        # Keep a local pending row even when no runner is currently available.
+        # This allows process_tasks to retry submission later.
+        video_id, recording_id = _update_task_pending(source_type, source_id, task_type)
+
         site = Site.objects.get_current()
         runner_managers_list = _get_runner_managers(site)
         if not runner_managers_list:
-            log.error(
-                f"No runner manager defined for site {site.domain}. Cannot process {task_type} for {source_type} {source_id}."
+            log.warning(
+                f"No active runner manager defined for site {site.domain}. Cannot process {task_type} for {source_type} {source_id}."
             )
             return False
 
-        # Build payload and create/set pending task
+        # Build payload and try immediate submission
         data = _prepare_task_data(source_url, base_url, parameters, task_type)
-        video_id, recording_id = _update_task_pending(source_type, source_id, task_type)
 
         # Try each runner manager by priority and stop on the first healthy one.
         for rm in runner_managers_list:
@@ -502,7 +507,8 @@ def encode_video(video_id: int) -> None:
 
     except Exception as exc:
         log.error(
-            'Error to encode video "%(id)s": %(exc)s' % {"id": video_id, "exc": str(exc)}
+            'Error to encode video "%(id)s": %(exc)s'
+            % {"id": video_id, "exc": str(exc)}
         )
 
 

--- a/pod/video_encode_transcript/runner_manager_utils.py
+++ b/pod/video_encode_transcript/runner_manager_utils.py
@@ -301,6 +301,7 @@ def _get_ordered_thumbnail_entries(
     info_encode_thumbnail: EncodedThumbnailInfo | list[EncodedThumbnailInfo],
 ) -> list[EncodedThumbnailInfo]:
     """Return thumbnail entries with the preferred (middle) candidate first."""
+    # Accept both a single thumbnail payload and a list from different callers.
     thumbnail_entries: list[EncodedThumbnailInfo]
     if isinstance(info_encode_thumbnail, list):
         thumbnail_entries = info_encode_thumbnail
@@ -310,7 +311,8 @@ def _get_ordered_thumbnail_entries(
     if not thumbnail_entries:
         return []
 
-    # Try to normalize list order using the trailing index in filenames (e.g. xx_0.png).
+    # Build sortable tuples: (numeric filename suffix, original position, payload).
+    # Example matched suffix: "thumb_2.png" -> 2.
     indexed_entries: list[tuple[int | None, int, EncodedThumbnailInfo]] = []
     for position, thumbnail_data in enumerate(thumbnail_entries):
         filename = thumbnail_data.get("filename", "")
@@ -318,11 +320,13 @@ def _get_ordered_thumbnail_entries(
         index = int(match.group(1)) if match else None
         indexed_entries.append((index, position, thumbnail_data))
 
-    has_numeric_indexes = any(index is not None for index, _, _ in indexed_entries)
+    has_numeric_indexes = any(entry[0] is not None for entry in indexed_entries)
     if has_numeric_indexes:
+        # Keep numerically indexed files first (ordered by index), then fallback entries
+        # without index in their original input order.
         thumbnail_entries = [
-            thumbnail_data
-            for _, _, thumbnail_data in sorted(
+            entry[2]
+            for entry in sorted(
                 indexed_entries,
                 key=lambda item: (
                     item[0] is None,
@@ -331,6 +335,7 @@ def _get_ordered_thumbnail_entries(
             )
         ]
 
+    # Move the middle candidate to the first position as the preferred thumbnail.
     preferred_index = len(thumbnail_entries) // 2
     ordered_entries = [thumbnail_entries[preferred_index]]
     ordered_entries.extend(

--- a/pod/video_encode_transcript/runner_manager_utils.py
+++ b/pod/video_encode_transcript/runner_manager_utils.py
@@ -39,7 +39,7 @@ from .utils import (
 
 if getattr(settings, "USE_PODFILE", False):
     FILEPICKER = True
-    from pod.podfile.models import CustomImageModel, UserFolder
+    from pod.podfile.models import CustomImageModel
 else:
     FILEPICKER = False
     from pod.main.models import CustomImageModel
@@ -232,7 +232,15 @@ def remote_audio_part(
         msg += import_remote_audio(
             info_video["encode_audio"], output_dir, video_to_encode
         )
-        if info_video["has_stream_thumbnail"] and info_video.get("encode_thumbnail"):
+        # Avoid importing the same thumbnail twice when both audio and video are present.
+        if (
+            info_video["has_stream_thumbnail"]
+            and info_video.get("encode_thumbnail")
+            and not (
+                info_video.get("has_stream_video", False)
+                and info_video.get("encode_video")
+            )
+        ):
             msg += import_remote_thumbnail(
                 info_video["encode_thumbnail"], output_dir, video_to_encode
             )
@@ -263,7 +271,9 @@ def remote_video_part(
                 )
                 video_to_encode.save()
                 msg += "\n- existing overview:\n%s" % overview_vtt
-                add_encoding_log(video_id, "attach existing overview: %s" % overview_vtt)
+                add_encoding_log(
+                    video_id, "attach existing overview: %s" % overview_vtt
+                )
             except Exception as err:
                 err_msg = f"Error attaching existing overview: {err}"
                 add_encoding_log(video_id, err_msg)
@@ -275,7 +285,9 @@ def remote_video_part(
                 info_video["encode_thumbnail"], output_dir, video_to_encode
             )
         else:
-            add_encoding_log(video_id, "No thumbnail info in json; skip thumbnail attach")
+            add_encoding_log(
+                video_id, "No thumbnail info in json; skip thumbnail attach"
+            )
     elif info_video["has_stream_video"] or info_video.get("encode_video"):
         msg += "\n- has stream video but not info video "
         add_encoding_log(video_to_encode.id, msg)
@@ -285,61 +297,118 @@ def remote_video_part(
     return msg
 
 
+def _get_ordered_thumbnail_entries(
+    info_encode_thumbnail: EncodedThumbnailInfo | list[EncodedThumbnailInfo],
+) -> list[EncodedThumbnailInfo]:
+    """Return thumbnail entries with the preferred (middle) candidate first."""
+    thumbnail_entries: list[EncodedThumbnailInfo]
+    if isinstance(info_encode_thumbnail, list):
+        thumbnail_entries = info_encode_thumbnail
+    else:
+        thumbnail_entries = [info_encode_thumbnail]
+
+    if not thumbnail_entries:
+        return []
+
+    # Try to normalize list order using the trailing index in filenames (e.g. xx_0.png).
+    indexed_entries: list[tuple[int | None, int, EncodedThumbnailInfo]] = []
+    for position, thumbnail_data in enumerate(thumbnail_entries):
+        filename = thumbnail_data.get("filename", "")
+        match = re.search(r"_(\d+)(?=\.[^.]+$)", os.path.basename(filename))
+        index = int(match.group(1)) if match else None
+        indexed_entries.append((index, position, thumbnail_data))
+
+    has_numeric_indexes = any(index is not None for index, _, _ in indexed_entries)
+    if has_numeric_indexes:
+        thumbnail_entries = [
+            thumbnail_data
+            for _, _, thumbnail_data in sorted(
+                indexed_entries,
+                key=lambda item: (
+                    item[0] is None,
+                    item[0] if item[0] is not None else item[1],
+                ),
+            )
+        ]
+
+    preferred_index = len(thumbnail_entries) // 2
+    ordered_entries = [thumbnail_entries[preferred_index]]
+    ordered_entries.extend(
+        thumbnail_data
+        for pos, thumbnail_data in enumerate(thumbnail_entries)
+        if pos != preferred_index
+    )
+    return ordered_entries
+
+
+def _save_thumbnail_for_video(
+    video_to_encode: Video,
+    thumbnailfilename: str,
+    thumbnail_name: str,
+) -> CustomImageModel:
+    """Persist one thumbnail file and return the stored image object."""
+    if FILEPICKER:
+        videodir = video_to_encode.get_or_create_video_folder()
+        thumbnail = CustomImageModel(folder=videodir, created_by=video_to_encode.owner)
+    else:
+        thumbnail = CustomImageModel()
+    with open(thumbnailfilename, "rb") as thumbnail_file:
+        thumbnail.file.save(
+            thumbnail_name,
+            File(thumbnail_file),
+            save=True,
+        )
+    thumbnail.save()
+    return thumbnail
+
+
 def import_remote_thumbnail(
     info_encode_thumbnail: EncodedThumbnailInfo | list[EncodedThumbnailInfo],
     output_dir: str,
     video_to_encode: Video,
 ) -> str:
-    """Import thumbnail data generated during remote encoding."""
+    """Import all generated thumbnails and associate one preferred thumbnail to the video."""
     msg = ""
-    thumbnail_data = info_encode_thumbnail
-    if isinstance(thumbnail_data, list):
-        # Keep backward compatibility with payloads that wrap a single thumbnail in a list.
-        if not thumbnail_data:
-            msg += "\nERROR THUMBNAILS missing data "
-            add_encoding_log(video_to_encode.id, msg)
-            change_encoding_step(video_to_encode.id, -1, msg)
-            send_email(msg, video_to_encode.id)
-            return msg
-        thumbnail_data = thumbnail_data[0]
-
-    thumbnailfilename = os.path.join(output_dir, thumbnail_data["filename"])
-    if check_file(thumbnailfilename):
-        if FILEPICKER:
-            homedir, created = UserFolder.objects.get_or_create(
-                name="home", owner=video_to_encode.owner
-            )
-            videodir, created = UserFolder.objects.get_or_create(
-                name="%s" % video_to_encode.slug, owner=video_to_encode.owner
-            )
-            thumbnail = CustomImageModel(
-                folder=videodir, created_by=video_to_encode.owner
-            )
-            thumbnail.file.save(
-                thumbnail_data["filename"],
-                File(open(thumbnailfilename, "rb")),
-                save=True,
-            )
-            thumbnail.save()
-            video_to_encode.thumbnail = thumbnail
-            video_to_encode.save()
-        else:
-            thumbnail = CustomImageModel()
-            thumbnail.file.save(
-                thumbnail_data["filename"],
-                File(open(thumbnailfilename, "rb")),
-                save=True,
-            )
-            thumbnail.save()
-            video_to_encode.thumbnail = thumbnail
-            video_to_encode.save()
-        msg += "\n- thumbnailfilename:\n%s" % thumbnailfilename
-    else:
-        msg += "\nERROR THUMBNAILS %s " % thumbnailfilename
-        msg += "Wrong file or path"
+    ordered_thumbnails = _get_ordered_thumbnail_entries(info_encode_thumbnail)
+    if not ordered_thumbnails:
+        msg += "\nERROR THUMBNAILS missing data "
         add_encoding_log(video_to_encode.id, msg)
         change_encoding_step(video_to_encode.id, -1, msg)
         send_email(msg, video_to_encode.id)
+        return msg
+
+    checked_thumbnail_files: list[str] = []
+    selected_thumbnail: CustomImageModel | None = None
+    for thumbnail_data in ordered_thumbnails:
+        thumbnail_name = thumbnail_data.get("filename")
+        if not thumbnail_name:
+            continue
+
+        thumbnailfilename = os.path.join(output_dir, thumbnail_name)
+        checked_thumbnail_files.append(thumbnailfilename)
+        if not check_file(thumbnailfilename):
+            continue
+
+        stored_thumbnail = _save_thumbnail_for_video(
+            video_to_encode,
+            thumbnailfilename,
+            thumbnail_name,
+        )
+        if selected_thumbnail is None:
+            selected_thumbnail = stored_thumbnail
+        msg += "\n- thumbnailfilename:\n%s" % thumbnailfilename
+
+    if selected_thumbnail is not None:
+        video_to_encode.thumbnail = selected_thumbnail
+        video_to_encode.save()
+        return msg
+
+    missing_files = ", ".join(checked_thumbnail_files) or "missing data"
+    msg += "\nERROR THUMBNAILS %s " % missing_files
+    msg += "Wrong file or path"
+    add_encoding_log(video_to_encode.id, msg)
+    change_encoding_step(video_to_encode.id, -1, msg)
+    send_email(msg, video_to_encode.id)
     return msg
 
 

--- a/pod/video_encode_transcript/templates/admin_test_connection.html
+++ b/pod/video_encode_transcript/templates/admin_test_connection.html
@@ -10,6 +10,12 @@
       --test-connection-link-fg: var(--pod-btn-text, #fff);
     }
 
+    .object-tools a.runner-admin-link {
+      --runner-admin-link-bg: var(--button-bg);
+      --runner-admin-link-bg-hover: var(--pod-primary-darken);
+      --runner-admin-link-fg: var(--button-fg, var(--pod-btn-text));
+    }
+
     .object-tools a.test-connection-link {
       display: inline-flex;
       align-items: center;
@@ -24,7 +30,26 @@
       color: var(--test-connection-link-fg);
     }
 
+    .object-tools a.runner-admin-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      background: var(--runner-admin-link-bg);
+      color: var(--runner-admin-link-fg);
+    }
+
+    .object-tools a.runner-admin-link:hover,
+    .object-tools a.runner-admin-link:focus {
+      background: var(--runner-admin-link-bg-hover);
+      color: var(--runner-admin-link-fg);
+    }
+
     .object-tools a.test-connection-link .test-connection-icon {
+      font-size: 0.95rem;
+      line-height: 1;
+    }
+
+    .object-tools a.runner-admin-link .runner-admin-icon {
       font-size: 0.95rem;
       line-height: 1;
     }
@@ -33,6 +58,17 @@
 
 {% block object-tools-items %}
   {{ block.super }}
+  {% if change and original %}
+    <li>
+      <a class="runner-admin-link"
+         href="{% if original.url|slice:'-1:' == '/' %}{{ original.url }}admin{% else %}{{ original.url }}/admin{% endif %}"
+         target="_blank"
+         rel="noopener noreferrer">
+        <i class="bi bi-box-arrow-up-right runner-admin-icon" aria-hidden="true"></i>
+        {% trans "Runner administration" %}
+      </a>
+    </li>
+  {% endif %}
   {% if change and original %}
     <li>
       <a class="test-connection-link" href="{% url 'admin:video_encode_transcript_runnermanager_test_connection' original.pk|admin_urlquote %}">

--- a/pod/video_encode_transcript/tests/test_runner_manager_admin.py
+++ b/pod/video_encode_transcript/tests/test_runner_manager_admin.py
@@ -60,6 +60,39 @@ class RunnerManagerAdminTests(TestCase):
         self.assertContains(response, "Test connection")
         self.assertContains(response, "test-connection-link")
         self.assertContains(response, self.test_connection_url)
+        self.assertContains(response, "runner-admin-link")
+        self.assertContains(response, "https://runner.example.com/admin")
+
+    def test_change_page_runner_admin_link_handles_url_without_trailing_slash(self):
+        """Build remote admin URL correctly when runner URL has no trailing slash."""
+        self.runner_manager.url = "https://runner-no-slash.example.com"
+        self.runner_manager.save(update_fields=["url"])
+
+        response = self.client.get(self.change_url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "runner-admin-link")
+        self.assertContains(response, "https://runner-no-slash.example.com/admin")
+
+    def test_changelist_displays_activation_badge(self):
+        """Display activation badge in runner manager changelist."""
+        changelist_url = reverse(
+            "admin:video_encode_transcript_runnermanager_changelist"
+        )
+
+        response = self.client.get(changelist_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "bg-success")
+        self.assertContains(response, "Active")
+        self.assertContains(response, "runner-admin-list-link")
+        self.assertContains(response, "https://runner.example.com/admin")
+
+        self.runner_manager.is_active = False
+        self.runner_manager.save(update_fields=["is_active"])
+        response = self.client.get(changelist_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "bg-secondary")
+        self.assertContains(response, "Inactive")
 
     @patch("pod.video_encode_transcript.admin.requests.get")
     def test_test_connection_reports_unreachable_runner(self, mocked_get):

--- a/pod/video_encode_transcript/tests/test_runner_manager_round_robin.py
+++ b/pod/video_encode_transcript/tests/test_runner_manager_round_robin.py
@@ -110,3 +110,26 @@ class RunnerManagerRoundRobinTests(TestCase):
         ordered_ids = [rm.id for rm in _get_runner_managers(self.site)]
 
         self.assertEqual(ordered_ids, [rm2.id, rm1.id, rm4.id, rm3.id])
+
+    def test_get_runner_managers_excludes_inactive_runner_managers(self):
+        """Exclude inactive runner managers from the returned candidates."""
+        active_rm = RunnerManager.objects.create(
+            name="rm-active",
+            priority=1,
+            url="https://rr-active.example.com/",
+            token="token-active",
+            site=self.site,
+            is_active=True,
+        )
+        RunnerManager.objects.create(
+            name="rm-inactive",
+            priority=1,
+            url="https://rr-inactive.example.com/",
+            token="token-inactive",
+            site=self.site,
+            is_active=False,
+        )
+
+        ordered_ids = [rm.id for rm in _get_runner_managers(self.site)]
+
+        self.assertEqual(ordered_ids, [active_rm.id])

--- a/pod/video_encode_transcript/tests/test_studio_integration.py
+++ b/pod/video_encode_transcript/tests/test_studio_integration.py
@@ -65,7 +65,7 @@ class StudioFlowIntegrationTests(TestCase):
 
                 # Destination path must include user hash and video id
                 dest_dir = os.path.join(
-                    tmp_media_root, "videos", user_hash, str(fake_video.id)
+                    tmp_media_root, "videos", user_hash, f"{fake_video.id:04d}"
                 )
                 self.assertTrue(os.path.isdir(dest_dir))
                 # Source folder removed

--- a/pod/video_encode_transcript/tests/test_views_helpers.py
+++ b/pod/video_encode_transcript/tests/test_views_helpers.py
@@ -16,6 +16,8 @@ import requests
 
 from pod.video_encode_transcript.views import (
     _download_and_store_manifest_member,
+    _format_video_directory,
+    _get_destination_directory,
     _get_user_hashkey_from_recording,
     _merge_or_move_directory,
 )
@@ -134,6 +136,44 @@ class ViewsHelpersTests(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             _get_user_hashkey_from_recording(BadRecording())
+
+    def test_format_video_directory_uses_minimum_four_digits(self):
+        """Format short numeric ids with leading zeros."""
+        self.assertEqual(_format_video_directory(1), "0001")
+        self.assertEqual(_format_video_directory("42"), "0042")
+        self.assertEqual(_format_video_directory(12345), "12345")
+
+    def test_get_destination_directory_uses_padded_video_id(self):
+        """Build destination path with a zero-padded video id for encoding tasks."""
+        task = SimpleNamespace(
+            type="encoding",
+            video=SimpleNamespace(
+                id=1,
+                owner=SimpleNamespace(owner=SimpleNamespace(hashkey="hash123")),
+            ),
+        )
+        with patch("pod.video_encode_transcript.views.MEDIA_ROOT", self.tmp_root):
+            with patch("pod.video_encode_transcript.views.VIDEOS_DIR", "videos"):
+                dest_dir = _get_destination_directory(task)
+
+        expected = os.path.join(self.tmp_root, "videos", "hash123", "0001")
+        self.assertEqual(dest_dir, expected)
+
+    def test_get_destination_directory_uses_padded_video_id_for_transcription(self):
+        """Build destination path with a zero-padded video id for transcription tasks."""
+        task = SimpleNamespace(
+            type="transcription",
+            video=SimpleNamespace(
+                id=9,
+                owner=SimpleNamespace(owner=SimpleNamespace(hashkey="hash123")),
+            ),
+        )
+        with patch("pod.video_encode_transcript.views.MEDIA_ROOT", self.tmp_root):
+            with patch("pod.video_encode_transcript.views.VIDEOS_DIR", "videos"):
+                dest_dir = _get_destination_directory(task)
+
+        expected = os.path.join(self.tmp_root, "videos", "hash123", "0009")
+        self.assertEqual(dest_dir, expected)
 
     def test_download_and_store_manifest_member_retries_chunked_transfer(self):
         """Retry streamed download on chunked transfer break and overwrite partial data."""

--- a/pod/video_encode_transcript/views.py
+++ b/pod/video_encode_transcript/views.py
@@ -66,6 +66,14 @@ def _get_videos_dir() -> str:
     return str(getattr(settings, "VIDEOS_DIR", "videos"))
 
 
+def _format_video_directory(video_id: int | str) -> str:
+    """Return normalized video directory name using at least 4 digits."""
+    try:
+        return f"{int(video_id):04d}"
+    except (TypeError, ValueError):
+        return str(video_id)
+
+
 class NotifyTaskPayload(TypedDict, total=False):
     """Payload sent by Runner Manager to the notify endpoint."""
 
@@ -410,20 +418,22 @@ def _get_destination_directory(task: Task, dest_base: str | None = None) -> str:
     if dest_base is None:
         # Choose base directory based on task type (encoding, studio or transcription)
         if task.type == "transcription" and getattr(task, "video", None):
+            video_dir = _format_video_directory(task.video.id)
             dest_dir = os.path.join(
                 MEDIA_ROOT,
                 VIDEOS_DIR,
                 str(task.video.owner.owner.hashkey),
-                str(task.video.id),
+                video_dir,
             )
         elif task.type == "studio":
             dest_dir = os.path.join(MEDIA_ROOT, "tasks", str(task.id))
         else:
+            video_dir = _format_video_directory(task.video.id)
             dest_dir = os.path.join(
                 MEDIA_ROOT,
                 VIDEOS_DIR,
                 str(task.video.owner.owner.hashkey),
-                str(task.video.id),
+                video_dir,
             )
         log.info(f"Save result into {dest_dir}")
         os.makedirs(os.path.dirname(dest_dir), exist_ok=True)
@@ -773,7 +783,7 @@ def _create_video_from_studio_task(task: Task, extracted_dir: str | None = None)
     - Validate that the task references a recording (`task.recording_id`).
     - Expect `studio_base.mp4` under MEDIA_ROOT/tasks/<task.id> by default.
     - Create a new Video via `save_basic_video(recording, src_file)`.
-    - Move the task extraction directory to MEDIA_ROOT/VIDEOS_DIR/<hashkey>/<video_id>.
+    - Move the task extraction directory to MEDIA_ROOT/VIDEOS_DIR/<hashkey>/<%04d video_id>.
     - Return the created video's id.
 
     Args:
@@ -857,7 +867,7 @@ def _move_task_directory_to_video(
     """Move the task extraction directory into the final video directory.
 
     Source: MEDIA_ROOT/tasks/<task.id> by default.
-    Destination: MEDIA_ROOT/VIDEOS_DIR/<hashkey>/<video_id>
+    Destination: MEDIA_ROOT/VIDEOS_DIR/<hashkey>/<%04d video_id>
 
     Args:
         task: The `Task` instance (must contain `recording_id`).
@@ -885,8 +895,9 @@ def _move_task_directory_to_video(
             raise RuntimeError(f"Recording not found: {task.recording_id}")
 
     user_hashkey = _get_user_hashkey_from_recording(recording)
+    video_dir = _format_video_directory(video_id)
     dest_dir = os.path.join(
-        _get_media_root(), _get_videos_dir(), user_hashkey, str(video_id)
+        _get_media_root(), _get_videos_dir(), user_hashkey, video_dir
     )
 
     _merge_or_move_directory(source_dir, dest_dir)


### PR DESCRIPTION
## Summary
This PR improves dashboard filtering behavior, strengthens runner manager administration and task routing, and updates translation catalogs.

## What changed
- Added support for dashboard filters using slugs, numeric IDs, and comma-separated query values.
- Improved filter synchronization between URL parameters, session storage, dashboard chips, and the category aside.
- Added a clear category filter action in the aside and kept UI state aligned with current query params.
- Hardened dashboard refresh JavaScript with defensive checks for missing globals and DOM elements.
- Added an `is_active` flag on runner managers to enable/disable managers without deleting configuration.
- Updated task dispatching and background processing to use active runner managers only.
- Kept tasks in pending state when no active runner manager is available for retry later.
- Improved runner admin UX with status badges and direct links to remote runner administration.
- Enhanced remote thumbnail import to support multiple generated thumbnails and avoid duplicate attachment.
- Added/updated tests for category CSV filtering, ID/CSV filters, runner admin UI behavior, and inactive-manager exclusion.
- Updated French translation catalogs.

## Impact
- More robust and predictable dashboard filtering UX.
- Safer and clearer runner manager operations in admin and processing flows.
- Translation coverage updated for newly introduced admin and filter labels.
