### PR TITLE
chore: update esup-runner images to latest versions from ghcr.io/esup...

### DIFF
--- a/deployment/dev/docker-compose.yml
+++ b/deployment/dev/docker-compose.yml
@@ -93,7 +93,7 @@ services:
       - pod-network
 
   esup-runner-manager:
-    image: benjisere/esup-runner-manager:v1.0.0
+    image: ghcr.io/esupportail/esup-runner-manager:latest
     container_name: pod-esup-manager
     env_file:
       - ../../.env
@@ -113,7 +113,7 @@ services:
       - pod-network
 
   esup-runner-runner:
-    image: benjisere/esup-runner-runner:v1.0.0
+    image: ghcr.io/esupportail/esup-runner-runner:latest
     container_name: pod-esup-runner
     env_file:
       - ../../.env


### PR DESCRIPTION
# chore: update esup-runner images to latest versions from ghcr.io/esup…

This Pull Request updates the local development docker-compose configuration to use the official GitHub Container Registry images for the Esup-Runner microservices.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
