### PR TITLE
Refactor runner manager task submission and align process_tasks payloads

### DIFF
--- a/pod/video_encode_transcript/management/commands/process_tasks.py
+++ b/pod/video_encode_transcript/management/commands/process_tasks.py
@@ -40,7 +40,6 @@ Example cron (every 3 minutes):
 `*/3 * * * * /usr/bin/bash -c 'export WORKON_HOME=/home/pod/.virtualenvs; export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3; cd /usr/local/django_projects/podv4; source /usr/local/bin/virtualenvwrapper.sh; workon django_pod4; python manage.py process_tasks >> /usr/local/django_projects/podv4/pod/log/process_tasks.log 2>&1'`
 """
 
-import json
 import logging
 from datetime import timedelta
 
@@ -50,14 +49,18 @@ from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from pod.cut.models import CutVideo
-from pod.dressing.models import Dressing
 from pod.recorder.models import Recording
 from pod.video.models import Video
 from pod.video_encode_transcript.models import RunnerManager, Task
-from pod.video_encode_transcript.runner_manager_utils import (
-    store_before_remote_encoding_recording,
-    store_before_remote_encoding_video,
+from pod.video_encode_transcript.runner_manager import (
+    _build_base_url as build_runner_base_url,
+    _build_studio_source_url as build_runner_studio_source_url,
+    _build_transcription_source_url as build_runner_transcription_source_url,
+    _build_video_source_url as build_runner_video_source_url,
+    _prepare_encoding_parameters as prepare_runner_encoding_parameters,
+    _prepare_task_data as build_runner_task_data,
+    _prepare_transcription_parameters as prepare_runner_transcription_parameters,
+    _submit_to_runner_managers as submit_runner_task_to_managers,
 )
 from pod.video_encode_transcript.task_queue import (
     get_user_priority,
@@ -322,7 +325,7 @@ class Command(BaseCommand):
                 self.print_log(
                     f"Processing task {task.id} for video {video.id} - Priority: {priority_label}"
                 )
-                result = self._submit_encoding_task(video, task, site, runner_managers)
+                result = self._submit_encoding_task(video, site, runner_managers)
                 if result:
                     success_count += 1
                     self.print_success(
@@ -361,7 +364,7 @@ class Command(BaseCommand):
                 self.print_log(
                     f"Processing studio task {task.id} for recording {recording.id}"
                 )
-                result = self._submit_studio_task(recording, task, site, runner_managers)
+                result = self._submit_studio_task(recording, site, runner_managers)
                 if result:
                     success_count += 1
                     self.print_success(
@@ -404,9 +407,7 @@ class Command(BaseCommand):
                 self.print_log(
                     f"Processing transcription task {task.id} for video {video.id} - Priority: {priority_label}"
                 )
-                result = self._submit_transcription_task(
-                    video, task, site, runner_managers
-                )
+                result = self._submit_transcription_task(video, site, runner_managers)
                 if result:
                     success_count += 1
                     self.print_success(
@@ -571,364 +572,79 @@ class Command(BaseCommand):
             f"studio {success_count_studio}/{len(pending_studio_tasks)} successfully submitted"
         )
 
-    def _submit_encoding_task(
-        self, video: Video, task: Task, site: Site, runner_managers: list
+    def _submit_task_to_runner_managers(
+        self,
+        *,
+        task_type: str,
+        source_type: str,
+        source_id: int,
+        source_url: str,
+        base_url: str,
+        parameters: dict,
+        runner_managers: list,
     ) -> bool:
-        """
-        Try to submit an encoding task to available runner managers.
-        Returns True if successful, False otherwise.
-        """
-        VERSION = getattr(settings, "VERSION", "4.X")
-        TEMPLATE_VISIBLE_SETTINGS = getattr(
-            settings,
-            "TEMPLATE_VISIBLE_SETTINGS",
-            {
-                "TITLE_SITE": "Pod",
-                "TITLE_ETB": "University name",
-            },
+        """Build the runner payload and submit it using shared runner helpers."""
+        data = build_runner_task_data(
+            source_url=source_url,
+            base_url=base_url,
+            parameters=parameters,
+            task_type=task_type,
         )
-        __TITLE_SITE__ = TEMPLATE_VISIBLE_SETTINGS.get("TITLE_SITE", "Pod")
-        __TITLE_ETB__ = TEMPLATE_VISIBLE_SETTINGS.get("TITLE_ETB", "University name")
+        return submit_runner_task_to_managers(
+            runner_managers=runner_managers,
+            data=data,
+            task_type=task_type,
+            source_type=source_type,
+            source_id=source_id,
+        )
 
-        base_url = self._build_base_url(site)
-        content_url = self._build_content_url(video, base_url)
-        parameters = self._prepare_encoding_parameters(video, base_url)
-
-        data = {
-            "etab_name": f"{__TITLE_ETB__} / {__TITLE_SITE__}",
-            "app_name": "Esup-Pod",
-            "app_version": f"{VERSION}",
-            "task_type": "encoding",
-            "source_url": f"{content_url}",
-            "notify_url": f"{base_url}/runner/notify_task_end/",
-            "parameters": parameters,
-        }
-
-        return self._post_encoding_to_runner(data, task, video, runner_managers)
-
-    def _build_base_url(self, site: Site) -> str:
-        SECURE_SSL_REDIRECT = getattr(settings, "SECURE_SSL_REDIRECT", False)
-        url_scheme = "https" if SECURE_SSL_REDIRECT else "http"
-        return f"{url_scheme}://{site.domain}"
-
-    def _build_content_url(self, video: Video, base_url: str) -> str:
-        return "%s/media/%s" % (base_url, video.video)
-
-    def _prepare_encoding_parameters(self, video: Video, base_url: str) -> dict:
-        from pod.video_encode_transcript.encoding_utils import get_list_rendition
-
-        list_rendition = get_list_rendition()
-        str_resolution = {
-            str(k): {"resolution": v["resolution"], "encode_mp4": v["encode_mp4"]}
-            for k, v in list_rendition.items()
-        }
-        parameters = {"rendition": json.dumps(str_resolution)}
-
-        cut_info = self._get_cut_info(video)
-        if cut_info:
-            parameters["cut"] = json.dumps(cut_info)
-
-        dressing_info = self._get_dressing_info(video, base_url)
-        if dressing_info:
-            parameters["dressing"] = json.dumps(dressing_info)
-
-        return parameters
-
-    def _get_cut_info(self, video: Video) -> dict | None:
-        try:
-            cut_video = CutVideo.objects.get(video=video)
-            return {
-                "start": str(cut_video.start),
-                "end": str(cut_video.end),
-                "initial_duration": str(cut_video.duration),
-            }
-        except CutVideo.DoesNotExist:
-            return None
-
-    def _get_dressing_info(self, video: Video, base_url: str) -> dict | None:
-        try:
-            if not Dressing.objects.filter(videos=video).exists():
-                return None
-            dressing = Dressing.objects.get(videos=video)
-            if not dressing:
-                return None
-            str_dressing_info: dict = {}
-            if dressing.watermark:
-                watermark_content_url = "%s/media/%s" % (
-                    base_url,
-                    str(dressing.watermark.file.name),
-                )
-                str_dressing_info["watermark"] = watermark_content_url
-                str_dressing_info["watermark_position"] = dressing.position
-                str_dressing_info["watermark_opacity"] = str(dressing.opacity)
-            if dressing.opening_credits:
-                str_dressing_info["opening_credits"] = dressing.opening_credits.slug
-                opening_content_url = "%s/media/%s" % (
-                    base_url,
-                    str(dressing.opening_credits.video.name),
-                )
-                str_dressing_info["opening_credits_video"] = opening_content_url
-                str_dressing_info["opening_credits_video_duration"] = str(
-                    dressing.opening_credits.duration
-                )
-            if dressing.ending_credits:
-                str_dressing_info["ending_credits"] = dressing.ending_credits.slug
-                ending_content_url = "%s/media/%s" % (
-                    base_url,
-                    str(dressing.ending_credits.video.name),
-                )
-                str_dressing_info["ending_credits_video"] = ending_content_url
-                str_dressing_info["ending_credits_video_duration"] = str(
-                    dressing.ending_credits.duration
-                )
-            return str_dressing_info or None
-        except Exception as exc:
-            log.warning(
-                "Error retrieving dressing for video id: %s, %s", video.id, str(exc)
-            )
-            return None
-
-    def _post_encoding_to_runner(
-        self, data: dict, task: Task, video: Video, runner_managers: list
+    def _submit_encoding_task(
+        self, video: Video, site: Site, runner_managers: list
     ) -> bool:
-        for runner_manager in runner_managers:
-            try:
-                execute_url = runner_manager.url
-                if not execute_url.endswith("/"):
-                    execute_url += "/"
-                execute_url += "task/execute"
-
-                headers = {
-                    "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    "Authorization": f"Bearer {runner_manager.token}",
-                }
-
-                response = requests.post(
-                    execute_url, data=json.dumps(data), headers=headers, timeout=30
-                )
-
-                if response.status_code == 200:
-                    task_id = response.json().get("task_id")
-                    status = response.json().get("status")
-
-                    task.status = status
-                    task.runner_manager = runner_manager
-                    task.task_id = task_id
-                    task.save()
-                    store_before_remote_encoding_video(video.id, execute_url, data)
-
-                    log.info(
-                        f"Successfully submitted encoding task for video {video.id} to runner manager {runner_manager.name}"
-                    )
-                    return True
-                log.warning(
-                    f"Runner manager {runner_manager.name} returned status code {response.status_code}"
-                )
-            except requests.RequestException as exc:
-                log.warning(
-                    f"Cannot reach runner manager {runner_manager.name}: {str(exc)}"
-                )
-
-        return False
+        """Submit an encoding task using shared runner manager helpers."""
+        base_url = build_runner_base_url(site)
+        source_url = build_runner_video_source_url(video, base_url)
+        parameters = prepare_runner_encoding_parameters(video=video, base_url=base_url)
+        return self._submit_task_to_runner_managers(
+            task_type="encoding",
+            source_type="video",
+            source_id=video.id,
+            source_url=source_url,
+            base_url=base_url,
+            parameters=parameters,
+            runner_managers=runner_managers,
+        )
 
     def _submit_transcription_task(
-        self, video: Video, task: Task, site: Site, runner_managers: list
+        self, video: Video, site: Site, runner_managers: list
     ) -> bool:
-        """
-        Try to submit a transcription task to available runner managers.
-        Returns True if successful, False otherwise.
-        """
-        from pod.video_encode_transcript.transcript import (
-            resolve_transcription_language,
+        """Submit a transcription task using shared runner manager helpers."""
+        base_url = build_runner_base_url(site)
+        source_url = build_runner_transcription_source_url(video, base_url)
+        parameters = prepare_runner_transcription_parameters(video=video)
+        return self._submit_task_to_runner_managers(
+            task_type="transcription",
+            source_type="video",
+            source_id=video.id,
+            source_url=source_url,
+            base_url=base_url,
+            parameters=parameters,
+            runner_managers=runner_managers,
         )
-
-        # Get settings
-        SECURE_SSL_REDIRECT = getattr(settings, "SECURE_SSL_REDIRECT", False)
-        VERSION = getattr(settings, "VERSION", "4.X")
-        TEMPLATE_VISIBLE_SETTINGS = getattr(
-            settings,
-            "TEMPLATE_VISIBLE_SETTINGS",
-            {
-                "TITLE_SITE": "Pod",
-                "TITLE_ETB": "University name",
-            },
-        )
-        __TITLE_SITE__ = TEMPLATE_VISIBLE_SETTINGS.get("TITLE_SITE", "Pod")
-        __TITLE_ETB__ = TEMPLATE_VISIBLE_SETTINGS.get("TITLE_ETB", "University name")
-
-        # Build content URL: prefer mp3 if available, else video file
-        url_scheme = "https" if SECURE_SSL_REDIRECT else "http"
-        base_url = url_scheme + "://" + site.domain
-        mp3 = video.get_video_mp3() if hasattr(video, "get_video_mp3") else None
-        if mp3 and getattr(mp3, "source_file", None) and getattr(mp3, "url", None):
-            content_url = f"{base_url}{mp3.url}"
-        else:
-            content_url = f"{base_url}/media/{video.video}"
-
-        # Prepare transcription parameters (aligned with runner_manager._prepare_transcription_parameters)
-        transcription_type = getattr(settings, "TRANSCRIPTION_TYPE", None)
-        normalize = bool(getattr(settings, "TRANSCRIPTION_NORMALIZE", False))
-        params = {
-            "language": resolve_transcription_language(video),
-            "duration": float(getattr(video, "duration", 0) or 0),
-            "normalize": normalize,
-        }
-        if transcription_type:
-            params["model_type"] = transcription_type
-
-        data = {
-            "etab_name": f"{__TITLE_ETB__} / {__TITLE_SITE__}",
-            "app_name": "Esup-Pod",
-            "app_version": f"{VERSION}",
-            "task_type": "transcription",
-            "source_url": f"{content_url}",
-            "notify_url": f"{base_url}/runner/notify_task_end/",
-            "parameters": params,
-        }
-
-        # Try each runner manager
-        for runner_manager in runner_managers:
-            try:
-                execute_url = runner_manager.url
-                if not execute_url.endswith("/"):
-                    execute_url += "/"
-                execute_url += "task/execute"
-
-                headers = {
-                    "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    "Authorization": f"Bearer {runner_manager.token}",
-                }
-
-                response = requests.post(
-                    execute_url, data=json.dumps(data), headers=headers, timeout=30
-                )
-
-                if response.status_code == 200:
-                    task_id = response.json().get("task_id")
-                    status = response.json().get("status")
-
-                    # Update task
-                    task.status = status
-                    task.runner_manager = runner_manager
-                    task.task_id = task_id
-                    task.save()
-
-                    log.info(
-                        f"Successfully submitted transcription task for video {video.id} to runner manager {runner_manager.name}"
-                    )
-                    return True
-                else:
-                    log.warning(
-                        f"Runner manager {runner_manager.name} returned status code {response.status_code}"
-                    )
-            except requests.RequestException as exc:
-                log.warning(
-                    f"Cannot reach runner manager {runner_manager.name}: {str(exc)}"
-                )
-
-        return False
 
     def _submit_studio_task(
-        self, recording: Recording, task: Task, site: Site, runner_managers: list
+        self, recording: Recording, site: Site, runner_managers: list
     ) -> bool:
-        """
-        Try to submit a studio task (recording XML link) to available runner managers.
-        Returns True if successful, False otherwise.
-        """
-        # Get settings
-        SECURE_SSL_REDIRECT = getattr(settings, "SECURE_SSL_REDIRECT", False)
-        VERSION = getattr(settings, "VERSION", "4.X")
-        TEMPLATE_VISIBLE_SETTINGS = getattr(
-            settings,
-            "TEMPLATE_VISIBLE_SETTINGS",
-            {
-                "TITLE_SITE": "Pod",
-                "TITLE_ETB": "University name",
-            },
+        """Submit a studio task using shared runner manager helpers."""
+        base_url = build_runner_base_url(site)
+        source_url = build_runner_studio_source_url(recording, base_url)
+        parameters = prepare_runner_encoding_parameters(video=None)
+        return self._submit_task_to_runner_managers(
+            task_type="studio",
+            source_type="recording",
+            source_id=recording.id,
+            source_url=source_url,
+            base_url=base_url,
+            parameters=parameters,
+            runner_managers=runner_managers,
         )
-        __TITLE_SITE__ = TEMPLATE_VISIBLE_SETTINGS.get("TITLE_SITE", "Pod")
-        __TITLE_ETB__ = TEMPLATE_VISIBLE_SETTINGS.get("TITLE_ETB", "University name")
-
-        # Build source XML URL from MEDIA_ROOT to MEDIA_URL
-        url_scheme = "https" if SECURE_SSL_REDIRECT else "http"
-        base_url = url_scheme + "://" + site.domain
-        media_url = getattr(settings, "MEDIA_URL", "/media/").rstrip("/")
-        try:
-            import os
-
-            rel_path = os.path.relpath(
-                str(recording.source_file), str(getattr(settings, "MEDIA_ROOT", ""))
-            )
-        except Exception:
-            rel_path = str(recording.source_file)
-        rel_path = rel_path.lstrip("/")
-        source_url = f"{base_url}{media_url}/{rel_path}"
-
-        # Parameters: same rendition payload as for video, no cut
-        from pod.video_encode_transcript.encoding_utils import get_list_rendition
-
-        list_rendition = get_list_rendition()
-        str_resolution = {
-            str(k): {"resolution": v["resolution"], "encode_mp4": v["encode_mp4"]}
-            for k, v in list_rendition.items()
-        }
-        json_resolution = json.dumps(str_resolution)
-        parameters = {"rendition": json_resolution}
-
-        data = {
-            "etab_name": f"{__TITLE_ETB__} / {__TITLE_SITE__}",
-            "app_name": "Esup-Pod",
-            "app_version": f"{VERSION}",
-            "task_type": "studio",
-            "source_url": f"{source_url}",
-            "notify_url": f"{base_url}/runner/notify_task_end/",
-            "parameters": parameters,
-        }
-
-        # Try each runner manager
-        for runner_manager in runner_managers:
-            try:
-                execute_url = runner_manager.url
-                if not execute_url.endswith("/"):
-                    execute_url += "/"
-                execute_url += "task/execute"
-
-                headers = {
-                    "Accept": "application/json",
-                    "Content-Type": "application/json",
-                    "Authorization": f"Bearer {runner_manager.token}",
-                }
-
-                response = requests.post(
-                    execute_url, data=json.dumps(data), headers=headers, timeout=30
-                )
-
-                if response.status_code == 200:
-                    task_id = response.json().get("task_id")
-                    status = response.json().get("status")
-
-                    # Update task with studio type
-                    task.status = status
-                    task.runner_manager = runner_manager
-                    task.task_id = task_id
-                    task.save()
-                    store_before_remote_encoding_recording(
-                        recording.id, execute_url, data
-                    )
-
-                    log.info(
-                        f"Successfully submitted studio task for recording {recording.id} to runner manager {runner_manager.name}"
-                    )
-                    return True
-                else:
-                    log.warning(
-                        f"Runner manager {runner_manager.name} returned status code {response.status_code}"
-                    )
-            except requests.RequestException as exc:
-                log.warning(
-                    f"Cannot reach runner manager {runner_manager.name}: {str(exc)}"
-                )
-
-        return False

--- a/pod/video_encode_transcript/runner_manager.py
+++ b/pod/video_encode_transcript/runner_manager.py
@@ -119,56 +119,105 @@ def _attach_cut_info(parameters: ParametersDict, video: Video) -> None:
         pass
 
 
-def _attach_dressing_info(parameters: ParametersDict, video: Video) -> None:
+def _build_base_url(site: Site) -> str:
+    """Build the public base URL for a given Django site."""
+    url_scheme = "https" if SECURE_SSL_REDIRECT else "http"
+    return f"{url_scheme}://{site.domain}"
+
+
+def _build_video_source_url(video: Video, base_url: str) -> str:
+    """Build the public source URL for a video file."""
+    return f"{base_url}/media/{video.video}"
+
+
+def _build_transcription_source_url(video: Video, base_url: str) -> str:
+    """Build the preferred source URL for transcription tasks."""
+    mp3 = video.get_video_mp3() if hasattr(video, "get_video_mp3") else None
+    mp3file = getattr(mp3, "source_file", None) if mp3 else None
+    if mp3file is not None and getattr(mp3file, "url", None):
+        return f"{base_url}{mp3file.url}"
+    return _build_video_source_url(video, base_url)
+
+
+def _build_studio_source_url(recording: Recording, base_url: str) -> str:
+    """Build the public source URL for a studio XML file."""
+    source_file = recording.source_file
+    media_url = getattr(settings, "MEDIA_URL", "/media/").rstrip("/")
+    try:
+        rel_path = os.path.relpath(
+            str(source_file), str(getattr(settings, "MEDIA_ROOT", ""))
+        )
+    except Exception:
+        rel_path = str(source_file)
+    rel_path = rel_path.lstrip("/")
+    return f"{base_url}{media_url}/{rel_path}"
+
+
+def _build_media_asset_url(base_url: str, asset_name: str) -> str:
+    """Build a public media URL for a stored asset name."""
+    return f"{base_url}/media/{asset_name}"
+
+
+def _extend_with_watermark_info(
+    dressing_info: ParametersDict, dressing: Any, base_url: str
+) -> None:
+    """Append watermark-related dressing metadata when available."""
+    if not dressing.watermark:
+        return
+
+    log.info("Dressing watermark found")
+    dressing_info["watermark"] = _build_media_asset_url(
+        base_url, str(dressing.watermark.file.name)
+    )
+    dressing_info["watermark_position"] = dressing.position
+    dressing_info["watermark_opacity"] = str(dressing.opacity)
+
+
+def _extend_with_credit_info(
+    dressing_info: ParametersDict, credit_name: str, credit, base_url: str
+) -> None:
+    """Append opening/ending credit metadata when available."""
+    if not credit:
+        return
+
+    log.info("Dressing %s found", credit_name.replace("_", " "))
+    dressing_info[credit_name] = credit.slug
+    dressing_info[f"{credit_name}_video"] = _build_media_asset_url(
+        base_url, str(credit.video.name)
+    )
+    dressing_info[f"{credit_name}_video_duration"] = str(credit.duration)
+
+
+def _attach_dressing_info(
+    parameters: ParametersDict, video: Video, base_url: Optional[str] = None
+) -> None:
     """Attach dressing information to parameters if available for the given video."""
     try:
         from pod.dressing.models import Dressing
 
-        site = Site.objects.get_current()
-        url_scheme = "https" if SECURE_SSL_REDIRECT else "http"
-        base_url = url_scheme + "://" + site.domain
+        if base_url is None:
+            site = Site.objects.get_current()
+            base_url = _build_base_url(site)
 
-        str_dressing_info = {}
-        if Dressing.objects.filter(videos=video).exists():
-            log.info("Dressing found for video id: %s", video.id)
-            dressing = Dressing.objects.get(videos=video)
-            if dressing:
-                if dressing.watermark:
-                    log.info("Dressing watermark found")
-                    watermark_content_url = "%s/media/%s" % (
-                        base_url,
-                        str(dressing.watermark.file.name),
-                    )
-                    str_dressing_info["watermark"] = watermark_content_url
-                    str_dressing_info["watermark_position"] = dressing.position
-                    str_dressing_info["watermark_opacity"] = str(dressing.opacity)
-                if dressing.opening_credits:
-                    log.info("Dressing opening credits found")
-                    str_dressing_info["opening_credits"] = dressing.opening_credits.slug
-                    opening_content_url = "%s/media/%s" % (
-                        base_url,
-                        str(dressing.opening_credits.video.name),
-                    )
-                    str_dressing_info["opening_credits_video"] = opening_content_url
-                    str_dressing_info["opening_credits_video_duration"] = str(
-                        dressing.opening_credits.duration
-                    )
-                if dressing.ending_credits:
-                    log.info("Dressing ending credits found")
-                    str_dressing_info["ending_credits"] = dressing.ending_credits.slug
-                    ending_content_url = "%s/media/%s" % (
-                        base_url,
-                        str(dressing.ending_credits.video.name),
-                    )
-                    str_dressing_info["ending_credits_video"] = ending_content_url
-                    str_dressing_info["ending_credits_video_duration"] = str(
-                        dressing.ending_credits.duration
-                    )
-                    # str_dressing_info["ending_credits_video_hasaudio"] = str(
-                    #     dressing.ending_credits.video.has_audio()
-                    # )
-        if str_dressing_info:
-            parameters["dressing"] = json.dumps(str_dressing_info)
+        if not Dressing.objects.filter(videos=video).exists():
+            return
+
+        log.info("Dressing found for video id: %s", video.id)
+        dressing = Dressing.objects.get(videos=video)
+        if not dressing:
+            return
+
+        dressing_info: ParametersDict = {}
+        _extend_with_watermark_info(dressing_info, dressing, base_url)
+        _extend_with_credit_info(
+            dressing_info, "opening_credits", dressing.opening_credits, base_url
+        )
+        _extend_with_credit_info(
+            dressing_info, "ending_credits", dressing.ending_credits, base_url
+        )
+
+        if dressing_info:
+            parameters["dressing"] = json.dumps(dressing_info)
     except Exception as exc:
         log.error(f"Error obtaining dressing for video {video.id}: {str(exc)}")
 
@@ -190,6 +239,7 @@ def _attach_video_metadata(parameters: ParametersDict, video: Video) -> None:
 
 def _prepare_encoding_parameters(
     video: Optional[Video] = None,
+    base_url: Optional[str] = None,
 ) -> ParametersDict:
     """Prepare encoding parameters for video or recording.
 
@@ -197,6 +247,8 @@ def _prepare_encoding_parameters(
         video: Video object (for video encoding).
                For studio recordings, pass None as video-specific metadata,
                cut and dressing info do not apply.
+        base_url: Explicit base URL to use for dressing asset URLs.
+                  Defaults to the current site URL when omitted.
 
     Returns:
         Dictionary with rendition and, when a video is provided, optional
@@ -207,7 +259,10 @@ def _prepare_encoding_parameters(
 
     if video:
         _attach_cut_info(parameters, video)
-        _attach_dressing_info(parameters, video)
+        if base_url is None:
+            _attach_dressing_info(parameters, video)
+        else:
+            _attach_dressing_info(parameters, video, base_url=base_url)
         _attach_video_metadata(parameters, video)
 
     return parameters
@@ -431,6 +486,35 @@ def _submit_to_runner_manager(
     return True
 
 
+def _submit_to_runner_managers(
+    *,
+    runner_managers: list[RunnerManager],
+    data: RunnerManagerTaskPayload,
+    task_type: TaskType,
+    source_type: SourceType,
+    source_id: Union[int, str],
+) -> bool:
+    """Try runner managers in order and stop on the first successful submission."""
+    video_id, recording_id = _ids_for(source_type, source_id)
+
+    for rm in runner_managers:
+        if _submit_to_runner_manager(
+            rm,
+            data=data,
+            task_type=task_type,
+            source_type=source_type,
+            video_id=video_id,
+            recording_id=recording_id,
+        ):
+            return True
+
+    log.warning(
+        f"No runner manager available to process {task_type} for {source_type} {source_id}. "
+        f"Task will remain pending and will be retried by the process_tasks command."
+    )
+    return False
+
+
 def _update_task_pending(
     source_type: SourceType, source_id: Union[int, str], task_type: TaskType
 ) -> tuple[Optional[int], Optional[int]]:
@@ -497,7 +581,7 @@ def _send_task_to_runner_manager(
     try:
         # Keep a local pending row even when no runner is currently available.
         # This allows process_tasks to retry submission later.
-        video_id, recording_id = _update_task_pending(source_type, source_id, task_type)
+        _update_task_pending(source_type, source_id, task_type)
 
         site = Site.objects.get_current()
         runner_managers_list = _get_runner_managers(site)
@@ -510,23 +594,13 @@ def _send_task_to_runner_manager(
         # Build payload and try immediate submission
         data = _prepare_task_data(source_url, base_url, parameters, task_type)
 
-        # Try each runner manager by priority and stop on the first healthy one.
-        for rm in runner_managers_list:
-            if _submit_to_runner_manager(
-                rm,
-                data=data,
-                task_type=task_type,
-                source_type=source_type,
-                video_id=video_id,
-                recording_id=recording_id,
-            ):
-                return True
-
-        log.warning(
-            f"No runner manager available to process {task_type} for {source_type} {source_id}. "
-            f"Task will remain pending and will be retried by the process_tasks command."
+        return _submit_to_runner_managers(
+            runner_managers=runner_managers_list,
+            data=data,
+            task_type=task_type,
+            source_type=source_type,
+            source_id=source_id,
         )
-        return False
 
     except Exception as exc:
         log.error(
@@ -543,9 +617,8 @@ def encode_video(video_id: int) -> None:
         # Get video info
         video = get_object_or_404(Video, id=video_id)
         # Build content URL
-        url_scheme = "https" if SECURE_SSL_REDIRECT else "http"
-        base_url = url_scheme + "://" + site.domain
-        content_url = "%s/media/%s" % (base_url, video.video)
+        base_url = _build_base_url(site)
+        content_url = _build_video_source_url(video, base_url)
 
         # Prepare encoding parameters
         parameters = _prepare_encoding_parameters(video=video)
@@ -579,22 +652,8 @@ def encode_studio_recording(recording_id: int) -> None:
         site = Site.objects.get_current()
         # Get studio recording
         recording = Recording.objects.get(id=recording_id)
-        # Source file corresponds to Pod XML file
-        source_file = recording.source_file
-
-        # Build source file URL.
-        # `source_file` is sometimes an absolute MEDIA_ROOT path and sometimes already relative.
-        url_scheme = "https" if SECURE_SSL_REDIRECT else "http"
-        base_url = url_scheme + "://" + site.domain
-        media_url = getattr(settings, "MEDIA_URL", "/media/").rstrip("/")
-        try:
-            rel_path = os.path.relpath(
-                str(source_file), str(getattr(settings, "MEDIA_ROOT", ""))
-            )
-        except Exception:
-            rel_path = str(source_file)
-        rel_path = rel_path.lstrip("/")
-        source_url = f"{base_url}{media_url}/{rel_path}"
+        base_url = _build_base_url(site)
+        source_url = _build_studio_source_url(recording, base_url)
 
         # Prepare encoding parameters (no specific cut info for studio recordings)
         parameters = _prepare_encoding_parameters(video=None)
@@ -622,15 +681,8 @@ def transcript_video(video_id: int) -> None:
         site = Site.objects.get_current()
         # Get video info
         video = get_object_or_404(Video, id=video_id)
-        # Get associated mp3 file if exists
-        mp3file = video.get_video_mp3().source_file if video.get_video_mp3() else None
-        url_scheme = "https" if SECURE_SSL_REDIRECT else "http"
-        base_url = url_scheme + "://" + site.domain
-        if mp3file is not None:
-            content_url = "%s%s" % (base_url, mp3file.url)
-        else:
-            # Build video content URL
-            content_url = "%s/media/%s" % (base_url, video.video)
+        base_url = _build_base_url(site)
+        content_url = _build_transcription_source_url(video, base_url)
 
         # Prepare transcript parameters
         parameters = _prepare_transcription_parameters(video=video)

--- a/pod/video_encode_transcript/runner_manager.py
+++ b/pod/video_encode_transcript/runner_manager.py
@@ -99,7 +99,12 @@ def _build_rendition_parameters() -> ParametersDict:
     """Return rendition parameters serialized for the runner payload."""
     list_rendition = get_list_rendition()
     str_resolution: dict[str, dict[str, Any]] = {
-        str(k): {"resolution": v["resolution"], "encode_mp4": v["encode_mp4"]}
+        str(k): {
+            "resolution": v["resolution"],
+            "video_bitrate": v["video_bitrate"],
+            "audio_bitrate": v["audio_bitrate"],
+            "encode_mp4": v["encode_mp4"],
+        }
         for k, v in list_rendition.items()
     }
     return {"rendition": json.dumps(str_resolution)}

--- a/pod/video_encode_transcript/tests/test_process_tasks.py
+++ b/pod/video_encode_transcript/tests/test_process_tasks.py
@@ -23,7 +23,14 @@ class ProcessTasksCommandPayloadTests(SimpleTestCase):
 
     @patch(
         "pod.video_encode_transcript.runner_manager.get_list_rendition",
-        return_value={360: {"resolution": "640x360", "encode_mp4": True}},
+        return_value={
+            360: {
+                "resolution": "640x360",
+                "video_bitrate": "750k",
+                "audio_bitrate": "96k",
+                "encode_mp4": True,
+            }
+        },
     )
     @patch("pod.video_encode_transcript.runner_manager._attach_dressing_info")
     @patch("pod.video_encode_transcript.runner_manager._attach_cut_info")
@@ -56,7 +63,14 @@ class ProcessTasksCommandPayloadTests(SimpleTestCase):
         self.assertEqual(payload["parameters"]["video_title"], "Sample video")
         self.assertEqual(
             json.loads(payload["parameters"]["rendition"]),
-            {"360": {"resolution": "640x360", "encode_mp4": True}},
+            {
+                "360": {
+                    "resolution": "640x360",
+                    "video_bitrate": "750k",
+                    "audio_bitrate": "96k",
+                    "encode_mp4": True,
+                }
+            },
         )
         mock_get_list_rendition.assert_called_once_with()
         mock_attach_cut_info.assert_called_once()
@@ -134,7 +148,14 @@ class ProcessTasksCommandPayloadTests(SimpleTestCase):
     )
     @patch(
         "pod.video_encode_transcript.runner_manager.get_list_rendition",
-        return_value={720: {"resolution": "1280x720", "encode_mp4": False}},
+        return_value={
+            720: {
+                "resolution": "1280x720",
+                "video_bitrate": "2000k",
+                "audio_bitrate": "128k",
+                "encode_mp4": False,
+            }
+        },
     )
     def test_submit_studio_task_uses_shared_source_url_and_payload(
         self, mock_get_list_rendition, mock_submit_runner_task_to_managers
@@ -155,7 +176,14 @@ class ProcessTasksCommandPayloadTests(SimpleTestCase):
         )
         self.assertEqual(
             json.loads(payload["parameters"]["rendition"]),
-            {"720": {"resolution": "1280x720", "encode_mp4": False}},
+            {
+                "720": {
+                    "resolution": "1280x720",
+                    "video_bitrate": "2000k",
+                    "audio_bitrate": "128k",
+                    "encode_mp4": False,
+                }
+            },
         )
         self.assertNotIn("video_id", payload["parameters"])
         mock_get_list_rendition.assert_called_once_with()

--- a/pod/video_encode_transcript/tests/test_process_tasks.py
+++ b/pod/video_encode_transcript/tests/test_process_tasks.py
@@ -1,0 +1,168 @@
+"""
+Tests for the process_tasks management command runner payloads for Esup-Pod.
+
+Run with `python manage.py test pod.video_encode_transcript.tests.test_process_tasks`
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from django.test import SimpleTestCase, override_settings
+
+from pod.video_encode_transcript.management.commands.process_tasks import Command
+
+
+class ProcessTasksCommandPayloadTests(SimpleTestCase):
+    """Verify process_tasks delegates payload building to shared runner helpers."""
+
+    def setUp(self) -> None:
+        self.command = Command()
+        self.site = SimpleNamespace(domain="example.com")
+        self.runner_manager = SimpleNamespace(name="runner-a")
+
+    @patch(
+        "pod.video_encode_transcript.runner_manager.get_list_rendition",
+        return_value={360: {"resolution": "640x360", "encode_mp4": True}},
+    )
+    @patch("pod.video_encode_transcript.runner_manager._attach_dressing_info")
+    @patch("pod.video_encode_transcript.runner_manager._attach_cut_info")
+    @patch(
+        "pod.video_encode_transcript.management.commands.process_tasks.submit_runner_task_to_managers"
+    )
+    def test_submit_encoding_task_includes_video_metadata(
+        self,
+        mock_submit_runner_task_to_managers,
+        mock_attach_cut_info,
+        mock_attach_dressing_info,
+        mock_get_list_rendition,
+    ) -> None:
+        """Encoding tasks should build a shared payload including video metadata."""
+        mock_submit_runner_task_to_managers.return_value = True
+
+        video = SimpleNamespace(
+            id=17,
+            slug="sample-video",
+            title="Sample video",
+            video="videos/sample.mp4",
+        )
+
+        result = self.command._submit_encoding_task(video, self.site, [self.runner_manager])
+
+        self.assertTrue(result)
+        payload = mock_submit_runner_task_to_managers.call_args.kwargs["data"]
+        self.assertEqual(payload["parameters"]["video_id"], 17)
+        self.assertEqual(payload["parameters"]["video_slug"], "sample-video")
+        self.assertEqual(payload["parameters"]["video_title"], "Sample video")
+        self.assertEqual(
+            json.loads(payload["parameters"]["rendition"]),
+            {"360": {"resolution": "640x360", "encode_mp4": True}},
+        )
+        mock_get_list_rendition.assert_called_once_with()
+        mock_attach_cut_info.assert_called_once()
+        mock_attach_dressing_info.assert_called_once()
+        self.assertEqual(
+            payload["source_url"], "http://example.com/media/videos/sample.mp4"
+        )
+        self.assertEqual(
+            payload["notify_url"], "http://example.com/runner/notify_task_end/"
+        )
+        mock_submit_runner_task_to_managers.assert_called_once_with(
+            runner_managers=[self.runner_manager],
+            data=payload,
+            task_type="encoding",
+            source_type="video",
+            source_id=17,
+        )
+
+    @override_settings(
+        TRANSCRIPTION_TYPE="whisper",
+        TRANSCRIPTION_NORMALIZE=True,
+    )
+    @patch(
+        "pod.video_encode_transcript.management.commands.process_tasks.submit_runner_task_to_managers"
+    )
+    @patch(
+        "pod.video_encode_transcript.transcript.resolve_transcription_language",
+        return_value="fr",
+    )
+    def test_submit_transcription_task_includes_video_metadata(
+        self, mock_resolve_transcription_language, mock_submit_runner_task_to_managers
+    ) -> None:
+        """Transcription tasks should build a shared payload including metadata."""
+        mock_submit_runner_task_to_managers.return_value = True
+
+        video = Mock(
+            id=23,
+            slug="transcript-video",
+            title="Transcript video",
+            transcript="fr",
+            duration=12.5,
+            video="videos/transcript.mp4",
+        )
+        video.get_video_mp3.return_value = None
+
+        result = self.command._submit_transcription_task(video, self.site, [self.runner_manager])
+
+        self.assertTrue(result)
+        payload = mock_submit_runner_task_to_managers.call_args.kwargs["data"]
+        self.assertEqual(payload["parameters"]["language"], "fr")
+        self.assertEqual(payload["parameters"]["duration"], 12.5)
+        self.assertTrue(payload["parameters"]["normalize"])
+        self.assertEqual(payload["parameters"]["model_type"], "whisper")
+        self.assertEqual(payload["parameters"]["video_id"], 23)
+        self.assertEqual(payload["parameters"]["video_slug"], "transcript-video")
+        self.assertEqual(payload["parameters"]["video_title"], "Transcript video")
+        self.assertEqual(
+            payload["source_url"], "http://example.com/media/videos/transcript.mp4"
+        )
+        mock_submit_runner_task_to_managers.assert_called_once_with(
+            runner_managers=[self.runner_manager],
+            data=payload,
+            task_type="transcription",
+            source_type="video",
+            source_id=23,
+        )
+        mock_resolve_transcription_language.assert_called_once_with(video)
+
+    @override_settings(
+        MEDIA_ROOT="/srv/media",
+        MEDIA_URL="/media/",
+    )
+    @patch(
+        "pod.video_encode_transcript.management.commands.process_tasks.submit_runner_task_to_managers"
+    )
+    @patch(
+        "pod.video_encode_transcript.runner_manager.get_list_rendition",
+        return_value={720: {"resolution": "1280x720", "encode_mp4": False}},
+    )
+    def test_submit_studio_task_uses_shared_source_url_and_payload(
+        self, mock_get_list_rendition, mock_submit_runner_task_to_managers
+    ) -> None:
+        """Studio tasks should reuse shared source URL and payload builders."""
+        mock_submit_runner_task_to_managers.return_value = True
+
+        recording = SimpleNamespace(id=31, source_file="/srv/media/studio/source.xml")
+
+        result = self.command._submit_studio_task(
+            recording, self.site, [self.runner_manager]
+        )
+
+        self.assertTrue(result)
+        payload = mock_submit_runner_task_to_managers.call_args.kwargs["data"]
+        self.assertEqual(
+            payload["source_url"], "http://example.com/media/studio/source.xml"
+        )
+        self.assertEqual(
+            json.loads(payload["parameters"]["rendition"]),
+            {"720": {"resolution": "1280x720", "encode_mp4": False}},
+        )
+        self.assertNotIn("video_id", payload["parameters"])
+        mock_get_list_rendition.assert_called_once_with()
+        mock_submit_runner_task_to_managers.assert_called_once_with(
+            runner_managers=[self.runner_manager],
+            data=payload,
+            task_type="studio",
+            source_type="recording",
+            source_id=31,
+        )

--- a/pod/video_encode_transcript/tests/test_runner_manager_helpers.py
+++ b/pod/video_encode_transcript/tests/test_runner_manager_helpers.py
@@ -95,8 +95,18 @@ class RunnerManagerHelperTests(SimpleTestCase):
         with patch(
             "pod.video_encode_transcript.runner_manager.get_list_rendition",
             return_value={
-                360: {"resolution": "640x360", "encode_mp4": True},
-                720: {"resolution": "1280x720", "encode_mp4": False},
+                360: {
+                    "resolution": "640x360",
+                    "video_bitrate": "750k",
+                    "audio_bitrate": "96k",
+                    "encode_mp4": True,
+                },
+                720: {
+                    "resolution": "1280x720",
+                    "video_bitrate": "2000k",
+                    "audio_bitrate": "128k",
+                    "encode_mp4": False,
+                },
             },
         ):
             params = _build_rendition_parameters()
@@ -104,10 +114,48 @@ class RunnerManagerHelperTests(SimpleTestCase):
         self.assertEqual(
             json.loads(params["rendition"]),
             {
-                "360": {"resolution": "640x360", "encode_mp4": True},
-                "720": {"resolution": "1280x720", "encode_mp4": False},
+                "360": {
+                    "resolution": "640x360",
+                    "video_bitrate": "750k",
+                    "audio_bitrate": "96k",
+                    "encode_mp4": True,
+                },
+                "720": {
+                    "resolution": "1280x720",
+                    "video_bitrate": "2000k",
+                    "audio_bitrate": "128k",
+                    "encode_mp4": False,
+                },
             },
         )
+
+    def test_build_rendition_parameters_includes_bitrate_fields_for_each_rendition(
+        self,
+    ) -> None:
+        """Ensure each serialized rendition includes both audio and video bitrates."""
+        with patch(
+            "pod.video_encode_transcript.runner_manager.get_list_rendition",
+            return_value={
+                360: {
+                    "resolution": "640x360",
+                    "video_bitrate": "750k",
+                    "audio_bitrate": "96k",
+                    "encode_mp4": True,
+                },
+                1080: {
+                    "resolution": "1920x1080",
+                    "video_bitrate": "3000k",
+                    "audio_bitrate": "192k",
+                    "encode_mp4": False,
+                },
+            },
+        ):
+            params = _build_rendition_parameters()
+
+        rendition_payload = json.loads(params["rendition"])
+        for rendition_data in rendition_payload.values():
+            self.assertIn("video_bitrate", rendition_data)
+            self.assertIn("audio_bitrate", rendition_data)
 
     def test_attach_cut_info_adds_serialized_cut(self) -> None:
         """Store cut metadata when a CutVideo row exists."""


### PR DESCRIPTION
## Summary

This PR refactors runner manager task submission to reduce duplicated logic and keep payload generation consistent across direct runner manager calls and the `process_tasks` management command.

## Changes

- move shared runner manager submission logic into reusable helpers
- reuse shared payload builders from `runner_manager.py` in `process_tasks.py`
- align encoding and transcription payloads sent by `process_tasks` with direct runner manager flows
- add dedicated tests for `process_tasks` payload generation and delegation
- simplify dressing metadata handling in `runner_manager.py` to satisfy flake8 complexity checks
- Add video_bitrate and audio_bitrate to each rendition entry sent to the Runner Manager payload.
- Update related helper and process task tests to validate the enriched rendition format.
