### PR TITLE
FEAT(video): integrate complete video duplication system ISO V4

### DIFF
--- a/deployment/dev/docker-compose.yml
+++ b/deployment/dev/docker-compose.yml
@@ -20,11 +20,11 @@ services:
       - pod-network
 
   api:
+    user: "${USER_UID:-1000}:${USER_GID:-1000}"
     build:
       context: ../../
       dockerfile: deployment/dev/Dockerfile
     container_name: pod-api
-    user: "${USER_UID:-1000}:${USER_GID:-1000}"
     volumes:
       - ../../:/app
       - ../../media:/app/media
@@ -63,11 +63,11 @@ services:
       - pod-network
 
   celery:
+    user: "${USER_UID:-1000}:${USER_GID:-1000}"
     build:
       context: ../../
       dockerfile: deployment/dev/Dockerfile
     container_name: pod-celery
-    user: "${USER_UID:-1000}:${USER_GID:-1000}"
     volumes:
       - ../../:/app
       - ../../media:/app/media

--- a/docs/video/README.md
+++ b/docs/video/README.md
@@ -65,6 +65,7 @@ A video passes through the following states:
 | **GET**      | `/api/videos/{slug}/stream/`          | Stream the video file directly.                   |
 | **POST**     | `/api/videos/{slug}/register_view/`   | Increment the view counter.                       |
 | **POST**     | `/api/videos/{slug}/unlock/`          | Unlock a password-protected restricted video.     |
+| **POST**     | `/api/videos/{slug}/duplicate/`       | Duplicate a video (creates a full copy).          |
 | **GET**      | `/api/types/`                         | List available video types.                       |
 | **GET**      | `/api/disciplines/`                   | List available disciplines.                       |
 | **GET**      | `/api/tags/`                          | List available tags.                              |

--- a/scripts/test_api_curl.sh
+++ b/scripts/test_api_curl.sh
@@ -286,7 +286,7 @@ echo -e "${GREEN}OK${NC}"
 # 15. FINAL VERIFICATION (Ensure deletion)
 echo -n ">>> [15/15] Verifying Deletion... "
 VIDEO_CHECK=$(curl -s -X 'GET' "$BASE_URL/api/videos/$VIDEO_SLUG/" -H "$AUTH_HEADER")
-if [[ "$VIDEO_CHECK" != *"No Video matches"* ]]; then
+if [[ "$VIDEO_CHECK" != *"Video not found"* ]]; then
     echo -e "${RED}FAILED${NC}"
     echo "Error: Video still exists or unexpected response. Response: $VIDEO_CHECK"
     exit 1

--- a/src/apps/video/models/Video.py
+++ b/src/apps/video/models/Video.py
@@ -78,6 +78,7 @@ class Video(models.Model):
         max_length=250,
         help_text=_("A title as short and accurate as possible."),
     )
+
     slug = models.SlugField(
         _("Slug"),
         unique=True,
@@ -85,9 +86,13 @@ class Video(models.Model):
         editable=False,
         help_text=_("URL friendly identifier."),
     )
+
     description = models.TextField(
-        _("Description"), blank=True, help_text=_("Full description of the content.")
+        _("Description"),
+        blank=True,
+        help_text=_("Full description of the content."),
     )
+
     video_file = models.FileField(
         _("Video File"),
         upload_to=get_storage_path_video,
@@ -95,6 +100,7 @@ class Video(models.Model):
         null=True,
         blank=True,
     )
+
     is_video = models.BooleanField(
         _("Is Video"),
         default=True,
@@ -110,6 +116,7 @@ class Video(models.Model):
         blank=True,
         help_text=_("Custom cover image for the video."),
     )
+
     overview = models.ImageField(
         _("Overview"),
         upload_to=get_storage_path_image,
@@ -118,13 +125,16 @@ class Video(models.Model):
         editable=False,
         help_text=_("Automatically generated image from the video."),
     )
+
     duration = models.IntegerField(_("Duration (s)"), default=0, editable=False)
     view_count = models.PositiveIntegerField(_("View Count"), default=0, editable=False)
+
     is_360 = models.BooleanField(
         _("360° Video"),
         default=False,
         help_text=_("Check if this is a 360-degree immersive video."),
     )
+
     # 4. OWNERSHIP & ACCESS
     owner = models.ForeignKey(
         settings.AUTH_USER_MODEL,
@@ -132,6 +142,7 @@ class Video(models.Model):
         on_delete=models.CASCADE,
         verbose_name=_("Owner"),
     )
+
     channel = models.ForeignKey(
         "collection.Channel",
         on_delete=models.SET_NULL,
@@ -141,6 +152,7 @@ class Video(models.Model):
         verbose_name=_("Channel"),
         help_text=_("The channel this video belongs to."),
     )
+
     co_owners = models.ManyToManyField(
         settings.AUTH_USER_MODEL,
         related_name="co_owned_videos",
@@ -148,6 +160,7 @@ class Video(models.Model):
         verbose_name=_("Co-Owners"),
         help_text=_("Users with edit rights on this video."),
     )
+
     status = models.CharField(
         _("Status"),
         max_length=2,
@@ -155,6 +168,7 @@ class Video(models.Model):
         default=Status.DRAFT,
         db_index=True,
     )
+
     encoding_status = models.CharField(
         _("Encoding Status"),
         max_length=2,
@@ -165,6 +179,7 @@ class Video(models.Model):
             "Tracks the encoding pipeline state independently from the video’s visibility."
         ),
     )
+
     is_auth_required = models.BooleanField(
         _("Authentication Required"),
         default=False,
@@ -172,14 +187,16 @@ class Video(models.Model):
             "If checked, users must be logged in to access this video (even if they have the password)."
         ),
     )
+
     # 4. ACCESS CONTROL
     sites = models.ManyToManyField(
         Site,
-        blank=True,
+        blank=False,
         related_name="videos",
         verbose_name=_("Sites"),
         help_text=_("Portals where this video will be published."),
     )
+
     password = models.CharField(
         _("Password"),
         max_length=128,
@@ -194,11 +211,13 @@ class Video(models.Model):
         default=False,
         help_text=_("Allow users to download the source file."),
     )
+
     disable_comment = models.BooleanField(
         _("Disable Comments"),
         default=False,
         help_text=_("Prevent users from commenting on this specific content."),
     )
+
     order = models.PositiveSmallIntegerField(
         _("Order"),
         default=1,
@@ -206,6 +225,7 @@ class Video(models.Model):
         null=True,
         help_text=_("Order priority in channels or playlists."),
     )
+
     # 6.CONTENT DESCRIPTION & CLASSIFICATION
     date_of_event = models.DateField(
         _("Date of Event"), default=date.today, blank=True, null=True
@@ -224,6 +244,7 @@ class Video(models.Model):
         blank=True,
         null=True,
     )
+
     language = models.ForeignKey(
         "video.Language",
         on_delete=models.SET_NULL,
@@ -232,12 +253,14 @@ class Video(models.Model):
         null=True,
         help_text=_("Language spoken in the video (e.g. 'fr', 'en')."),
     )
+
     transcript_language = models.CharField(
         _("Transcript Language"),
         max_length=10,
         blank=True,
         help_text=_("Language of the available audio transcription."),
     )
+
     restricted_groups = models.ManyToManyField(
         "authentication.AccessGroup",
         blank=True,
@@ -245,6 +268,7 @@ class Video(models.Model):
         verbose_name=_("Restricted Groups"),
         help_text=_("One or more groups who can access this video."),
     )
+
     type = models.ForeignKey(
         "video.Type",
         on_delete=models.SET_NULL,
@@ -252,10 +276,11 @@ class Video(models.Model):
         verbose_name=_("Type"),
         help_text=_("The general format of the video."),
     )
-    # [TODO] themes = models.ManyToManyField("video.Theme", blank=True)
+
     disciplines = models.ManyToManyField(
         "video.Discipline", blank=True, verbose_name=_("Disciplines")
     )
+
     tags = tagulous.models.TagField(
         blank=True, help_text=_("A comma-separated list of tags.")
     )
@@ -263,6 +288,7 @@ class Video(models.Model):
     # 7. TIMESTAMPS
     created_at = models.DateTimeField(_("Created At"), default=timezone.now)
     updated_at = models.DateTimeField(auto_now=True)
+
     date_to_delete = models.DateField(
         _("Expiration Date"),
         null=True,
@@ -375,9 +401,5 @@ class Video(models.Model):
         """
         Returns the V4-compatible permalink.
         Format: /video/<slug>/ where slug is already "0042-my-video-title".
-
-        previously this returned f"/video/{self.pk}-{self.slug}/" which
-        produced a double-ID like /video/42-0042-titre/. The slug already embeds
-        the zero-padded ID, so only the slug is needed here.
         """
         return f"/video/{self.slug}/"

--- a/src/apps/video/services/duplicate.py
+++ b/src/apps/video/services/duplicate.py
@@ -4,11 +4,13 @@ Esup-Pod - Video duplication service.
 
 from django.db import transaction
 from django.utils.text import slugify
-from src.apps.video.models import Video
-from .slug import generate_unique_slug
-from .files import duplicate_source_file
-from src.apps.video.services.sites import assign_default_site
 from django.utils.translation import gettext_lazy as _
+
+from src.apps.video.models import Video
+from src.apps.video.services.sites import assign_default_site
+
+from .files import duplicate_source_file
+from .slug import generate_unique_slug
 
 
 @transaction.atomic
@@ -25,7 +27,7 @@ def duplicate_video(original: Video, user, request=None):
     new_slug = generate_unique_slug(slugify(base_slug))
 
     duplicated = Video.objects.create(
-        title=f"{_('Copy of')} {original.title}",
+        title=_("Copy of %(title)s") % {"title": original.title},
         slug=new_slug,
         type=original.type,
         owner=user,

--- a/src/apps/video/services/duplicate.py
+++ b/src/apps/video/services/duplicate.py
@@ -8,6 +8,7 @@ from src.apps.video.models import Video
 from .slug import generate_unique_slug
 from .files import duplicate_source_file
 from src.apps.video.services.sites import assign_default_site
+from django.utils.translation import gettext_lazy as _
 
 
 @transaction.atomic
@@ -24,7 +25,7 @@ def duplicate_video(original: Video, user, request=None):
     new_slug = generate_unique_slug(slugify(base_slug))
 
     duplicated = Video.objects.create(
-        title=f"Copy of {original.title}",
+        title=f"{_('Copy of')} {original.title}",
         slug=new_slug,
         type=original.type,
         owner=user,
@@ -50,7 +51,7 @@ def duplicate_video(original: Video, user, request=None):
     elif request:
         assign_default_site(duplicated, request)
     else:
-        raise ValueError("Video must have at least one site")
+        raise ValueError(_("Video must have at least one site"))
 
     if original.video_file:
         duplicated.video_file.name = duplicate_source_file(

--- a/src/apps/video/services/duplicate.py
+++ b/src/apps/video/services/duplicate.py
@@ -1,0 +1,104 @@
+"""
+Esup-Pod - Video duplication service.
+"""
+
+from django.db import transaction
+from django.utils.text import slugify
+from src.apps.video.models import Video
+from .slug import generate_unique_slug
+from .files import duplicate_source_file
+from src.apps.video.services.sites import assign_default_site
+
+
+@transaction.atomic
+def duplicate_video(original: Video, user, request=None):
+    """
+    Duplicates a Video instance for the given user.
+
+    Creates a new Video in DRAFT status with all scalar fields copied,
+    the source file physically duplicated on disk, and all M2M relations
+    (disciplines, restricted_groups, co_owners) mirrored.
+    """
+
+    base_slug = f"{original.slug}-copy"
+    new_slug = generate_unique_slug(slugify(base_slug))
+
+    duplicated = Video.objects.create(
+        title=f"Copy of {original.title}",
+        slug=new_slug,
+        type=original.type,
+        owner=user,
+        description=original.description,
+        is_auth_required=original.is_auth_required,
+        password=original.password,
+        allow_downloading=original.allow_downloading,
+        is_360=original.is_360,
+        transcript_language=original.transcript_language,
+        license=original.license,
+        cursus=original.cursus,
+        language=original.language,
+        thumbnail=original.thumbnail,
+        status=Video.Status.DRAFT,
+        channel=original.channel,
+        date_of_event=original.date_of_event,
+        disable_comment=original.disable_comment,
+        tags=original.get_tag_list(),
+    )
+
+    if original.sites.exists():
+        duplicated.sites.set(original.sites.all())
+    elif request:
+        assign_default_site(duplicated, request)
+    else:
+        raise ValueError("Video must have at least one site")
+
+    if original.video_file:
+        duplicated.video_file.name = duplicate_source_file(
+            duplicated.id,
+            original.video_file.path,
+            original.video_file.name,
+        )
+        duplicated.save(update_fields=["video_file"])
+
+    duplicated.disciplines.set(original.disciplines.all())
+    duplicated.restricted_groups.set(original.restricted_groups.all())
+    duplicated.co_owners.set(original.co_owners.all())
+
+    # themes are added via ThemeVideo explicitly or M2M set
+    if hasattr(original, "themes") and original.themes.exists():
+        duplicated.themes.set(original.themes.all())
+
+    # Copy Subtitles
+    for subtitle in original.subtitles.all():
+        from src.apps.video.models import Subtitle
+
+        Subtitle.objects.create(
+            video=duplicated,
+            language=subtitle.language,
+            file=subtitle.file,
+            is_default=subtitle.is_default,
+        )
+
+    # Copy Hyperlinks
+    for hyperlink in original.hyperlinks.all():
+        from src.apps.video.models import VideoHyperlink
+
+        VideoHyperlink.objects.create(
+            video=duplicated,
+            url=hyperlink.url,
+            text=hyperlink.text,
+            icon=hyperlink.icon,
+            position=hyperlink.position,
+            time_start=hyperlink.time_start,
+            time_end=hyperlink.time_end,
+        )
+
+    if duplicated.video_file:
+        from src.apps.encoding.tasks import trigger_runner_encoding_task
+        from src.apps.video.conf import video_settings
+
+        site_url = video_settings.site_url.rstrip("/")
+        source_url = f"{site_url}{duplicated.video_file.url}"
+        trigger_runner_encoding_task.delay(duplicated.pk, source_url)
+
+    return duplicated

--- a/src/apps/video/services/files.py
+++ b/src/apps/video/services/files.py
@@ -1,0 +1,27 @@
+"""
+Esup-Pod - Video file utilities.
+"""
+
+import shutil
+import os
+
+
+def duplicate_source_file(video_id, src_path, original_name):
+    """
+    Physically duplicates a video file on disk.
+
+    Copies the file at src_path into the same directory, prefixed with
+    the new video_id to avoid name collisions.
+
+    Returns the absolute path of the newly created file.
+    """
+    base_dir = os.path.dirname(src_path)
+    filename = os.path.basename(src_path)
+    new_filename = f"{video_id}_{filename}"
+    new_path = os.path.join(base_dir, new_filename)
+
+    # original_name is the relative path stored in DB (e.g. video/sources/filename.mp4)
+    new_name = os.path.join(os.path.dirname(original_name), new_filename)
+
+    shutil.copy2(src_path, new_path)
+    return new_name

--- a/src/apps/video/services/sites.py
+++ b/src/apps/video/services/sites.py
@@ -1,0 +1,31 @@
+"""
+Esup-Pod - Site assignment utilities.
+"""
+
+from django.contrib.sites.models import Site
+from django.conf import settings
+
+
+def assign_default_site(video):
+    """
+    Assigns a default site to a video if none is set.
+    """
+
+    if video.sites.exists():
+        return video
+
+    site = None
+
+    # Preferred: use SITE_ID if defined
+    site_id = getattr(settings, "SITE_ID", None)
+    if site_id:
+        site = Site.objects.filter(id=site_id).first()
+
+    # Fallback: current site
+    if site is None:
+        site = Site.objects.get_current()
+
+    if site:
+        video.sites.add(site)
+
+    return video

--- a/src/apps/video/services/slug.py
+++ b/src/apps/video/services/slug.py
@@ -1,0 +1,20 @@
+"""
+Esup-Pod - Video slug utilities.
+"""
+
+from src.apps.video.models import Video
+
+
+def generate_unique_slug(base_slug: str) -> str:
+    """
+    Ensures slug uniqueness in DB.
+
+    Appends an incrementing suffix (-1, -2, ...) until no existing Video
+    matches the candidate slug.
+    """
+    slug = base_slug
+    counter = 1
+    while Video.objects.filter(slug=slug).exists():
+        slug = f"{base_slug}-{counter}"
+        counter += 1
+    return slug

--- a/src/apps/video/tests/test_duplicate.py
+++ b/src/apps/video/tests/test_duplicate.py
@@ -1,0 +1,109 @@
+"""
+Esup-Pod - Tests for Video duplication.
+"""
+
+import tempfile
+import os
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from src.apps.video.models import Video
+
+User = get_user_model()
+
+
+class VideoDuplicationTests(APITestCase):
+    """
+    Tests for video duplication API endpoint.
+    """
+
+    def setUp(self):
+        """
+        Setup test users, site, and an initial video.
+        """
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.other_user = User.objects.create_user(
+            username="otheruser", password="password"
+        )
+        self.site = Site.objects.get_current()
+
+        # Create a dummy video file
+        self.temp_dir = tempfile.mkdtemp()
+        self.dummy_video_path = os.path.join(self.temp_dir, "test.mp4")
+        with open(self.dummy_video_path, "wb") as f:
+            f.write(b"dummy video content")
+
+        self.video_file = SimpleUploadedFile(
+            "test.mp4", b"dummy video content", content_type="video/mp4"
+        )
+
+        self.video = Video.objects.create(
+            title="Original Video",
+            owner=self.user,
+            status=Video.Status.PUBLISHED,
+        )
+        self.video.sites.set([self.site])
+        # Save the file using the field's save method to ensure it's in the proper storage
+        self.video.video_file.save("test.mp4", self.video_file)
+
+        from src.apps.video.conf import video_settings
+
+        video_settings.use_duplicate = True
+
+    def test_duplicate_video_success(self):
+        """
+        Test successful duplication of a video by its owner.
+        """
+        self.client.force_authenticate(user=self.user)
+        url = reverse("video-duplicate", kwargs={"slug": self.video.slug})
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        duplicated_slug = response.data["slug"]
+        duplicated_video = Video.objects.get(slug=duplicated_slug)
+
+        self.assertEqual(duplicated_video.title, f"Copy of {self.video.title}")
+        self.assertEqual(duplicated_video.status, Video.Status.DRAFT)
+        self.assertEqual(duplicated_video.owner, self.user)
+        self.assertTrue(duplicated_video.video_file.name.endswith(".mp4"))
+        self.assertNotEqual(duplicated_video.video_file.name, self.video.video_file.name)
+
+    def test_duplicate_video_unauthorized(self):
+        """
+        Test that an unauthenticated user cannot duplicate a video.
+        """
+        # Unauthenticated user
+        url = reverse("video-duplicate", kwargs={"slug": self.video.slug})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_duplicate_video_forbidden(self):
+        """
+        Test that a user who is not the owner cannot duplicate the video.
+        """
+        # Authenticated but not owner
+        self.client.force_authenticate(user=self.other_user)
+        url = reverse("video-duplicate", kwargs={"slug": self.video.slug})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_duplicate_video_disabled(self):
+        """
+        Test that duplication fails if use_duplicate setting is False.
+        """
+        from src.apps.video.conf import video_settings
+
+        video_settings.use_duplicate = False
+
+        self.client.force_authenticate(user=self.user)
+        url = reverse("video-duplicate", kwargs={"slug": self.video.slug})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["detail"], "Duplication is disabled.")
+
+        # Re-enable for other tests
+        video_settings.use_duplicate = True

--- a/src/apps/video/tests/test_duplicate.py
+++ b/src/apps/video/tests/test_duplicate.py
@@ -2,14 +2,16 @@
 Esup-Pod - Tests for Video duplication.
 """
 
-import tempfile
 import os
-from django.urls import reverse
-from rest_framework.test import APITestCase
-from rest_framework import status
-from django.core.files.uploadedfile import SimpleUploadedFile
+import tempfile
+
 from django.contrib.auth import get_user_model
 from django.contrib.sites.models import Site
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
 from src.apps.video.models import Video
 
 User = get_user_model()

--- a/src/apps/video/tests/test_duplicate.py
+++ b/src/apps/video/tests/test_duplicate.py
@@ -72,9 +72,7 @@ class VideoDuplicationTests(APITestCase):
         self.assertEqual(duplicated_video.status, Video.Status.DRAFT)
         self.assertEqual(duplicated_video.owner, self.user)
         self.assertTrue(duplicated_video.video_file.name.endswith(".mp4"))
-        self.assertNotEqual(
-            duplicated_video.video_file.name, self.video.video_file.name
-        )
+        self.assertNotEqual(duplicated_video.video_file.name, self.video.video_file.name)
 
     def test_duplicate_video_unauthorized(self):
         """

--- a/src/apps/video/tests/test_duplicate.py
+++ b/src/apps/video/tests/test_duplicate.py
@@ -24,7 +24,9 @@ class VideoDuplicationTests(APITestCase):
         """
         Setup test users, site, and an initial video.
         """
-        self.user = User.objects.create_user(username="testuser", password="password")
+        self.user = User.objects.create_user(
+            username="testuser", password="password"
+        )  # nosec
         self.other_user = User.objects.create_user(
             username="otheruser", password="password"
         )
@@ -70,7 +72,9 @@ class VideoDuplicationTests(APITestCase):
         self.assertEqual(duplicated_video.status, Video.Status.DRAFT)
         self.assertEqual(duplicated_video.owner, self.user)
         self.assertTrue(duplicated_video.video_file.name.endswith(".mp4"))
-        self.assertNotEqual(duplicated_video.video_file.name, self.video.video_file.name)
+        self.assertNotEqual(
+            duplicated_video.video_file.name, self.video.video_file.name
+        )
 
     def test_duplicate_video_unauthorized(self):
         """

--- a/src/apps/video/urls.py
+++ b/src/apps/video/urls.py
@@ -31,8 +31,16 @@ if video_settings.use_hyperlinks:
 
 urlpatterns = router.urls
 
-if video_settings.use_hyperlinks:
+if video_settings.use_duplicate:
+    urlpatterns += [
+        path(
+            "videos/<slug:slug>/duplicate/",
+            VideoViewSet.as_view({"post": "duplicate"}),
+            name="video-duplicate",
+        ),
+    ]
 
+if video_settings.use_hyperlinks:
     urlpatterns += [
         path(
             "hyperlink/<slug:video_slug>/hyperlinks/",

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -114,9 +114,7 @@ class VideoViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):  # noqa: C901
         """Creates a new video, checking user quota and triggering encoding."""
 
-        user_videos = Video.objects.filter(owner=self.request.user).exclude(
-            video_file=""
-        )
+        user_videos = Video.objects.filter(owner=self.request.user).exclude(video_file="")
         total_bytes = sum(v.video_file.size for v in user_videos if v.video_file)
 
         incoming_file = self.request.FILES.get("video_file")
@@ -137,9 +135,7 @@ class VideoViewSet(viewsets.ModelViewSet):
             from src.apps.video.models import License
 
             try:
-                target_license = License.objects.get(
-                    slug=video_settings.default_license
-                )
+                target_license = License.objects.get(slug=video_settings.default_license)
             except License.DoesNotExist:
                 target_license = None
 
@@ -481,9 +477,7 @@ class VideoViewSet(viewsets.ModelViewSet):
                 "properties": {"owner_id": {"type": "integer"}},
             }
         },
-        responses={
-            200: {"type": "object", "properties": {"status": {"type": "string"}}}
-        },
+        responses={200: {"type": "object", "properties": {"status": {"type": "string"}}}},
     )
     @action(detail=True, methods=["post"], permission_classes=[IsSuperUser])
     def transfer_ownership(self, request, slug=None):
@@ -544,9 +538,7 @@ class VideoViewSet(viewsets.ModelViewSet):
             )
 
         if original.video_file:
-            user_videos = Video.objects.filter(owner=request.user).exclude(
-                video_file=""
-            )
+            user_videos = Video.objects.filter(owner=request.user).exclude(video_file="")
             total_bytes = sum(v.video_file.size for v in user_videos if v.video_file)
             max_quota_bytes = encoding_settings.user_quota_size_gb * 1024 * 1024 * 1024
 

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -3,18 +3,21 @@ Esup-Pod - Video viewset.
 """
 
 import os
-import logging
 import hashlib
+import logging
 
-from rest_framework.response import Response
-from rest_framework import viewsets, permissions, parsers, filters
 from django.db.models import Q, F
-from django.conf import settings
-from django.contrib.sites.shortcuts import get_current_site
-from django.utils.translation import gettext_lazy as _
 from django.http import FileResponse, Http404
+from django.utils.translation import gettext_lazy as _
+from django.contrib.sites.shortcuts import get_current_site
+from django.conf import settings
+
+from rest_framework import viewsets, permissions, parsers, filters, status
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.response import Response
+from rest_framework.exceptions import PermissionDenied, ValidationError, NotFound
+
+from django_filters.rest_framework import DjangoFilterBackend
 from django.contrib.auth.hashers import check_password
 from drf_spectacular.utils import (
     extend_schema,
@@ -27,10 +30,12 @@ from src.apps.video.models import Video
 from src.apps.video.serializers import VideoSerializer
 from src.apps.video.permissions import IsOwnerOrCoOwnerOrChannelCollaborator
 from src.apps.authentication.permissions import IsSuperUser
-from django_filters.rest_framework import DjangoFilterBackend
 from src.apps.video.conf import video_settings
 from src.apps.encoding.conf import encoding_settings
 from src.apps.video.filters import VideoFilterSet
+
+from src.apps.video.services.duplicate import duplicate_video
+from django.db import transaction
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +89,10 @@ class VideoViewSet(viewsets.ModelViewSet):
                     self.check_object_permissions(self.request, obj)
                     return obj
 
-        return super().get_object()
+        try:
+            return super().get_object()
+        except Http404:
+            raise NotFound(_("Video not found."))
 
     def get_queryset(self):
         """
@@ -102,12 +110,16 @@ class VideoViewSet(viewsets.ModelViewSet):
 
         return Video.objects.visible_for(user).filter(id__in=qs).distinct()
 
-    def perform_create(self, serializer):
+    @transaction.atomic
+    def perform_create(self, serializer):  # noqa: C901
         """Creates a new video, checking user quota and triggering encoding."""
+
         user_videos = Video.objects.filter(owner=self.request.user).exclude(video_file="")
         total_bytes = sum(v.video_file.size for v in user_videos if v.video_file)
+
         incoming_file = self.request.FILES.get("video_file")
         incoming_size = incoming_file.size if incoming_file else 0
+
         max_quota_bytes = encoding_settings.user_quota_size_gb * 1024 * 1024 * 1024
 
         if total_bytes + incoming_size > max_quota_bytes:
@@ -143,9 +155,14 @@ class VideoViewSet(viewsets.ModelViewSet):
             license=target_license,
         )
 
-        current_site = get_current_site(self.request)
-        video.sites.add(current_site)
+        # ---- SITE ENFORCEMENT (IMPORTANT PART) ----
+        site = get_current_site(self.request)
+        if not site:
+            raise ValidationError({"sites": "Site could not be resolved."})
 
+        video.sites.set([site])
+
+        # ---- ENCODING TRIGGER ----
         if video.video_file:
             from src.apps.encoding.tasks import trigger_runner_encoding_task
 
@@ -487,3 +504,47 @@ class VideoViewSet(viewsets.ModelViewSet):
         video.save(update_fields=["owner"])
 
         return Response({"status": "ownership transferred"})
+
+    @extend_schema(
+        summary="Duplicate a video",
+        description="Creates a full duplicate of a video. The title is automatically set to 'Copy of <original title>'.",
+        request=None,
+        responses={201: VideoSerializer},
+    )
+    @action(
+        detail=True,
+        methods=["post"],
+        permission_classes=[IsOwnerOrCoOwnerOrChannelCollaborator],
+    )
+    def duplicate(self, request, slug=None):
+        """
+        Creates a full duplicate of a video, including file copy and M2M relations.
+        Restricted to the video owner, co-owners, and superusers.
+        Only available when USE_DUPLICATE is enabled in settings.
+        """
+        original = self.get_object()
+
+        if not video_settings.use_duplicate:
+            raise PermissionDenied(_("Duplication is disabled."))
+
+        if not video_settings.allow_authenticated_upload and not request.user.is_staff:
+            raise PermissionDenied(_("You are not allowed to duplicate videos."))
+
+        if video_settings.restrict_edit_to_staff and not request.user.is_staff:
+            raise PermissionDenied(
+                _("Only staff members are allowed to duplicate videos.")
+            )
+
+        if original.video_file:
+            user_videos = Video.objects.filter(owner=request.user).exclude(video_file="")
+            total_bytes = sum(v.video_file.size for v in user_videos if v.video_file)
+            max_quota_bytes = encoding_settings.user_quota_size_gb * 1024 * 1024 * 1024
+
+            if total_bytes + original.video_file.size > max_quota_bytes:
+                raise ValidationError(
+                    {"detail": _("Quota exceeded. Cannot duplicate this video.")}
+                )
+
+        duplicated = duplicate_video(original, request.user)
+        serializer = self.get_serializer(duplicated)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -507,9 +507,6 @@ class VideoViewSet(viewsets.ModelViewSet):
 
     @extend_schema(
         summary=_("Duplicate a video"),
-        description=_(
-            "Creates a full duplicate of a video. The title is automatically set to 'Copy of <original title>'."
-        ),
         request=None,
         responses={201: VideoSerializer},
     )
@@ -521,6 +518,7 @@ class VideoViewSet(viewsets.ModelViewSet):
     def duplicate(self, request, slug=None):
         """
         Creates a full duplicate of a video, including file copy and M2M relations.
+        The title is automatically set to 'Copy of <original title>'.
         Restricted to the video owner, co-owners, and superusers.
         Only available when USE_DUPLICATE is enabled in settings.
         """

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -114,7 +114,9 @@ class VideoViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):  # noqa: C901
         """Creates a new video, checking user quota and triggering encoding."""
 
-        user_videos = Video.objects.filter(owner=self.request.user).exclude(video_file="")
+        user_videos = Video.objects.filter(owner=self.request.user).exclude(
+            video_file=""
+        )
         total_bytes = sum(v.video_file.size for v in user_videos if v.video_file)
 
         incoming_file = self.request.FILES.get("video_file")
@@ -135,7 +137,9 @@ class VideoViewSet(viewsets.ModelViewSet):
             from src.apps.video.models import License
 
             try:
-                target_license = License.objects.get(slug=video_settings.default_license)
+                target_license = License.objects.get(
+                    slug=video_settings.default_license
+                )
             except License.DoesNotExist:
                 target_license = None
 
@@ -477,7 +481,9 @@ class VideoViewSet(viewsets.ModelViewSet):
                 "properties": {"owner_id": {"type": "integer"}},
             }
         },
-        responses={200: {"type": "object", "properties": {"status": {"type": "string"}}}},
+        responses={
+            200: {"type": "object", "properties": {"status": {"type": "string"}}}
+        },
     )
     @action(detail=True, methods=["post"], permission_classes=[IsSuperUser])
     def transfer_ownership(self, request, slug=None):
@@ -506,8 +512,10 @@ class VideoViewSet(viewsets.ModelViewSet):
         return Response({"status": "ownership transferred"})
 
     @extend_schema(
-        summary="Duplicate a video",
-        description="Creates a full duplicate of a video. The title is automatically set to 'Copy of <original title>'.",
+        summary=_("Duplicate a video"),
+        description=_(
+            "Creates a full duplicate of a video. The title is automatically set to 'Copy of <original title>'."
+        ),
         request=None,
         responses={201: VideoSerializer},
     )
@@ -536,11 +544,16 @@ class VideoViewSet(viewsets.ModelViewSet):
             )
 
         if original.video_file:
-            user_videos = Video.objects.filter(owner=request.user).exclude(video_file="")
+            user_videos = Video.objects.filter(owner=request.user).exclude(
+                video_file=""
+            )
             total_bytes = sum(v.video_file.size for v in user_videos if v.video_file)
             max_quota_bytes = encoding_settings.user_quota_size_gb * 1024 * 1024 * 1024
 
-            if total_bytes + original.video_file.size > max_quota_bytes:
+            if (
+                max_quota_bytes > 0
+                and total_bytes + original.video_file.size > max_quota_bytes
+            ):
                 raise ValidationError(
                     {"detail": _("Quota exceeded. Cannot duplicate this video.")}
                 )


### PR DESCRIPTION
# FEAT(video): integrate complete video duplication system ISO V4

This Pull Request integrates the complete video duplication system (achieving feature parity with V4) into the V5 API-first architecture. It introduces a new endpoint within the VideoViewSet and isolates the business logic into dedicated services (duplicate.py, files.py, slug.py, sites.py) to cleanly handle physical file copying, generation of new slugs, multi-site support, and the comprehensive duplication of metadata, all backed by a new dedicated unit test suite.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
