### PR TITLE
FIX[API]: Several bugs and oversights have been fixed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
   quality-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"
@@ -45,10 +45,10 @@ jobs:
     needs: [quality-check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/scripts/check_pydocs.py
+++ b/scripts/check_pydocs.py
@@ -14,6 +14,7 @@ It uses 'git ls-files' to scan relevant files, falling back to an OS walk if git
 import ast
 import os
 import subprocess
+import sys
 
 
 def get_git_files(root_dir="src"):
@@ -143,6 +144,8 @@ def run_audit(root_dir="src"):
 
     if not found_issues:
         print("Everything is perfect! 🏁")
+    else:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/apps/video/serializers/VideoSerializer.py
+++ b/src/apps/video/serializers/VideoSerializer.py
@@ -16,6 +16,37 @@ from .DisciplineSerializer import DisciplineSerializer
 User = get_user_model()
 
 
+class TagListSerializerField(serializers.Field):
+    """
+    Custom field for django-tagulous TagField to support read and write operations.
+    """
+
+    def get_value(self, dictionary):
+        if self.field_name not in dictionary:
+            return serializers.empty
+        if hasattr(dictionary, "getlist"):
+            return dictionary.getlist(self.field_name)
+        return dictionary.get(self.field_name)
+
+    def to_representation(self, value):
+        return [tag.name for tag in value.all()]
+
+    def to_internal_value(self, data):
+        if isinstance(data, list):
+            result = []
+            for item in data:
+                if isinstance(item, str):
+                    result.extend([t.strip() for t in item.split(",") if t.strip()])
+                else:
+                    result.append(item)
+            return result
+        if isinstance(data, str):
+            return [tag.strip() for tag in data.split(",") if tag.strip()]
+        raise serializers.ValidationError(
+            "Expected a list of tags or a comma-separated string."
+        )
+
+
 class VideoSerializer(serializers.ModelSerializer):
     """
     Esup-Pod - Serializer for the Video model.
@@ -23,14 +54,18 @@ class VideoSerializer(serializers.ModelSerializer):
 
     owner = serializers.ReadOnlyField(source="owner.username")
     owner_id = serializers.ReadOnlyField(source="owner.id")
+    owner_first_name = serializers.ReadOnlyField(source="owner.first_name")
+    owner_last_name = serializers.ReadOnlyField(source="owner.last_name")
     video_url = serializers.SerializerMethodField()
     status_label = serializers.CharField(source="get_status_display", read_only=True)
     encoding_status_label = serializers.CharField(
         source="get_encoding_status_display", read_only=True
     )
     has_password = serializers.BooleanField(source="password", read_only=True)
-    password = serializers.CharField(write_only=True, required=False)
-    tags = serializers.StringRelatedField(many=True, required=False)
+    password = serializers.CharField(
+        write_only=True, required=False, allow_blank=True, allow_null=True
+    )
+    tags = TagListSerializerField(required=False)
     subtitles = SubtitleSerializer(many=True, read_only=True)
     encodings = serializers.SerializerMethodField()
     co_owners = serializers.PrimaryKeyRelatedField(
@@ -72,6 +107,8 @@ class VideoSerializer(serializers.ModelSerializer):
             "is_video",
             "owner",
             "owner_id",
+            "owner_first_name",
+            "owner_last_name",
             "co_owners",
             "status",
             "status_label",
@@ -111,6 +148,8 @@ class VideoSerializer(serializers.ModelSerializer):
             "duration",
             "owner",
             "owner_id",
+            "owner_first_name",
+            "owner_last_name",
             "status_label",
             "encoding_status",
             "encoding_status_label",

--- a/src/apps/video/serializers/VideoSerializer.py
+++ b/src/apps/video/serializers/VideoSerializer.py
@@ -22,6 +22,7 @@ class TagListSerializerField(serializers.Field):
     """
 
     def get_value(self, dictionary):
+        """Extracts the field value from the provided dictionary."""
         if self.field_name not in dictionary:
             return serializers.empty
         if hasattr(dictionary, "getlist"):
@@ -32,6 +33,7 @@ class TagListSerializerField(serializers.Field):
         return [tag.name for tag in value.all()]
 
     def to_internal_value(self, data):
+        """Converts the provided data into the internal list format."""
         if isinstance(data, list):
             result = []
             for item in data:

--- a/src/apps/video/tests/test_views.py
+++ b/src/apps/video/tests/test_views.py
@@ -225,6 +225,52 @@ class VideoViewSetTests(APITestCase):
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_update_video_tags(self):
+        """Verifies that tags can be updated via the API."""
+        self.client.force_authenticate(user=self.user)
+        url = reverse("video-detail", kwargs={"slug": self.video.slug})
+        data = {"tags": ["newtag1", "newtag2"]}
+        response = self.client.patch(url, data, format="multipart")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.video.refresh_from_db()
+        tags = [t.name for t in self.video.tags.all()]
+        self.assertIn("newtag1", tags)
+        self.assertIn("newtag2", tags)
+        self.assertNotIn("django", tags)
+        data = {"tags": "newtag3, newtag4"}
+        response = self.client.patch(url, data, format="multipart")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.video.refresh_from_db()
+        tags = [t.name for t in self.video.tags.all()]
+        self.assertIn("newtag3", tags)
+        self.assertIn("newtag4", tags)
+        self.assertNotIn("newtag1", tags)
+
+    def test_clear_video_password(self):
+        """Verifies that setting the password to an empty string clears the password lock."""
+        self.client.force_authenticate(user=self.user)
+        url = reverse("video-detail", kwargs={"slug": self.restricted_video.slug})
+        response = self.client.get(url)
+        self.assertTrue(response.data["has_password"])
+        data = {"password": ""}
+        response = self.client.patch(url, data, format="multipart")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.data["has_password"])
+        self.restricted_video.refresh_from_db()
+        self.assertFalse(bool(self.restricted_video.password))
+
+    def test_owner_first_last_name_in_payload(self):
+        """Verifies that owner_first_name and owner_last_name are present in video payload."""
+        self.user.first_name = "Jean"
+        self.user.last_name = "Dupont"
+        self.user.save()
+
+        url = reverse("video-detail", kwargs={"slug": self.video.slug})
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["owner_first_name"], "Jean")
+        self.assertEqual(response.data["owner_last_name"], "Dupont")
+
 
 @override_settings(MEDIA_ROOT=TEMP_MEDIA_ROOT)
 class SubtitleViewSetTests(APITestCase):


### PR DESCRIPTION
# FIX[API]: Several bugs and oversights have been fixed.

This PR addresses several bugs and missing features in the video API to improve integration with the front-end application:

- Video Tagging System: Replaced the read-only tag field with a custom TagListSerializerField to support creating and updating tags using either a list of strings or a comma-separated string (fixing the NotImplementedError crash).
- Clearing Video Password: Updated the password field in VideoSerializer to accept empty and null values (allow_blank=True, allow_null=True). This allows clients to clear a video's password lock via the API and restore normal public access.
- Public Owner Identity: Added read-only owner_first_name and owner_last_name fields directly to the video payload, allowing unauthenticated users to display the creator's full name while watching a video.
- Unit Tests: Added dedicated test cases in test_views.py to assert the behavior of writable tags, password clearing, and the presence of owner details.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
