### PR TITLE
Fix - Skip Placeholder Email Alerts and Count Visible Caption Characters

### DIFF
--- a/pod/completion/static/js/caption_maker.js
+++ b/pod/completion/static/js/caption_maker.js
@@ -574,6 +574,15 @@ function generateWEBVTT() {
 }
 
 /**
+ * Count displayed caption characters without line breaks.
+ * @param {string} captionText - Caption content
+ * @return {number} character count without carriage returns/new lines
+ */
+function getCaptionVisibleLength(captionText) {
+  return captionText.replace(/[\r\n]/g, "").length;
+}
+
+/**
  * Check validity of every form and fires an invalid event on invalid elements.
  *
  * @return {bool} true if everything's fine
@@ -965,7 +974,7 @@ function createCaptionBlock(newCaption, spawnFunction) {
       const nbCharsMsg = gettext("%s/%s characters");
       // Update numberCharactersDiv content
       const updateCharacterCount = () => {
-        let nbCharacters = this.captionTextInput.value.length;
+        let nbCharacters = getCaptionVisibleLength(this.captionTextInput.value);
         this.numberCharactersDiv.textContent = interpolate(nbCharsMsg, [
           nbCharacters,
           80,

--- a/pod/video_encode_transcript/tests/test_utils.py
+++ b/pod/video_encode_transcript/tests/test_utils.py
@@ -5,8 +5,12 @@ Run with `python manage.py test pod.video_encode_transcript.tests.test_utils`
 """
 
 import unittest
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
 
 from ..encoding_utils import get_dressing_position_value, sec_to_timestamp
+from ..utils import send_email_item
 
 
 class EncodingUtilitiesTests(unittest.TestCase):
@@ -33,3 +37,49 @@ class EncodingUtilitiesTests(unittest.TestCase):
         self.assertEqual(sec_to_timestamp(-1), "00:00:00.000")
         self.assertEqual(sec_to_timestamp(60.000), "00:01:00.000")
         print(" ---> sec_to_timestamp: OK! --- EncodginUtilsTest")
+
+
+class SendEmailItemTests(SimpleTestCase):
+    """Test admin alert email guards."""
+
+    @override_settings(
+        EMAIL_HOST="smtp.univ.fr",
+        ADMINS=(("Name", "adminmail@univ.fr"),),
+    )
+    @patch("pod.video_encode_transcript.utils.mail_admins")
+    def test_send_email_item_skips_placeholder_smtp_settings(
+        self, mock_mail_admins
+    ) -> None:
+        """Do not attempt an SMTP send when project placeholder settings are unchanged."""
+        send_email_item("Task 42 failed", "Task", "task-42")
+        mock_mail_admins.assert_not_called()
+
+    @override_settings(
+        EMAIL_HOST="smtp.example.org",
+        ADMINS=(("Ops", "ops@example.org"),),
+    )
+    @patch("pod.video_encode_transcript.utils.mail_admins")
+    def test_send_email_item_uses_configured_smtp_settings(
+        self, mock_mail_admins
+    ) -> None:
+        """Keep sending admin alert emails when SMTP settings are explicitly configured."""
+        send_email_item("Task 42 failed", "Task", "task-42")
+        mock_mail_admins.assert_called_once()
+
+    @override_settings(EMAIL_HOST="smtp.example.org", ADMINS=())
+    @patch("pod.video_encode_transcript.utils.mail_admins")
+    def test_send_email_item_skips_when_admins_are_empty(
+        self, mock_mail_admins
+    ) -> None:
+        """Do not attempt an SMTP send when no admin recipients are configured."""
+        send_email_item("Task 42 failed", "Task", "task-42")
+        mock_mail_admins.assert_not_called()
+
+    @override_settings(EMAIL_HOST="", ADMINS=(("Ops", "ops@example.org"),))
+    @patch("pod.video_encode_transcript.utils.mail_admins")
+    def test_send_email_item_skips_when_email_host_is_empty(
+        self, mock_mail_admins
+    ) -> None:
+        """Do not attempt an SMTP send when the SMTP host is not configured."""
+        send_email_item("Task 42 failed", "Task", "task-42")
+        mock_mail_admins.assert_not_called()

--- a/pod/video_encode_transcript/utils.py
+++ b/pod/video_encode_transcript/utils.py
@@ -51,6 +51,8 @@ __TITLE_SITE__ = (
 )
 
 DEFAULT_FROM_EMAIL = getattr(settings, "DEFAULT_FROM_EMAIL", "noreply@univ.fr")
+DEFAULT_PLACEHOLDER_EMAIL_HOST = "smtp.univ.fr"
+DEFAULT_PLACEHOLDER_ADMINS = (("Name", "adminmail@univ.fr"),)
 
 USE_ESTABLISHMENT_FIELD = getattr(settings, "USE_ESTABLISHMENT_FIELD", False)
 
@@ -110,8 +112,38 @@ def create_outputdir(video_id, video_path):
 ###############################################################
 
 
+def _admin_failure_emails_are_enabled() -> bool:
+    """Return True when admin alert emails should be sent.
+
+    The project ships with placeholder SMTP/admin settings. When those defaults
+    are still in place, trying to send a failure email only triggers an
+    unnecessary SMTP connection attempt.
+    """
+    admins = tuple(getattr(settings, "ADMINS", ()) or ())
+    if not admins:
+        return False
+    if admins == DEFAULT_PLACEHOLDER_ADMINS:
+        return False
+
+    email_host = str(getattr(settings, "EMAIL_HOST", "") or "").strip()
+    if not email_host:
+        return False
+    if email_host == DEFAULT_PLACEHOLDER_EMAIL_HOST:
+        return False
+
+    return True
+
+
 def send_email_item(msg, item, item_id) -> None:
     """Send email notification when encoding fails for a specific item."""
+    if not _admin_failure_emails_are_enabled():
+        logger.info(
+            "Skipping admin alert email for %s %s because SMTP/admin email settings are not configured.",
+            item,
+            item_id,
+        )
+        return
+
     subject = "[" + __TITLE_SITE__ + "] Error Encoding %s id: %s" % (item, item_id)
     message = "Error Encoding %s id: %s\n%s" % (item, item_id, msg)
     html_message = "<p>Error Encoding %s id: %s</p><p>%s</p>" % (

--- a/pod/video_encode_transcript/utils.py
+++ b/pod/video_encode_transcript/utils.py
@@ -137,7 +137,7 @@ def _admin_failure_emails_are_enabled() -> bool:
 def send_email_item(msg, item, item_id) -> None:
     """Send email notification when encoding fails for a specific item."""
     if not _admin_failure_emails_are_enabled():
-        logger.info(
+        logger.warning(
             "Skipping admin alert email for %s %s because SMTP/admin email settings are not configured.",
             item,
             item_id,


### PR DESCRIPTION
## Summary

This PR improves two reliability behaviors:
1. It prevents failure alert emails from being sent when email settings are still placeholders or incomplete.
2. It updates caption character counting to ignore line breaks and reflect visible characters only.

