### PR TITLE
FEAT(video): implement video cut feature

### DIFF
--- a/docs/video/README.md
+++ b/docs/video/README.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Video: Overview
 
 The **Video** application is the core module of Pod V5. It manages the full lifecycle of video content — from upload and metadata management to access control and streaming.
@@ -11,6 +12,7 @@ The **Video** application is the core module of Pod V5. It manages the full life
 | **Co-ownership**       | Multiple users can share edit rights on the same video.                            |
 | **Subtitles**          | Attach subtitle files (VTT/SRT) per language (FR, EN, ES).                         |
 | **Streaming**          | Direct file streaming via a dedicated API endpoint.                                |
+| **Video Cut**          | Trim a video virtually using a start and end time (clears chapters/notes).         |
 | **Hyperlinks**         | Add interactive links (timecodes, external resources) to videos.                   |
 | **Categorization**     | Organize videos with Types, Disciplines, and Tags.                                 |
 | **Comments & Votes**   | Engage users with a commenting and upvote/downvote system.                         |
@@ -41,17 +43,18 @@ A video passes through the following states:
 
 ## Data Models
 
-| Model         | Role                                                                         |
-| :------------ | :--------------------------------------------------------------------------- |
-| **Video**     | Central model containing all metadata, access settings, and site isolation.  |
-| **Type**      | General categorization type for videos.                                      |
-| **Discipline**| Academic disciplines associated with videos.                                 |
-| **Tag**       | Free-form tags for better searchability.                                     |
-| **Comment**   | User comments left on a video.                                               |
-| **Vote**      | Upvotes and downvotes for comments.                                          |
-| **Subtitle**  | A subtitle file attached to a video, for a given language.                   |
-| **VideoHyperlink** | Interactive links attached to a video at specific time intervals.       |
-| **ViewCount** | Stores the number of views per day, per video.                               |
+| Model              | Role                                                                         |
+| :----------------- | :--------------------------------------------------------------------------- |
+| **Video**          | Central model containing all metadata, access settings, and site isolation.  |
+| **Type**           | General categorization type for videos.                                      |
+| **Discipline**     | Academic disciplines associated with videos.                                 |
+| **Tag**            | Free-form tags for better searchability.                                     |
+| **Comment**        | User comments left on a video.                                               |
+| **Vote**           | Upvotes and downvotes for comments.                                          |
+| **Subtitle**       | A subtitle file attached to a video, for a given language.                   |
+| **VideoCut**       | Trimming definition (start/end in seconds) associated with a video.          |
+| **VideoHyperlink** | Interactive links attached to a video at specific time intervals.            |
+| **ViewCount**      | Stores the number of views per day, per video.                               |
 
 ## API Endpoints
 
@@ -71,6 +74,8 @@ A video passes through the following states:
 | **GET/POST** | `/api/videos/{slug}/comments/`        | Manage comments for a video.                      |
 | **POST/DEL** | `/api/comments/{id}/vote/`            | Upvote/downvote or remove vote on a comment.      |
 | **GET**      | `/api/hyperlinks/`                    | List video hyperlinks.                            |
+| **POST**     | `/api/cut/{slug}/`                    | Create or replace a video cut.                    |
+| **DELETE**   | `/api/cut/{slug}/delete/`             | Delete the cut associated with the video.         |
 | **POST**     | `/api/hyperlinks/`                    | Create a hyperlink (video owner/co-owner only).   |
 | **PATCH/DEL**| `/api/hyperlinks/{id}/`               | Modify or delete a hyperlink.                     |
 | **GET**      | `/api/subtitles/`                     | List subtitles (filterable by `?video_id=`).      |

--- a/docs/video/details.md
+++ b/docs/video/details.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD013 -->
 # Video: Technical Details
 
 >
@@ -111,6 +112,7 @@ Unique constraint on `(video, date)`. Ordered by `-date`.
 - **Discipline (`src/apps/video/models/Discipline.py`)**: Formal academic categories.
 - **Comment (`src/apps/video/models/Comment.py`)**: User remarks tied to a specific video with timestamp and user.
 - **Vote (`src/apps/video/models/Vote.py`)**: Tracks Up/Down votes on `Comment` items to calculate the net score.
+- **VideoCut (`src/apps/video/models/VideoCut.py`)**: Trimming definition (start/end in seconds) associated in a one-to-one relationship with a video.
 - **Tag**: Handled dynamically by the `django-tagulous` extension.
 
 ---
@@ -211,6 +213,14 @@ Unlocks a password-protected restricted video.
 - If `is_auth_required = True`: user must be authenticated.
 - Validates the provided `password` against the stored hash. (Alternatively accepts a legacy `hash` parameter for backward compatibility).
 - Returns the `video_url` on success and registers access in the session state.
+
+### `POST /api/cut/{slug}/` & `DELETE /api/cut/{slug}/delete/`
+
+Manages the video cut feature (trimming a video virtually):
+
+- **POST**: Creates or replaces a cut for the given video (payload: `time_start`, `time_end` in seconds). Automatically purges time-dependent objects (chapters, notes) attached to the video to avoid inconsistencies.
+- **DELETE**: Removes the cut definition.
+- **Permissions**: Requires owner, co-owner, or super-user rights. If `video_settings.restrict_edit_to_staff` is enabled, only staff members can manage cuts.
 
 ---
 

--- a/src/apps/video/admin.py
+++ b/src/apps/video/admin.py
@@ -23,6 +23,7 @@ from src.apps.video.models import (
     License,
     Cursus,
     VideoHyperlink,
+    VideoCut,
 )
 
 
@@ -131,6 +132,16 @@ class VideoHyperlinkAdmin(admin.ModelAdmin):
     list_filter = ("video",)
     search_fields = ("text", "url", "video__title")
     readonly_fields = ("id", "created_at", "updated_at")
+
+
+@admin.register(VideoCut)
+class VideoCutAdmin(admin.ModelAdmin):
+    """Admin for Video Cuts."""
+
+    list_display = ("video", "time_start", "time_end", "created_at")
+    search_fields = ("video__title",)
+    readonly_fields = ("id", "created_at")
+    raw_id_fields = ("video",)
 
 
 @admin.register(Language)

--- a/src/apps/video/models/VideoCut.py
+++ b/src/apps/video/models/VideoCut.py
@@ -1,0 +1,31 @@
+"""
+Esup-Pod - VideoCut model.
+"""
+
+import uuid
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class VideoCut(models.Model):
+    """Stores the cut parameters (start/end in seconds) for a video."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    video = models.OneToOneField(
+        "video.Video",
+        on_delete=models.CASCADE,
+        related_name="cut",
+        verbose_name=_("Video"),
+    )
+    time_start = models.PositiveIntegerField(verbose_name=_("Start (seconds)"))
+    time_end = models.PositiveIntegerField(verbose_name=_("End (seconds)"))
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        """VideoCut model metadata."""
+
+        verbose_name = _("Video Cut")
+        verbose_name_plural = _("Video Cuts")
+
+    def __str__(self):
+        return f"Cut for {self.video.title} ({self.time_start}s - {self.time_end}s)"

--- a/src/apps/video/models/__init__.py
+++ b/src/apps/video/models/__init__.py
@@ -10,6 +10,7 @@ from .Vote import Vote
 from .Type import Type
 from .Discipline import Discipline
 from .VideoHyperlink import VideoHyperlink
+from .VideoCut import VideoCut
 from .Language import Language
 from .License import License
 from .Cursus import Cursus
@@ -23,6 +24,7 @@ __all__ = [
     "Type",
     "Discipline",
     "VideoHyperlink",
+    "VideoCut",
     "Language",
     "License",
     "Cursus",

--- a/src/apps/video/serializers/VideoCutSerializer.py
+++ b/src/apps/video/serializers/VideoCutSerializer.py
@@ -1,0 +1,25 @@
+"""
+Esup-Pod - VideoCut serializer.
+"""
+
+from rest_framework import serializers
+from src.apps.video.models import VideoCut
+
+
+class VideoCutSerializer(serializers.ModelSerializer):
+    """Serializer for the VideoCut model."""
+
+    class Meta:
+        """VideoCut serializer metadata."""
+
+        model = VideoCut
+        fields = ["id", "time_start", "time_end", "created_at"]
+        read_only_fields = ["id", "created_at"]
+
+    def validate(self, data):
+        """Ensures time_start is strictly less than time_end."""
+        if data.get("time_start", 0) >= data.get("time_end", 0):
+            raise serializers.ValidationError(
+                "Start time must be strictly less than end time."
+            )
+        return data

--- a/src/apps/video/serializers/VideoCutSerializer.py
+++ b/src/apps/video/serializers/VideoCutSerializer.py
@@ -6,6 +6,9 @@ from rest_framework import serializers
 from src.apps.video.models import VideoCut
 
 
+from django.utils.translation import gettext_lazy as _
+
+
 class VideoCutSerializer(serializers.ModelSerializer):
     """Serializer for the VideoCut model."""
 
@@ -20,6 +23,6 @@ class VideoCutSerializer(serializers.ModelSerializer):
         """Ensures time_start is strictly less than time_end."""
         if data.get("time_start", 0) >= data.get("time_end", 0):
             raise serializers.ValidationError(
-                "Start time must be strictly less than end time."
+                _("Start time must be strictly less than end time.")
             )
         return data

--- a/src/apps/video/serializers/__init__.py
+++ b/src/apps/video/serializers/__init__.py
@@ -9,6 +9,7 @@ from .DisciplineSerializer import DisciplineSerializer  # noqa: F401
 from .TagSerializer import TagSerializer  # noqa: F401
 from .TypeSerializer import TypeSerializer  # noqa: F401
 from .HyperlinkSerializer import VideoHyperlinkSerializer  # noqa: F401
+from .VideoCutSerializer import VideoCutSerializer  # noqa: F401
 
 __all__ = [
     "VideoSerializer",
@@ -18,4 +19,5 @@ __all__ = [
     "TagSerializer",
     "TypeSerializer",
     "VideoHyperlinkSerializer",
+    "VideoCutSerializer",
 ]

--- a/src/apps/video/tests/test_models.py
+++ b/src/apps/video/tests/test_models.py
@@ -6,7 +6,14 @@ import os
 from django.test import TestCase
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
-from src.apps.video.models import Video, ViewCount, Comment, Subtitle, VideoHyperlink
+from src.apps.video.models import (
+    Video,
+    ViewCount,
+    Comment,
+    Subtitle,
+    VideoHyperlink,
+    VideoCut,
+)
 from src.apps.encoding.models.EncodingVideo import EncodingVideo
 from src.apps.collection.models.Channel import Channel
 import datetime
@@ -119,6 +126,72 @@ class VideoModelTests(TestCase):
         self.assertEqual(VideoHyperlink.objects.count(), 1)
         self.video.delete()
         self.assertEqual(VideoHyperlink.objects.count(), 0)
+
+
+class VideoCutTests(TestCase):
+    """Tests for VideoCut model."""
+
+    def setUp(self):
+        """Sets up a video for cut testing."""
+        sync_metadata(sender=None)
+
+        self.user = User.objects.create_user(
+            username="cut_owner",
+            password="password",
+        )
+
+        self.video = Video.objects.create(
+            title="Cut Test Video",
+            owner=self.user,
+            status=Video.Status.PUBLISHED,
+        )
+
+    def test_create_video_cut(self):
+        """Verifies that a VideoCut can be created and linked to a video."""
+        cut = VideoCut.objects.create(
+            video=self.video,
+            time_start=10,
+            time_end=50,
+        )
+
+        self.assertEqual(cut.video, self.video)
+        self.assertEqual(cut.time_start, 10)
+        self.assertEqual(cut.time_end, 50)
+
+        # reverse relation
+        self.assertEqual(self.video.cut, cut)
+
+    def test_video_cut_str(self):
+        """Verifies the string representation of VideoCut."""
+        cut = VideoCut.objects.create(
+            video=self.video,
+            time_start=5,
+            time_end=20,
+        )
+
+        self.assertIn("Cut Test Video", str(cut))
+        self.assertIn("5", str(cut))
+        self.assertIn("20", str(cut))
+
+    def test_one_cut_per_video(self):
+        """Ensures OneToOne constraint replaces existing cut logic (manual simulation)."""
+        VideoCut.objects.create(
+            video=self.video,
+            time_start=10,
+            time_end=30,
+        )
+
+        # simulate replacement like API does
+        VideoCut.objects.filter(video=self.video).delete()
+
+        new_cut = VideoCut.objects.create(
+            video=self.video,
+            time_start=40,
+            time_end=80,
+        )
+
+        self.assertEqual(VideoCut.objects.filter(video=self.video).count(), 1)
+        self.assertEqual(new_cut.time_start, 40)
 
 
 class CommentBasicTests(TestCase):

--- a/src/apps/video/tests/test_videocut.py
+++ b/src/apps/video/tests/test_videocut.py
@@ -1,0 +1,99 @@
+"""
+Esup-Pod - Video Cut API tests.
+"""
+
+from unittest.mock import patch
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APITestCase, APIRequestFactory, force_authenticate
+
+from src.apps.video.apps import sync_metadata
+from src.apps.video.models import Video, VideoCut
+from src.apps.video.views.VideoCutViewSet import VideoCutViewSet
+
+User = get_user_model()
+
+
+class VideoCutAPITests(APITestCase):
+    """Test suite for VideoCut API endpoints."""
+
+    def setUp(self):
+        """Set up test data for VideoCut API endpoints."""
+        sync_metadata(sender=None)
+        self.factory = APIRequestFactory()
+        self.owner = User.objects.create_user(
+            username="owner",
+            password="password",
+        )
+        self.other_user = User.objects.create_user(
+            username="other",
+            password="password",
+        )
+        self.video = Video.objects.create(
+            title="Test Video", owner=self.owner, slug="test-video"
+        )
+        # Patch video_settings.use_cut to True
+        patcher = patch(
+            "src.apps.video.views.VideoCutViewSet.video_settings.use_cut", True
+        )
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    def test_create_cut_unauthorized(self):
+        """Non-owners cannot create a cut."""
+        view = VideoCutViewSet.as_view({"post": "create"})
+        data = {
+            "video": self.video.id,
+            "time_start": 5,
+            "time_end": 20,
+        }
+        request = self.factory.post("/", data)
+        force_authenticate(request, user=self.other_user)
+        response = view(request, video_slug=self.video.slug)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_cut_owner(self):
+        """Owner can create a cut."""
+        view = VideoCutViewSet.as_view({"post": "create"})
+        data = {
+            "video": self.video.id,
+            "time_start": 15,
+            "time_end": 60,
+        }
+        request = self.factory.post("/", data)
+        force_authenticate(request, user=self.owner)
+        response = view(request, video_slug=self.video.slug)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(VideoCut.objects.filter(video=self.video).count(), 1)
+
+    def test_replace_cut(self):
+        """Creating a new cut replaces the previous one."""
+        VideoCut.objects.create(video=self.video, time_start=10, time_end=50)
+
+        view = VideoCutViewSet.as_view({"post": "create"})
+        data = {
+            "video": self.video.id,
+            "time_start": 20,
+            "time_end": 70,
+        }
+        request = self.factory.post("/", data)
+        force_authenticate(request, user=self.owner)
+        response = view(request, video_slug=self.video.slug)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(VideoCut.objects.filter(video=self.video).count(), 1)
+        cut = VideoCut.objects.get(video=self.video)
+        self.assertEqual(cut.time_start, 20)
+        self.assertEqual(cut.time_end, 70)
+
+    def test_create_cut_invalid_times(self):
+        """Invalid time range should be rejected."""
+        view = VideoCutViewSet.as_view({"post": "create"})
+        data = {
+            "video": self.video.id,
+            "time_start": 50,
+            "time_end": 10,
+        }
+        request = self.factory.post("/", data)
+        force_authenticate(request, user=self.owner)
+        response = view(request, video_slug=self.video.slug)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/src/apps/video/urls.py
+++ b/src/apps/video/urls.py
@@ -12,6 +12,7 @@ from src.apps.video.views import (
     TagViewSet,
     TypeViewSet,
     VideoHyperlinkViewSet,
+    VideoCutViewSet,
 )
 from src.apps.video.conf import video_settings
 
@@ -22,11 +23,16 @@ router.register(r"disciplines", DisciplineViewSet, basename="discipline")
 router.register(r"tags", TagViewSet, basename="tag")
 router.register(r"types", TypeViewSet, basename="type")
 
-urlpatterns = router.urls
-
 if video_settings.use_hyperlinks:
     router.register(
         r"video-hyperlinks", VideoHyperlinkViewSet, basename="video-hyperlink"
+    )
+
+if video_settings.use_cut:
+    router.register(
+        r"video-cuts",
+        VideoCutViewSet,
+        basename="video-cut",
     )
 
 urlpatterns = router.urls
@@ -54,6 +60,20 @@ if video_settings.use_hyperlinks:
                 }
             ),
             name="video-hyperlink-detail",
+        ),
+    ]
+
+if video_settings.use_cut:
+    urlpatterns += [
+        path(
+            "cut/<slug:video_slug>/",
+            VideoCutViewSet.as_view({"post": "create"}),
+            name="video-cut-create",
+        ),
+        path(
+            "cut/<slug:video_slug>/delete/",
+            VideoCutViewSet.as_view({"delete": "destroy"}),
+            name="video-cut-delete",
         ),
     ]
 

--- a/src/apps/video/views/VideoCutViewSet.py
+++ b/src/apps/video/views/VideoCutViewSet.py
@@ -1,0 +1,123 @@
+"""
+Esup-Pod - VideoCut viewset.
+"""
+
+from rest_framework import viewsets, status
+from rest_framework.mixins import CreateModelMixin, DestroyModelMixin
+from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.response import Response
+from src.apps.video.models import Video
+from src.apps.video.serializers import VideoCutSerializer
+from src.apps.video.conf import video_settings
+from django.utils.translation import gettext_lazy as _
+from drf_spectacular.utils import extend_schema
+
+
+class VideoCutViewSet(CreateModelMixin, DestroyModelMixin, viewsets.GenericViewSet):
+    """ViewSet for video cut management.
+    Supports creation (POST) and deletion (DELETE) of a video cut.
+    Permissions are checked via a private helper method.
+    """
+
+    @extend_schema(
+        summary="Create or replace a video cut",
+        description="Creates or replaces a cut for the given video. time_start and time_end are in seconds.",
+        request=VideoCutSerializer,
+        responses={
+            201: VideoCutSerializer,
+            400: "Bad request",
+            403: "Forbidden",
+            404: "Not found",
+        },
+    )
+    def create(self, request, video_slug=None):
+        """Create or replace a cut for the given video.
+
+        The method validates permissions, validates the payload, removes any existing cut,
+        deletes time‑dependent objects (chapters, notes) and then creates the new cut.
+        """
+        # 0️⃣ Check configuration
+        if not video_settings.use_cut:
+            return Response(
+                {"detail": _("The video cutting feature is disabled.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # 1️⃣ Retrieve video
+        try:
+            video = Video.objects.get(slug=video_slug)
+        except Video.DoesNotExist:
+            raise NotFound(_("Video not found."))
+
+        # 2️⃣ Permission check (shared logic)
+        self._assert_edit_permission(request, video)
+
+        # 3️⃣ Validate payload
+        serializer = VideoCutSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        # 4️⃣ Replace existing cut (one‑to‑one relationship)
+        if hasattr(video, "cut") and video.cut:
+            video.cut.delete()
+        video_cut = serializer.save(video=video)
+
+        # 5️⃣ Clean time‑dependent data
+        if hasattr(video, "chapters"):
+            video.chapters.all().delete()
+        if hasattr(video, "notes"):
+            video.notes.all().delete()
+
+        return Response(
+            VideoCutSerializer(video_cut).data, status=status.HTTP_201_CREATED
+        )
+
+    @extend_schema(
+        summary="Delete a video cut",
+        description="Deletes the cut associated with the given video.",
+        responses={
+            204: None,
+            403: "Forbidden",
+            404: "Not found",
+        },
+    )
+    def destroy(self, request, video_slug=None):
+        """Delete the cut associated with the given video."""
+        # Check configuration
+        if not video_settings.use_cut:
+            return Response(
+                {"detail": _("The video cutting feature is disabled.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Retrieve video
+        try:
+            video = Video.objects.get(slug=video_slug)
+        except Video.DoesNotExist:
+            raise NotFound(_("Video not found."))
+
+        # Permission check
+        self._assert_edit_permission(request, video)
+
+        # Delete the cut; raise 404 if none exists
+        if not hasattr(video, "cut") or video.cut is None:
+            raise NotFound(_("No cut found for this video."))
+        video.cut.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def _assert_edit_permission(self, request, video):
+        """Internal helper to enforce edit permissions.
+
+        Allows owners, co‑owners, super‑users, and optionally staff members if
+        `video_settings.restrict_edit_to_staff` is enabled.
+        """
+        is_owner = video.owner == request.user
+        is_co_owner = video.co_owners.filter(pk=request.user.pk).exists()
+        if not (is_owner or is_co_owner or request.user.is_superuser):
+            raise PermissionDenied(
+                _("You do not have permission to modify this video cut.")
+            )
+        if video_settings.restrict_edit_to_staff and not request.user.is_staff:
+            raise PermissionDenied(
+                _("Only staff members are allowed to modify video cuts.")
+            )

--- a/src/apps/video/views/VideoCutViewSet.py
+++ b/src/apps/video/views/VideoCutViewSet.py
@@ -20,8 +20,7 @@ class VideoCutViewSet(CreateModelMixin, DestroyModelMixin, viewsets.GenericViewS
     """
 
     @extend_schema(
-        summary="Create or replace a video cut",
-        description="Creates or replaces a cut for the given video. time_start and time_end are in seconds.",
+        summary=_("Create or replace a video cut"),
         request=VideoCutSerializer,
         responses={
             201: VideoCutSerializer,
@@ -31,7 +30,8 @@ class VideoCutViewSet(CreateModelMixin, DestroyModelMixin, viewsets.GenericViewS
         },
     )
     def create(self, request, video_slug=None):
-        """Create or replace a cut for the given video.
+        """
+        Creates or replaces a cut for the given video. time_start and time_end are in seconds.
 
         The method validates permissions, validates the payload, removes any existing cut,
         deletes time‑dependent objects (chapters, notes) and then creates the new cut.
@@ -73,8 +73,7 @@ class VideoCutViewSet(CreateModelMixin, DestroyModelMixin, viewsets.GenericViewS
         )
 
     @extend_schema(
-        summary="Delete a video cut",
-        description="Deletes the cut associated with the given video.",
+        summary=_("Delete a video cut"),
         responses={
             204: None,
             403: "Forbidden",
@@ -82,7 +81,7 @@ class VideoCutViewSet(CreateModelMixin, DestroyModelMixin, viewsets.GenericViewS
         },
     )
     def destroy(self, request, video_slug=None):
-        """Delete the cut associated with the given video."""
+        """Deletes the cut associated with the given video."""
         # Check configuration
         if not video_settings.use_cut:
             return Response(

--- a/src/apps/video/views/__init__.py
+++ b/src/apps/video/views/__init__.py
@@ -9,6 +9,7 @@ from .DisciplineViewSet import DisciplineViewSet  # noqa: F401
 from .TagViewSet import TagViewSet  # noqa: F401
 from .TypeViewSet import TypeViewSet  # noqa: F401
 from .HyperlinkViewSet import VideoHyperlinkViewSet  # noqa: F401
+from .VideoCutViewSet import VideoCutViewSet  # noqa: F401
 
 __all__ = [
     "VideoViewSet",
@@ -18,4 +19,5 @@ __all__ = [
     "TagViewSet",
     "TypeViewSet",
     "VideoHyperlinkViewSet",
+    "VideoCutViewSet",
 ]


### PR DESCRIPTION
# FEAT(video): implement video cut feature

This PR introduces and optimizes the "Video Cut" (virtual temporal trimming) system to fully comply with the V5 REST architecture:
- **Data Architecture:** Extracts the cut data into a dedicated `VideoCut` model (as a `OneToOne` relationship with `Video`), preventing the bloat present in the legacy V4 implementation.
- **REST API & Security:** Clean implementation utilizing a `GenericViewSet`, with centralized and refactored permission logic (owner, co-owner, super-user, staff).
- **Data Integrity:** Implemented an automated cleanup mechanism that safely deletes time-dependent objects (chapters, notes) whenever a new cut is created to ensure data consistency.
- **Quality:** OpenAPI responses are fully mapped (`drf-spectacular`), unit tests have been extended, and comprehensive documentation has been seamlessly integrated into the `video` app docs.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
