### PR TITLE
FEAT[authentication]: add DELETE method to update_picture for profile picture removal

### DIFF
--- a/src/apps/authentication/tests/test_views.py
+++ b/src/apps/authentication/tests/test_views.py
@@ -155,3 +155,46 @@ class OIDCLoginViewTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(User.objects.filter(username="oidcuser").exists())
+
+
+class OwnerPictureTests(APITestCase):
+    """
+    Test suite for managing an owner's profile picture.
+    """
+
+    def setUp(self):
+        """
+        Initializes a test user and an image for upload.
+        """
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        self.user = User.objects.create_user(username="picuser", password="picpassword")
+        self.owner, _ = Owner.objects.get_or_create(user=self.user)
+        self.client.force_authenticate(user=self.user)
+
+        # Build the URL by appending 'picture/' to the owner detail URL
+        owner_detail_url = reverse("owner-detail", args=[self.owner.id])
+        self.url = f"{owner_detail_url}picture/"
+
+        self.image_content = b"fake_image_content"
+        self.uploaded_pic = SimpleUploadedFile(
+            "test_pic.jpg", self.image_content, content_type="image/jpeg"
+        )
+
+    def test_upload_and_delete_picture(self):
+        """
+        Tests that an authenticated user can upload a picture and then delete it.
+        """
+        # 1. Upload the picture
+        response = self.client.patch(
+            self.url, {"picture": self.uploaded_pic}, format="multipart"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.owner.refresh_from_db()
+        self.assertTrue(bool(self.owner.userpicture))
+
+        # 2. Delete the picture
+        delete_response = self.client.delete(self.url)
+        self.assertEqual(delete_response.status_code, status.HTTP_204_NO_CONTENT)
+        self.owner.refresh_from_db()
+        self.assertFalse(bool(self.owner.userpicture))

--- a/src/apps/authentication/views/model_views.py
+++ b/src/apps/authentication/views/model_views.py
@@ -8,6 +8,7 @@ and AccessGroup models.
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site
+from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema
 from rest_framework import filters, status, viewsets
 from rest_framework.decorators import action
@@ -103,19 +104,30 @@ class OwnerViewSet(viewsets.ModelViewSet):
             )
             return Response(serializer.data)
         except Owner.DoesNotExist:
-            return Response({"error": "User not found"}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": _("User not found")}, status=status.HTTP_404_NOT_FOUND)
 
-    @action(detail=True, methods=["post", "patch"], url_path="picture")
+    @action(detail=True, methods=["post", "patch", "delete"], url_path="picture")
     def update_picture(self, request, pk=None):
         """
-        Uploads and assigns an image as the user's profile picture.
+        Uploads and assigns an image as the user's profile picture, or deletes it.
         """
         owner = self.get_object()
+
+        if request.method == "DELETE":
+            if owner.userpicture:
+                owner.userpicture.delete(save=False)
+                owner.userpicture = None
+                owner.save(update_fields=["userpicture"])
+            return Response(
+                {"status": "success", "message": _("Profile picture deleted.")},
+                status=status.HTTP_204_NO_CONTENT,
+            )
+
         file = request.FILES.get("picture")
 
         if not file:
             return Response(
-                {"error": "No picture file provided in the request."},
+                {"error": _("No picture file provided in the request.")},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -128,7 +140,7 @@ class OwnerViewSet(viewsets.ModelViewSet):
         return Response(
             {
                 "status": "success",
-                "message": "Profile picture updated.",
+                "message": _("Profile picture updated."),
                 "userpicture": request.build_absolute_uri(owner.userpicture.url),
             },
             status=status.HTTP_200_OK,

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -342,12 +342,15 @@ class VideoViewSet(viewsets.ModelViewSet):
     @extend_schema(
         summary="Transfer video ownership",
         description="Allows an admin to change the owner of a video.",
-        request={"application/json": {"type": "object", "properties": {"owner_id": {"type": "integer"}}}},
+        request={
+            "application/json": {
+                "type": "object",
+                "properties": {"owner_id": {"type": "integer"}},
+            }
+        },
         responses={200: {"type": "object", "properties": {"status": {"type": "string"}}}},
     )
-    @action(
-        detail=True, methods=["post"], permission_classes=[permissions.IsAdminUser]
-    )
+    @action(detail=True, methods=["post"], permission_classes=[permissions.IsAdminUser])
     def transfer_ownership(self, request, slug=None):
         """
         Transfers the ownership of a video to another user.
@@ -360,6 +363,7 @@ class VideoViewSet(viewsets.ModelViewSet):
             raise ValidationError({"owner_id": _("This field is required.")})
 
         from django.contrib.auth import get_user_model
+
         User = get_user_model()
 
         try:


### PR DESCRIPTION
## FEAT[authentication]: add DELETE method to update_picture for profile picture removal

- New Endpoint Feature: Added the DELETE method to the /api/owners/{id}/picture/ endpoint.
- Profile Picture Removal: Users can now completely remove their profile picture via the API.
- Automatic Cleanup: When a picture is deleted, the physical image file is automatically removed from the server's storage to save space.
- Optimized Performance: The deletion process is optimized to update only the specific profile picture field in the database, making it faster and more reliable.
- Unit Tested: Added automated tests to ensure the upload and deletion of profile pictures work perfectly and won't break in future updates.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
