### PR TITLE
FEAT(video): add transfer_ownership endpoint for admins

### DIFF
--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -338,3 +338,36 @@ class VideoViewSet(viewsets.ModelViewSet):
 
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+    @extend_schema(
+        summary="Transfer video ownership",
+        description="Allows an admin to change the owner of a video.",
+        request={"application/json": {"type": "object", "properties": {"owner_id": {"type": "integer"}}}},
+        responses={200: {"type": "object", "properties": {"status": {"type": "string"}}}},
+    )
+    @action(
+        detail=True, methods=["post"], permission_classes=[permissions.IsAdminUser]
+    )
+    def transfer_ownership(self, request, slug=None):
+        """
+        Transfers the ownership of a video to another user.
+        Accessible only by administrators.
+        """
+        video = self.get_object()
+        new_owner_id = request.data.get("owner_id")
+
+        if not new_owner_id:
+            raise ValidationError({"owner_id": _("This field is required.")})
+
+        from django.contrib.auth import get_user_model
+        User = get_user_model()
+
+        try:
+            new_owner = User.objects.get(pk=new_owner_id)
+        except User.DoesNotExist:
+            raise ValidationError({"owner_id": _("User not found.")})
+
+        video.owner = new_owner
+        video.save(update_fields=["owner"])
+
+        return Response({"status": "ownership transferred"})


### PR DESCRIPTION
# feat(video): add transfer_ownership endpoint for admins

This PR introduces a new feature allowing administrators to transfer the ownership (owner) of a video to another user.

Currently, the owner field of a video is set to read-only (ReadOnlyField in VideoSerializer) for obvious security reasons. Therefore, it cannot be modified through the standard PATCH /api/videos/{slug} requests.

What was done:
Added a custom transfer_ownership action (POST method) to the VideoViewSet (/api/videos/{slug}/transfer_ownership/).


However, administrators frequently need the ability to reassign a video to a different user.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
