### PR TITLE
Fix Skip invalid non-JSON runner responses

### DIFF
--- a/pod/video_encode_transcript/runner_manager.py
+++ b/pod/video_encode_transcript/runner_manager.py
@@ -308,6 +308,42 @@ def _try_send_to_rm(
         return None
 
 
+def _parse_runner_response(
+    rm: RunnerManager, response: requests.Response
+) -> Optional[RunnerManagerResponse]:
+    """Parse and validate a runner manager HTTP response.
+
+    Returns None when the response body is not a valid JSON payload expected from
+    the runner manager (for example an HTML error page returned by a reverse proxy
+    with HTTP 200).
+    """
+    if not response.content:
+        return {}
+
+    try:
+        payload = response.json()
+    except ValueError:
+        content_type = response.headers.get("Content-Type", "")
+        log.warning(
+            "Runner manager %s returned HTTP 200 with non-JSON body "
+            "(Content-Type=%s). Trying next one.",
+            rm.name,
+            content_type or "unknown",
+        )
+        return None
+
+    if not isinstance(payload, dict):
+        log.warning(
+            "Runner manager %s returned an unexpected JSON payload type (%s). "
+            "Trying next one.",
+            rm.name,
+            type(payload).__name__,
+        )
+        return None
+
+    return cast(RunnerManagerResponse, payload)
+
+
 def _prestore_encoding_if_needed(
     *,
     task_type: TaskType,
@@ -360,8 +396,10 @@ def _submit_to_runner_manager(
     log.info(
         f"Runner manager {rm.name} is available to process {task_type} for {source_type} {video_id or recording_id}."
     )
-    # Runner may reply with no body; keep an empty payload in that case.
-    payload = cast(RunnerManagerResponse, response.json() if response.content else {})
+    payload = _parse_runner_response(rm, response)
+    if payload is None:
+        return False
+
     _update_task_from_response(video_id, recording_id, task_type, rm, payload)
     _prestore_encoding_if_needed(
         task_type=task_type,

--- a/pod/video_encode_transcript/tests/test_runner_manager_submission.py
+++ b/pod/video_encode_transcript/tests/test_runner_manager_submission.py
@@ -1,0 +1,100 @@
+"""Runner manager submission tests.
+
+Run with `python manage.py test pod.video_encode_transcript.tests.test_runner_manager_submission`
+"""
+
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase
+
+from pod.video_encode_transcript.runner_manager import _submit_to_runner_manager
+
+
+class RunnerManagerSubmissionTests(SimpleTestCase):
+    """Validate submission guardrails for runner manager responses."""
+
+    @patch("pod.video_encode_transcript.runner_manager._prestore_encoding_if_needed")
+    @patch("pod.video_encode_transcript.runner_manager._update_task_from_response")
+    @patch("pod.video_encode_transcript.runner_manager._try_send_to_rm")
+    def test_submit_rejects_http_200_with_invalid_body(
+        self,
+        mocked_try_send_to_rm,
+        mocked_update_task_from_response,
+        mocked_prestore,
+    ) -> None:
+        """Skip a runner returning HTTP 200 with a non-JSON body (proxy error page)."""
+        response = Mock()
+        response.status_code = 200
+        response.content = b"<html>HAProxy error</html>"
+        response.headers = {"Content-Type": "text/html"}
+        response.json.side_effect = ValueError("No JSON object could be decoded")
+        mocked_try_send_to_rm.return_value = response
+
+        rm = Mock()
+        rm.name = "rm-haproxy"
+
+        payload = {
+            "etab_name": "Etab / Site",
+            "app_name": "Esup-Pod",
+            "app_version": "4.X",
+            "task_type": "encoding",
+            "source_url": "https://example.com/media/video.mp4",
+            "notify_url": "https://example.com/runner/notify_task_end/",
+            "parameters": {},
+        }
+
+        result = _submit_to_runner_manager(
+            rm=rm,
+            data=payload,
+            task_type="encoding",
+            source_type="video",
+            video_id=123,
+            recording_id=None,
+        )
+
+        self.assertFalse(result)
+        mocked_update_task_from_response.assert_not_called()
+        mocked_prestore.assert_not_called()
+
+    @patch("pod.video_encode_transcript.runner_manager._prestore_encoding_if_needed")
+    @patch("pod.video_encode_transcript.runner_manager._update_task_from_response")
+    @patch("pod.video_encode_transcript.runner_manager._try_send_to_rm")
+    def test_submit_rejects_http_200_with_invalid_json_type(
+        self,
+        mocked_try_send_to_rm,
+        mocked_update_task_from_response,
+        mocked_prestore,
+    ) -> None:
+        """Skip a runner returning HTTP 200 with JSON payload of unexpected type."""
+        response = Mock()
+        response.status_code = 200
+        response.content = b"[\"proxy\", \"error\"]"
+        response.headers = {"Content-Type": "application/json"}
+        response.json.return_value = ["proxy", "error"]
+        mocked_try_send_to_rm.return_value = response
+
+        rm = Mock()
+        rm.name = "rm-invalid-json-type"
+
+        payload = {
+            "etab_name": "Etab / Site",
+            "app_name": "Esup-Pod",
+            "app_version": "4.X",
+            "task_type": "encoding",
+            "source_url": "https://example.com/media/video.mp4",
+            "notify_url": "https://example.com/runner/notify_task_end/",
+            "parameters": {},
+        }
+
+        result = _submit_to_runner_manager(
+            rm=rm,
+            data=payload,
+            task_type="encoding",
+            source_type="video",
+            video_id=124,
+            recording_id=None,
+        )
+
+        self.assertFalse(result)
+        mocked_update_task_from_response.assert_not_called()
+        mocked_prestore.assert_not_called()


### PR DESCRIPTION
## Summary
This PR makes Runner Manager response handling more robust when an endpoint returns HTTP 200 with an invalid body.

## What changed
- Added safe parsing/validation of Runner Manager responses.
- Ignored non-JSON or unexpected JSON payloads with warning logs.
- If a response is invalid, the flow now tries the next available Runner Manager.

## Impact
More reliable task dispatching and fewer failures caused by proxy/misconfiguration responses.