### PR TITLE
FEAT[CI]: add PyDoc audit script to quality check and Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Lint with flake8
         run: flake8 src --count --show-source --statistics
 
+      - name: Run PyDoc Audit
+        run: python scripts/check_pydocs.py
+
       - name: Create .env file
         run: cp .env.example .env
 

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ lint: start ## Run linters (black, flake8) inside the API service
 	$(DOCKER_COMPOSE_CMD) run --rm $(DOCKER_SERVICE_NAME) black . -l 90
 	$(call info,Running flake8...)
 	$(DOCKER_COMPOSE_CMD) run --rm $(DOCKER_SERVICE_NAME) flake8 src --count --show-source --statistics
+	$(call info,Running PyDoc audit...)
+	python3 scripts/check_pydocs.py
 
 clean: stop ## Full shutdown and cleanup. Usage: make clean [service]
 	$(call info,Cleaning (service(s): $(if $(SERVICE_ARGS),$(SERVICE_ARGS),all))...)

--- a/scripts/check_pydocs.py
+++ b/scripts/check_pydocs.py
@@ -1,0 +1,149 @@
+"""
+Esup-Pod - Documentation Audit Script
+
+This script audits Python files across the project to ensure code documentation standards.
+Specifically, it checks that:
+- The mention 'Esup-Pod' is present on the first or second line of the file.
+- A module-level docstring is defined.
+- Every class has an associated docstring.
+- Every function/method (excluding private methods other than __init__) has a docstring.
+
+It uses 'git ls-files' to scan relevant files, falling back to an OS walk if git is unavailable.
+"""
+
+import ast
+import os
+import subprocess
+
+
+def get_git_files(root_dir="src"):
+    """
+    Returns a list of all non-ignored Python files in the repository.
+    Uses 'git ls-files' to accurately respect .gitignore.
+    """
+    try:
+        output = subprocess.check_output(
+            ["git", "ls-files", "--cached", "--others", "--exclude-standard", root_dir],
+            universal_newlines=True,
+        )
+        files = output.splitlines()
+        return [
+            f
+            for f in files
+            if (f.endswith(".py") or f.endswith(".py.example")) and "__init__.py" not in f
+        ]
+    except subprocess.CalledProcessError:
+        print("Warning: Could not use git to filter files. Falling back to manual crawl.")
+        all_py_files = []
+        for root, dirs, filenames in os.walk(root_dir):
+            if any(
+                d in root for d in [".git", "__pycache__", "venv", ".venv", "migrations"]
+            ):
+                continue
+            for f in filenames:
+                if (
+                    f.endswith(".py") or f.endswith(".py.example")
+                ) and "__init__.py" not in f:
+                    all_py_files.append(os.path.join(root, f))
+        return all_py_files
+
+
+def check_file_pydocs(filepath):
+    """Analyzes docstrings and Esup-Pod mention in a Python file."""
+    with open(filepath, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    try:
+        tree = ast.parse(content)
+    except Exception as e:
+        return {"error": f"Parsing Error: {str(e)}"}
+
+    results = {
+        "missing_module_doc": False,
+        "missing_esup_pod": False,
+        "missing_class_docs": [],
+        "missing_func_docs": [],
+    }
+
+    lines = content.splitlines()
+    esup_pod_found = False
+    for i in range(min(2, len(lines))):
+        if "Esup-Pod" in lines[i]:
+            esup_pod_found = True
+            break
+
+    if not esup_pod_found:
+        results["missing_esup_pod"] = True
+
+    module_doc = ast.get_docstring(tree)
+    if not module_doc:
+        results["missing_module_doc"] = True
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            if not ast.get_docstring(node):
+                results["missing_class_docs"].append(node.name)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if (
+                node.name.startswith("__")
+                and node.name.endswith("__")
+                and node.name != "__init__"
+            ):
+                continue
+
+            func_length = node.end_lineno - node.lineno + 1
+            if func_length < 3:
+                continue
+
+            if not ast.get_docstring(node):
+                results["missing_func_docs"].append(node.name)
+
+    return results
+
+
+def run_audit(root_dir="src"):
+    """Audits clean files list and outputs issues."""
+    print(f"Auditing documentation (Git-aware) in: {root_dir}")
+    print("-" * 60)
+
+    clean_files = get_git_files(root_dir)
+    found_issues = False
+
+    for filepath in clean_files:
+        audit = check_file_pydocs(filepath)
+
+        if audit.get("error"):
+            print(f"FAILED: {filepath} - {audit['error']}")
+            continue
+
+        issues = []
+        if audit["missing_module_doc"]:
+            issues.append("MISSING module docstring")
+        elif audit["missing_esup_pod"]:
+            issues.append("MISSING 'Esup-Pod' in header")
+
+        if audit["missing_class_docs"]:
+            issues.append(
+                f"MISSING class docstrings: {', '.join(audit['missing_class_docs'])}"
+            )
+
+        if audit["missing_func_docs"]:
+            funcs = audit["missing_func_docs"]
+            summary = ", ".join(funcs[:5]) + (
+                f" (+{len(funcs)-5})" if len(funcs) > 5 else ""
+            )
+            issues.append(f"MISSING func docstrings: {summary}")
+
+        if issues:
+            found_issues = True
+            print(f"FILE: {filepath}")
+            for issue in issues:
+                print(f"  - {issue}")
+            print()
+
+    if not found_issues:
+        print("Everything is perfect! 🏁")
+
+
+if __name__ == "__main__":
+    run_audit()

--- a/src/apps/authentication/views/model_views.py
+++ b/src/apps/authentication/views/model_views.py
@@ -104,7 +104,9 @@ class OwnerViewSet(viewsets.ModelViewSet):
             )
             return Response(serializer.data)
         except Owner.DoesNotExist:
-            return Response({"error": _("User not found")}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {"error": _("User not found")}, status=status.HTTP_404_NOT_FOUND
+            )
 
     @action(detail=True, methods=["post", "patch", "delete"], url_path="picture")
     def update_picture(self, request, pk=None):


### PR DESCRIPTION
## FEAT[CI]: add PyDoc audit script to quality check and Makefile

This PR add a new Python script to automate the documentation audit, ensuring all files include the "Esup-Pod" header and proper docstrings. To enforce this standard, I integrated the script into the GitHub Actions CI pipeline so it runs automatically during the quality check job. Finally, I updated the project's Makefile to include this audit within the lint target, meaning the same checks will now run locally whenever a developer uses make ci or make 

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
