### PR TITLE
[FEAT] Add missing models to Django admin panel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,12 @@ jobs:
   # 1. Code Quality
   quality-check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref || github.ref }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -30,6 +34,13 @@ jobs:
       - name: Format code with Black
         run: |
           black . -l 90
+
+      - name: Commit formatted code
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: Auto-format code with Black"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"
 
       - name: Lint with flake8
         run: flake8 src --count --show-source --statistics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           ref: ${{ github.head_ref || github.ref }}
 
       - name: Set up Python 3.12

--- a/src/apps/encoding/admin.py
+++ b/src/apps/encoding/admin.py
@@ -1,0 +1,19 @@
+"""
+Esup-Pod - Admin configuration for the encoding app.
+"""
+
+from django.contrib import admin
+from src.apps.encoding.models import EncodingVideo
+
+
+@admin.register(EncodingVideo)
+class EncodingVideoAdmin(admin.ModelAdmin):
+    """
+    Admin configuration for the EncodingVideo model.
+    """
+
+    list_display = ("id", "video", "resolution", "created_at")
+    list_filter = ("resolution", "created_at")
+    search_fields = ("video__title", "resolution")
+    raw_id_fields = ("video",)
+    readonly_fields = ("created_at",)

--- a/src/apps/utils/admin.py
+++ b/src/apps/utils/admin.py
@@ -1,0 +1,16 @@
+"""
+Esup-Pod - Admin configuration for utils app.
+"""
+
+from django.contrib import admin
+from src.apps.utils.models.CustomImageModel import CustomImageModel
+
+
+@admin.register(CustomImageModel)
+class CustomImageModelAdmin(admin.ModelAdmin):
+    """
+    Admin configuration for CustomImageModel.
+    """
+
+    list_display = ("id", "file", "file_type", "file_size")
+    search_fields = ("file",)

--- a/src/apps/video/admin.py
+++ b/src/apps/video/admin.py
@@ -2,7 +2,13 @@
 Esup-Pod - Video administrator interface.
 """
 
+import tagulous.admin
 from django.contrib import admin
+from django import forms
+from django.contrib import messages
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+
 from src.apps.video.models import (
     Video,
     Type,
@@ -11,6 +17,9 @@ from src.apps.video.models import (
     Comment,
     ViewCount,
     Vote,
+    Language,
+    License,
+    Cursus,
 )
 
 
@@ -61,6 +70,33 @@ class SubtitleAdmin(admin.ModelAdmin):
     list_filter = ("language",)
 
 
+@admin.register(Language)
+class LanguageAdmin(admin.ModelAdmin):
+    """Admin for Language."""
+
+    list_display = ("name", "slug", "order")
+    search_fields = ("name", "slug")
+    ordering = ("order", "name")
+
+
+@admin.register(License)
+class LicenseAdmin(admin.ModelAdmin):
+    """Admin for License."""
+
+    list_display = ("name", "slug", "order")
+    search_fields = ("name", "slug")
+    ordering = ("order", "name")
+
+
+@admin.register(Cursus)
+class CursusAdmin(admin.ModelAdmin):
+    """Admin for Cursus."""
+
+    list_display = ("name", "slug", "order")
+    search_fields = ("name", "slug")
+    ordering = ("order", "name")
+
+
 @admin.register(Comment)
 class CommentAdmin(admin.ModelAdmin):
     """Admin for Comments."""
@@ -89,3 +125,75 @@ class VoteAdmin(admin.ModelAdmin):
     list_display = ("id", "user", "comment")
     search_fields = ("user__username", "comment__content")
     raw_id_fields = ("user", "comment")
+
+
+# Register Tagulous dynamic tag model with custom merge to delete merged tags
+@admin.register(Video.tags.tag_model)
+class VideoTagAdmin(tagulous.admin.TagModelAdmin):
+    """Admin for Video Tags."""
+
+    def merge_tags(self, request, queryset):
+        """
+        Admin action to merge tags and delete the old ones.
+        """
+        is_tree = issubclass(self.model, tagulous.models.TagTreeModel)
+
+        class MergeForm(forms.Form):
+            """Form for merging tags."""
+
+            _selected_action = forms.CharField(widget=forms.MultipleHiddenInput)
+            merge_to = forms.ModelChoiceField(queryset)
+
+        if is_tree:
+
+            class MergeForm(MergeForm):
+                """Form for merging tree tags."""
+
+                merge_children = forms.BooleanField(required=False)
+
+        if "merge" in request.POST:
+            merge_form = MergeForm(request.POST)
+            if merge_form.is_valid():
+                merge_to = merge_form.cleaned_data["merge_to"]
+                kwargs = {}
+                if is_tree and merge_form.cleaned_data.get("merge_children"):
+                    kwargs["children"] = True
+
+                # Merge tags using tagulous
+                merge_to.merge_tags(queryset, **kwargs)
+
+                # Delete the other tags
+                queryset.exclude(pk=merge_to.pk).delete()
+
+                self.message_user(request, "Tags merged successfully", messages.SUCCESS)
+                return HttpResponseRedirect(request.get_full_path())
+
+        else:
+            tag_pks = request.POST.getlist(admin.helpers.ACTION_CHECKBOX_NAME)
+            if len(tag_pks) < 2:
+                self.message_user(
+                    request,
+                    "You must select at least two tags to merge",
+                    messages.ERROR,
+                )
+                return HttpResponseRedirect(request.get_full_path())
+
+            merge_form = MergeForm(
+                initial={
+                    admin.helpers.ACTION_CHECKBOX_NAME: request.POST.getlist(
+                        admin.helpers.ACTION_CHECKBOX_NAME
+                    ),
+                    "merge_children": True,
+                }
+            )
+
+        return render(
+            request,
+            "tagulous/admin/merge_tags.html",
+            {
+                "title": "Merge tags",
+                "opts": self.model._meta,
+                "merge_form": merge_form,
+                "tags": queryset,
+            },
+        )

--- a/src/apps/video/admin.py
+++ b/src/apps/video/admin.py
@@ -8,6 +8,7 @@ from django import forms
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
+from django.utils.translation import gettext_lazy as _
 
 from src.apps.video.models import (
     Video,
@@ -165,7 +166,9 @@ class VideoTagAdmin(tagulous.admin.TagModelAdmin):
                 # Delete the other tags
                 queryset.exclude(pk=merge_to.pk).delete()
 
-                self.message_user(request, "Tags merged successfully", messages.SUCCESS)
+                self.message_user(
+                    request, _("Tags merged successfully"), messages.SUCCESS
+                )
                 return HttpResponseRedirect(request.get_full_path())
 
         else:
@@ -173,7 +176,7 @@ class VideoTagAdmin(tagulous.admin.TagModelAdmin):
             if len(tag_pks) < 2:
                 self.message_user(
                     request,
-                    "You must select at least two tags to merge",
+                    _("You must select at least two tags to merge"),
                     messages.ERROR,
                 )
                 return HttpResponseRedirect(request.get_full_path())
@@ -191,7 +194,7 @@ class VideoTagAdmin(tagulous.admin.TagModelAdmin):
             request,
             "tagulous/admin/merge_tags.html",
             {
-                "title": "Merge tags",
+                "title": _("Merge tags"),
                 "opts": self.model._meta,
                 "merge_form": merge_form,
                 "tags": queryset,

--- a/src/apps/video/admin.py
+++ b/src/apps/video/admin.py
@@ -3,7 +3,15 @@ Esup-Pod - Video administrator interface.
 """
 
 from django.contrib import admin
-from src.apps.video.models import Video, Type, Discipline, Subtitle
+from src.apps.video.models import (
+    Video,
+    Type,
+    Discipline,
+    Subtitle,
+    Comment,
+    ViewCount,
+    Vote,
+)
 
 
 @admin.register(Video)
@@ -51,3 +59,33 @@ class SubtitleAdmin(admin.ModelAdmin):
 
     list_display = ("video", "language", "file")
     list_filter = ("language",)
+
+
+@admin.register(Comment)
+class CommentAdmin(admin.ModelAdmin):
+    """Admin for Comments."""
+
+    list_display = ("id", "author", "video", "added", "parent", "direct_parent")
+    list_filter = ("added",)
+    search_fields = ("content", "author__username", "video__title")
+    raw_id_fields = ("author", "video", "parent", "direct_parent")
+    readonly_fields = ("added",)
+
+
+@admin.register(ViewCount)
+class ViewCountAdmin(admin.ModelAdmin):
+    """Admin for Video View Counts."""
+
+    list_display = ("video", "date", "count")
+    list_filter = ("date",)
+    search_fields = ("video__title",)
+    raw_id_fields = ("video",)
+
+
+@admin.register(Vote)
+class VoteAdmin(admin.ModelAdmin):
+    """Admin for Votes on Comments."""
+
+    list_display = ("id", "user", "comment")
+    search_fields = ("user__username", "comment__content")
+    raw_id_fields = ("user", "comment")

--- a/src/apps/video/apps.py
+++ b/src/apps/video/apps.py
@@ -3,6 +3,34 @@ Esup-Pod - Video application configuration.
 """
 
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+
+
+def sync_metadata(sender, **kwargs):
+    """Sync Cursus, Language, and License from config defaults to DB."""
+    try:
+        from src.apps.video.models import Language, License, Cursus
+        from src.apps.video.conf import video_settings
+
+        for order, item in enumerate(video_settings.languages):
+            Language.objects.get_or_create(
+                slug=item["value"],
+                defaults={"name": item["label"], "order": order},
+            )
+
+        for order, item in enumerate(video_settings.licenses):
+            License.objects.get_or_create(
+                slug=item["value"],
+                defaults={"name": item["label"], "order": order},
+            )
+
+        for order, item in enumerate(video_settings.cursus):
+            Cursus.objects.get_or_create(
+                slug=item["value"],
+                defaults={"name": item["label"], "order": order},
+            )
+    except Exception:
+        pass
 
 
 class VideoConfig(AppConfig):
@@ -18,3 +46,5 @@ class VideoConfig(AppConfig):
     def ready(self):
         """Connects signals and performs initialization on app startup."""
         import src.apps.video.signals  # noqa: F401
+
+        post_migrate.connect(sync_metadata, sender=self)

--- a/src/apps/video/conf.py
+++ b/src/apps/video/conf.py
@@ -176,6 +176,11 @@ class VideoConfig(BaseSettings):
         default=defaults.DEFAULT_TYPE_ID,
         description=_("Default Type ID for new videos."),
     )
+
+    # Note: We must use the `metadata_` prefix here. If we used `languages`,
+    # pydantic's DjangoSettingsSource would automatically load Django's native
+    # `LANGUAGES` setting (a list of tuples), crashing the db sync process.
+    # The clean `languages` API is exposed via @property methods below.
     metadata_languages: list = Field(
         default_factory=lambda: defaults.METADATA_LANGUAGES,
         description=_("Available languages for videos."),

--- a/src/apps/video/conf.py
+++ b/src/apps/video/conf.py
@@ -176,21 +176,36 @@ class VideoConfig(BaseSettings):
         default=defaults.DEFAULT_TYPE_ID,
         description=_("Default Type ID for new videos."),
     )
-    languages: list = Field(
+    metadata_languages: list = Field(
         default_factory=lambda: defaults.METADATA_LANGUAGES,
         description=_("Available languages for videos."),
         json_schema_extra={"public": True},
     )
-    licenses: list = Field(
+    metadata_licenses: list = Field(
         default_factory=lambda: defaults.METADATA_LICENSES,
         description=_("Available content licenses."),
         json_schema_extra={"public": True},
     )
-    cursus: list = Field(
+    metadata_cursus: list = Field(
         default_factory=lambda: defaults.METADATA_CURSUS,
         description=_("Available educational levels."),
         json_schema_extra={"public": True},
     )
+
+    @property
+    def languages(self) -> list:
+        """Alias for metadata_languages."""
+        return self.metadata_languages
+
+    @property
+    def licenses(self) -> list:
+        """Alias for metadata_licenses."""
+        return self.metadata_licenses
+
+    @property
+    def cursus(self) -> list:
+        """Alias for metadata_cursus."""
+        return self.metadata_cursus
 
     @classmethod
     def settings_customise_sources(

--- a/src/apps/video/models/Cursus.py
+++ b/src/apps/video/models/Cursus.py
@@ -1,0 +1,24 @@
+"""
+Esup-Pod - Cursus model for Metadata.
+"""
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class Cursus(models.Model):
+    """Educational levels/cursus categories."""
+
+    name = models.CharField(_("Name"), max_length=100)
+    slug = models.SlugField(_("Code"), max_length=10, primary_key=True)
+    order = models.PositiveSmallIntegerField(_("Order"), default=0)
+
+    class Meta:
+        """Cursus metadata."""
+
+        ordering = ["order", "name"]
+        verbose_name = _("Cursus")
+        verbose_name_plural = _("Cursus")
+
+    def __str__(self):
+        return self.name

--- a/src/apps/video/models/Language.py
+++ b/src/apps/video/models/Language.py
@@ -1,0 +1,24 @@
+"""
+Esup-Pod - Language model for Metadata.
+"""
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class Language(models.Model):
+    """Available languages for videos."""
+
+    name = models.CharField(_("Name"), max_length=100)
+    slug = models.SlugField(_("Code"), max_length=10, primary_key=True)
+    order = models.PositiveSmallIntegerField(_("Order"), default=0)
+
+    class Meta:
+        """Language metadata."""
+
+        ordering = ["order", "name"]
+        verbose_name = _("Language")
+        verbose_name_plural = _("Languages")
+
+    def __str__(self):
+        return self.name

--- a/src/apps/video/models/License.py
+++ b/src/apps/video/models/License.py
@@ -1,0 +1,24 @@
+"""
+Esup-Pod - License model for Metadata.
+"""
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class License(models.Model):
+    """Available content licenses for legal protection."""
+
+    name = models.CharField(_("Name"), max_length=100)
+    slug = models.SlugField(_("Code"), max_length=20, primary_key=True)
+    order = models.PositiveSmallIntegerField(_("Order"), default=0)
+
+    class Meta:
+        """License metadata."""
+
+        ordering = ["order", "name"]
+        verbose_name = _("License")
+        verbose_name_plural = _("Licenses")
+
+    def __str__(self):
+        return self.name

--- a/src/apps/video/models/Video.py
+++ b/src/apps/video/models/Video.py
@@ -348,8 +348,23 @@ class Video(models.Model):
 
         if not self.id:
             from src.apps.video.services.metadata import calculate_expiration_date
+            from src.apps.video.models import License, Type
 
             self.date_to_delete = calculate_expiration_date(self.owner)
+
+            if not self.license_id and video_settings.default_license:
+                try:
+                    self.license = License.objects.get(
+                        slug=video_settings.default_license
+                    )
+                except License.DoesNotExist:
+                    pass
+
+            if not self.type_id and video_settings.default_type_id:
+                try:
+                    self.type = Type.objects.get(pk=video_settings.default_type_id)
+                except Type.DoesNotExist:
+                    pass
 
         super().save(*args, **kwargs)
 

--- a/src/apps/video/models/Video.py
+++ b/src/apps/video/models/Video.py
@@ -72,26 +72,6 @@ class Video(models.Model):
         DONE = "DO", _("Done")
         ERROR = "ER", _("Error")
 
-    class License(models.TextChoices):
-        """Available content licenses for legal protection."""
-
-        CC_BY = "CC-BY", _("Creative Commons BY")
-        CC_BY_SA = "CC-BY-SA", _("Creative Commons BY-SA")
-        CC_BY_NC = "CC-BY-NC", _("Creative Commons BY-NC")
-        CC_BY_ND = "CC-BY-ND", _("Creative Commons BY-ND")
-        COPYRIGHT = "COPYRIGHT", _("All rights reserved")
-
-    class Cursus(models.TextChoices):
-        """Educational levels/cursus categories."""
-
-        L1 = "L1", _("Licence 1")
-        L2 = "L2", _("Licence 2")
-        L3 = "L3", _("Licence 3")
-        M1 = "M1", _("Master 1")
-        M2 = "M2", _("Master 2")
-        DOCTORATE = "D", _("Doctorate")
-        OTHER = "0", _("Other")
-
     # 2. CORE
     title = models.CharField(
         _("Title"),
@@ -230,25 +210,26 @@ class Video(models.Model):
     date_of_event = models.DateField(
         _("Date of Event"), default=date.today, blank=True, null=True
     )
-    license = models.CharField(
-        _("License"),
-        max_length=20,
-        choices=License.choices,
-        default=License.COPYRIGHT,
+    license = models.ForeignKey(
+        "video.License",
+        on_delete=models.SET_NULL,
+        verbose_name=_("License"),
         blank=True,
         null=True,
     )
-    cursus = models.CharField(
-        _("Cursus"),
-        max_length=10,
-        choices=Cursus.choices,
-        default=Cursus.OTHER,
+    cursus = models.ForeignKey(
+        "video.Cursus",
+        on_delete=models.SET_NULL,
+        verbose_name=_("Cursus"),
         blank=True,
+        null=True,
     )
-    language = models.CharField(
-        _("Main Language"),
-        max_length=10,
-        default=settings.LANGUAGE_CODE,
+    language = models.ForeignKey(
+        "video.Language",
+        on_delete=models.SET_NULL,
+        verbose_name=_("Main Language"),
+        blank=True,
+        null=True,
         help_text=_("Language spoken in the video (e.g. 'fr', 'en')."),
     )
     transcript_language = models.CharField(
@@ -338,7 +319,7 @@ class Video(models.Model):
             "date": self.created_at.strftime("%Y-%m-%d") if self.created_at else "",
             "format": "video/mp4",
             "rights": (
-                self.license if self.license else video_settings.default_dc_rights
+                self.license.slug if self.license else video_settings.default_dc_rights
             ),
             "coverage": video_settings.default_dc_coverage,
             "subject": ", ".join([d.title for d in self.disciplines.all()]),

--- a/src/apps/video/models/__init__.py
+++ b/src/apps/video/models/__init__.py
@@ -9,5 +9,19 @@ from .Comment import Comment
 from .Vote import Vote
 from .Type import Type
 from .Discipline import Discipline
+from .Language import Language
+from .License import License
+from .Cursus import Cursus
 
-__all__ = ["Video", "Subtitle", "ViewCount", "Comment", "Vote", "Type", "Discipline"]
+__all__ = [
+    "Video",
+    "Subtitle",
+    "ViewCount",
+    "Comment",
+    "Vote",
+    "Type",
+    "Discipline",
+    "Language",
+    "License",
+    "Cursus",
+]

--- a/src/apps/video/tests/test_metadata_api.py
+++ b/src/apps/video/tests/test_metadata_api.py
@@ -8,30 +8,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from src.apps.video.models import Type
-
-
-def populate_test_metadata():
-    """Populate Language, License, and Cursus default values for tests."""
-    from src.apps.video.models import Language, License, Cursus
-    from src.apps.video.conf import video_settings
-
-    for order, item in enumerate(video_settings.languages):
-        Language.objects.get_or_create(
-            slug=item["value"],
-            defaults={"name": item["label"], "order": order},
-        )
-
-    for order, item in enumerate(video_settings.licenses):
-        License.objects.get_or_create(
-            slug=item["value"],
-            defaults={"name": item["label"], "order": order},
-        )
-
-    for order, item in enumerate(video_settings.cursus):
-        Cursus.objects.get_or_create(
-            slug=item["value"],
-            defaults={"name": item["label"], "order": order},
-        )
+from src.apps.video.apps import sync_metadata
 
 
 class MetadataAPITests(APITestCase):
@@ -41,7 +18,7 @@ class MetadataAPITests(APITestCase):
 
     def setUp(self):
         """Set up the test environment."""
-        populate_test_metadata()
+        sync_metadata(sender=None)
         self.site = Site.objects.get_current()
         self.type = Type.objects.create(title="Course")
         self.type.sites.add(self.site)

--- a/src/apps/video/tests/test_metadata_api.py
+++ b/src/apps/video/tests/test_metadata_api.py
@@ -10,6 +10,30 @@ from rest_framework.test import APITestCase
 from src.apps.video.models import Type
 
 
+def populate_test_metadata():
+    """Populate Language, License, and Cursus default values for tests."""
+    from src.apps.video.models import Language, License, Cursus
+    from src.apps.video.conf import video_settings
+
+    for order, item in enumerate(video_settings.languages):
+        Language.objects.get_or_create(
+            slug=item["value"],
+            defaults={"name": item["label"], "order": order},
+        )
+
+    for order, item in enumerate(video_settings.licenses):
+        License.objects.get_or_create(
+            slug=item["value"],
+            defaults={"name": item["label"], "order": order},
+        )
+
+    for order, item in enumerate(video_settings.cursus):
+        Cursus.objects.get_or_create(
+            slug=item["value"],
+            defaults={"name": item["label"], "order": order},
+        )
+
+
 class MetadataAPITests(APITestCase):
     """
     Esup-Pod - Tests for the video metadata endpoints.
@@ -17,6 +41,7 @@ class MetadataAPITests(APITestCase):
 
     def setUp(self):
         """Set up the test environment."""
+        populate_test_metadata()
         self.site = Site.objects.get_current()
         self.type = Type.objects.create(title="Course")
         self.type.sites.add(self.site)

--- a/src/apps/video/tests/test_models.py
+++ b/src/apps/video/tests/test_models.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from src.apps.video.models import Video, ViewCount, Comment
 import datetime
 
-from src.apps.video.tests.test_metadata_api import populate_test_metadata
+from src.apps.video.apps import sync_metadata
 
 User = get_user_model()
 
@@ -19,7 +19,7 @@ class VideoModelTests(TestCase):
 
     def setUp(self):
         """Sets up a video and an owner for model testing."""
-        populate_test_metadata()
+        sync_metadata(sender=None)
         self.user = User.objects.create_user(username="owner", password="password")
         self.video = Video.objects.create(
             title="Model Test Video",
@@ -57,7 +57,7 @@ class CommentBasicTests(TestCase):
 
     def setUp(self):
         """Sets up a video and a user for comment testing."""
-        populate_test_metadata()
+        sync_metadata(sender=None)
         self.user = User.objects.create_user(username="commenter2", password="password")
         self.video = Video.objects.create(
             title="A Video", owner=self.user, status=Video.Status.PUBLISHED

--- a/src/apps/video/tests/test_models.py
+++ b/src/apps/video/tests/test_models.py
@@ -7,6 +7,8 @@ from django.contrib.auth import get_user_model
 from src.apps.video.models import Video, ViewCount, Comment
 import datetime
 
+from src.apps.video.tests.test_metadata_api import populate_test_metadata
+
 User = get_user_model()
 
 
@@ -17,13 +19,14 @@ class VideoModelTests(TestCase):
 
     def setUp(self):
         """Sets up a video and an owner for model testing."""
+        populate_test_metadata()
         self.user = User.objects.create_user(username="owner", password="password")
         self.video = Video.objects.create(
             title="Model Test Video",
             owner=self.user,
             description="A description",
             status=Video.Status.PUBLISHED,
-            license=Video.License.CC_BY,
+            license_id="CC-BY",
         )
 
     def test_get_dublin_core(self):
@@ -33,7 +36,7 @@ class VideoModelTests(TestCase):
         self.assertEqual(dc["description"], "A description")
         self.assertEqual(dc["creator"], "owner")
         self.assertEqual(dc["format"], "video/mp4")
-        self.assertEqual(dc["rights"], Video.License.CC_BY)
+        self.assertEqual(dc["rights"], "CC-BY")
 
     def test_view_count_creation(self):
         """Verifies daily view count records and their string representation."""
@@ -54,6 +57,7 @@ class CommentBasicTests(TestCase):
 
     def setUp(self):
         """Sets up a video and a user for comment testing."""
+        populate_test_metadata()
         self.user = User.objects.create_user(username="commenter2", password="password")
         self.video = Video.objects.create(
             title="A Video", owner=self.user, status=Video.Status.PUBLISHED

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -133,7 +133,14 @@ class VideoViewSet(viewsets.ModelViewSet):
                 }
             )
 
-        provided_license = self.request.data.get("license")
+        target_license = serializer.validated_data.get("license")
+        if not target_license and video_settings.default_license:
+            from src.apps.video.models import License
+
+            try:
+                target_license = License.objects.get(slug=video_settings.default_license)
+            except License.DoesNotExist:
+                target_license = None
 
         from src.apps.video.models import Type
 
@@ -148,9 +155,7 @@ class VideoViewSet(viewsets.ModelViewSet):
             owner=self.request.user,
             status=Video.Status.DRAFT,
             type=video_type,
-            license=(
-                provided_license if provided_license else video_settings.default_license
-            ),
+            license=target_license,
         )
 
         current_site = get_current_site(self.request)
@@ -342,14 +347,24 @@ class VideoViewSet(viewsets.ModelViewSet):
         """
         Returns dynamic choices for video fields to help the frontend.
         """
+        from src.apps.video.models import License, Cursus, Language
+
         return Response(
             {
-                "licenses": video_settings.licenses,
-                "cursus": video_settings.cursus,
+                "licenses": [
+                    {"value": lic.slug, "label": lic.name}
+                    for lic in License.objects.all()
+                ],
+                "cursus": [
+                    {"value": c.slug, "label": c.name} for c in Cursus.objects.all()
+                ],
                 "statuses": [
                     {"value": c[0], "label": c[1]} for c in Video.Status.choices
                 ],
-                "languages": video_settings.languages,
+                "languages": [
+                    {"value": lang.slug, "label": lang.name}
+                    for lang in Language.objects.all()
+                ],
             }
         )
 


### PR DESCRIPTION
# [FEAT] Add missing models to Django admin panel

This pull request adds and configures all the missing templates in the Django administration panel (particularly for encoding, utilities, and video applications) to provide comprehensive administration coverage. Furthermore, it streamlines the management of video metadata (languages, licenses, curricula) by replacing hard-coded text choices with database-editable foreign key relationships, while also adapting the API, unit tests, and correcting docstrings to ensure complete CI pipeline validation.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
