### PR TITLE
:green_heart: Implement Docker image publishing workflow on GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+name: Publish Docker Image to GHCR
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deployment/dev/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -38,7 +38,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: deployment/dev/Dockerfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Use your best judgment, and feel free to propose changes to this document in a p
   * [Reporting Bugs](#reporting-bugs)
   * [Suggesting Enhancements](#suggesting-enhancements)
   * [Pull Requests](#pull-requests)
+  * [Release Process](docs/RELEASE_PROCESS.md)
 
 * [Styleguides](#styleguides)
   * [Git Commit Messages](#git-commit-messages)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Ideally suited for Higher Education and Research institutions, it facilitates vi
 
 > [!NOTE]
 > This repository contains the **V5 (Python/Django)** backend.
-> Find the documentation here [ESUP-POD V5 Documentation](./docs/README.md)
+> Find the documentation here [ESUP-POD V5 Documentation](./docs/README.md).
+For more information on the release process, see [Release Procedure](./docs/RELEASE_PROCESS.md).
 > For the legacy V4 version or specific institutional documentation, please refer to the [ESUP-Portail Wiki](https://www.esup-portail.org/wiki/display/ES/esup-pod).
 
 ### Video file management platform

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,36 @@
+# EsupPod V5 Release Process
+
+This document describes the consensus procedure for publishing a new version of the **Pod_V5_Back** application to the GitHub Container Registry (GHCR).
+
+## Release Workflow
+
+To ensure stability and follow the project consensus, follow these steps in order:
+
+1. **PR Acceptance**: Wait for your Pull Request from `origin/dev_v5` (your fork) to `upstream/dev_v5` (main repository) to be reviewed and merged.
+2. **Local Sync**: Update your local `dev_v5` branch with the latest changes from the `upstream` repository.
+   ```bash
+   git fetch upstream
+   git checkout dev_v5
+   git merge upstream/dev_v5
+   ```
+3. **Tagging**: Once the code is merged, create a Git tag following the `vX.Y.Z` convention.
+   ```bash
+   git tag v5.0.0
+   ```
+4. **Pushing the Tag**: Push the tag to the `upstream` repository (or your fork if you have write access).
+   ```bash
+   git push upstream v5.0.0
+   ```
+
+## Automation
+
+Adding a tag starting with `v` triggers the [Publish Docker Image to GHCR](.github/workflows/release.yml) GitHub Action automatically:
+- It builds the Docker image using `deployment/dev/Dockerfile`.
+- It publishes the image to `ghcr.io` with tags for the specific version and `latest`.
+
+## Verification
+
+You can monitor the progress in the **Actions** tab of the GitHub repository. Once completed, the image will be available in the **Packages** section.
+
+---
+*See also: [Contributing Guide](../CONTRIBUTING.md)*


### PR DESCRIPTION
# Description
This Pull Request introduces the automation of publishing the project's Docker images to the GitHub Container Registry (ghcr.io) and its accompanying process documentation.
The goal is to simplify and standardize the release workflow for V5, binding the creation of a Git `v*` tag directly to the building and publishing of the Docker image.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v4` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
