### PR TITLE
Remove "print" & "paste" from default TinyMCE plugins

### DIFF
--- a/pod/main/settings.py
+++ b/pod/main/settings.py
@@ -326,8 +326,8 @@ TINYMCE_DEFAULT_CONFIG = {
     "theme": "silver",
     "height": 500,
     "menubar": False,
-    "plugins": "advlist,autolink,lists,link,image,charmap,print,preview,anchor,"
-    "searchreplace,visualblocks,code,fullscreen,insertdatetime,media,table,paste,"
+    "plugins": "advlist,autolink,lists,link,image,charmap,preview,anchor,"
+    "searchreplace,visualblocks,code,fullscreen,insertdatetime,media,table,"
     "code,help,wordcount",
     "toolbar": "undo redo | formatselect | "
     "bold italic backcolor | alignleft aligncenter "


### PR DESCRIPTION
Remove "print" & "paste" from default TinyMCE plugins (as they are in core now)

Fix Issue #1419
