### PR TITLE
FEAT(video): implement video bulk actions

### DIFF
--- a/docs/video/README.md
+++ b/docs/video/README.md
@@ -19,6 +19,7 @@ The **Video** application is the core module of Pod V5. It manages the full life
 | **View Tracking**      | Daily view count per video, accessible via the API.                                |
 | **Auto-expiration**    | Deletion date computed automatically based on the owner's affiliation.             |
 | **Encoding Pipeline**  | On upload, triggers an asynchronous encoding task via the Encoding app.            |
+| **Bulk Actions**       | Update or delete multiple videos in one request (async via Celery above threshold). |
 
 ## Video Status Lifecycle
 
@@ -76,6 +77,8 @@ A video passes through the following states:
 | **GET**      | `/api/subtitles/`                     | List subtitles (filterable by `?video_id=`).      |
 | **POST**     | `/api/subtitles/`                     | Attach a subtitle to a video.                     |
 | **DELETE**   | `/api/subtitles/{id}/`                | Delete a subtitle (video owner only).             |
+| **PATCH**    | `/api/videos/bulk/`                   | Bulk update fields on multiple videos.            |
+| **DELETE**   | `/api/videos/bulk/`                   | Bulk delete multiple videos.                      |
 
 ## Further Reading
 

--- a/docs/video/details.md
+++ b/docs/video/details.md
@@ -213,7 +213,6 @@ Unlocks a password-protected restricted video.
 - Validates the provided `password` against the stored hash. (Alternatively accepts a legacy `hash` parameter for backward compatibility).
 - Returns the `video_url` on success and registers access in the session state.
 
-<<<<<<< HEAD
 ### `PATCH|DELETE /api/videos/bulk/`
 
 Applies an update or deletion to **multiple videos in one request**.
@@ -240,7 +239,6 @@ Applies an update or deletion to **multiple videos in one request**.
   A `403 Forbidden` is raised on the first video that fails the check.
 - **Feature flag**: returns `400` if `USE_BULK_ACTIONS = False`.
 
-=======
 ### `POST /api/cut/{slug}/` & `DELETE /api/cut/{slug}/delete/`
 
 Manages the video cut feature (trimming a video virtually):
@@ -250,7 +248,6 @@ Manages the video cut feature (trimming a video virtually):
 - **Permissions**: Requires owner, co-owner, or super-user rights. If `video_settings.restrict_edit_to_staff` is enabled, only staff members can manage cuts.
 
 ---
->>>>>>> upstream/dev_v5
 
 ## 6. Upload & Encoding Flow
 
@@ -272,7 +269,6 @@ Manages the video cut feature (trimming a video virtually):
 
 Managed via `VideoConfig` (pydantic-settings in `src/apps/video/conf.py`). Settings are read from Django settings or environment variables with the prefix `POD_VIDEO_`.
 
-<<<<<<< HEAD
 | Setting                      | Default       | Description                                                 |
 | :--------------------------- | :------------ | :---------------------------------------------------------- |
 | `USE_HYPERLINKS`             | `True`        | Enables the video hyperlinks system globally.               |
@@ -289,22 +285,6 @@ Managed via `VideoConfig` (pydantic-settings in `src/apps/video/conf.py`). Setti
 | `DEFAULT_DC_RIGHTS`          | (string)      | Dublin Core `rights` metadata default.                      |
 | `USE_BULK_ACTIONS`           | `True`        | Enable bulk update/delete endpoint (`/api/videos/bulk/`).   |
 | `BULK_ASYNC_THRESHOLD`       | `20`          | Videos above this count are processed async via Celery.     |
-=======
-| Setting                      | Default       | Description                                                |
-| :--------------------------- | :------------ | :--------------------------------------------------------- |
-| `USE_HYPERLINKS`             | `True`        | Enables the video hyperlinks system globally.              |
-| `WEBTV_MODE`                 | `False`       | If `True`, video file is optional (WebTV / channel mode).  |
-| `ALLOW_AUTHENTICATED_UPLOAD` | `True`        | Allow authenticated non-staff users to upload.             |
-| `RESTRICT_EDIT_TO_STAFF`     | `False`       | Locks write access to staff and admins only.               |
-| `HOMEPAGE_SHOWS_PASSWORDED`  | `True`        | Show password-protected videos in public listing.          |
-| `DEFAULT_LICENSE`            | `"COPYRIGHT"` | Default license applied to newly created videos.           |
-| `DEFAULT_THUMBNAIL`          | (path)        | Path to the fallback thumbnail image.                      |
-| `DEFAULT_YEAR_DATE_DELETE`   | `2`           | Default years before expiration (if no affiliation match). |
-| `ACCOMMODATION_YEARS`        | `{}`          | Dict mapping affiliation → nb years before deletion.       |
-| `CACHE_TIMEOUT`              | `600`         | Cache TTL in seconds for video data.                       |
-| `DEFAULT_DC_COVERAGE`        | (string)      | Dublin Core `coverage` metadata default.                   |
-| `DEFAULT_DC_RIGHTS`          | (string)      | Dublin Core `rights` metadata default.                     |
->>>>>>> upstream/dev_v5
 
 ---
 

--- a/docs/video/details.md
+++ b/docs/video/details.md
@@ -212,7 +212,32 @@ Unlocks a password-protected restricted video.
 - Validates the provided `password` against the stored hash. (Alternatively accepts a legacy `hash` parameter for backward compatibility).
 - Returns the `video_url` on success and registers access in the session state.
 
----
+### `PATCH|DELETE /api/videos/bulk/`
+
+Applies an update or deletion to **multiple videos in one request**.
+
+**Request body:**
+
+```json
+{
+  "video_ids": [1, 2, 3],
+  "fields": { "allow_downloading": true }
+}
+```
+
+**Behaviour:**
+
+- `PATCH`: updates only the fields listed in `fields`. Fields in `BULK_EXCLUDED_FIELDS`
+  (`title`, `slug`, `owner`, `video_file`, `created_at`, `updated_at`, `duration`,
+  `encoding_status`) are rejected with `400 Bad Request`.
+- `DELETE`: deletes all listed videos. Returns `{ "deleted": N }`.
+- **Async threshold**: if the number of selected videos exceeds `BULK_ASYNC_THRESHOLD`
+  (default `20`, configurable), the operation is delegated to a Celery task and
+  the response is `202 Accepted` with `{ "status": "queued" }`.
+- **Permission check**: every video must be owned or co-owned by the requester.
+  A `403 Forbidden` is raised on the first video that fails the check.
+- **Feature flag**: returns `400` if `USE_BULK_ACTIONS = False`.
+
 
 ## 6. Upload & Encoding Flow
 
@@ -248,6 +273,8 @@ Managed via `VideoConfig` (pydantic-settings in `src/apps/video/conf.py`). Setti
 | `CACHE_TIMEOUT`              | `600`         | Cache TTL in seconds for video data.                        |
 | `DEFAULT_DC_COVERAGE`        | (string)      | Dublin Core `coverage` metadata default.                    |
 | `DEFAULT_DC_RIGHTS`          | (string)      | Dublin Core `rights` metadata default.                      |
+| `USE_BULK_ACTIONS`           | `True`        | Enable bulk update/delete endpoint (`/api/videos/bulk/`).   |
+| `BULK_ASYNC_THRESHOLD`       | `20`          | Videos above this count are processed async via Celery.     |
 
 ---
 
@@ -266,6 +293,7 @@ Key test files:
 - `test_hyperlinks.py`: Specific API test suite for the `VideoHyperlink` endpoints and permission checks.
 - `test_scenarios.py`: End-to-end scenario tests (full upload → encoding → publish flow).
 - `test_signals.py`: Tests for file cleanup signals.
+- `test_bulk_actions.py`: Tests for the bulk update/delete endpoint (permissions, async, feature flag).
 
 ---
 

--- a/src/apps/video/conf.py
+++ b/src/apps/video/conf.py
@@ -66,6 +66,17 @@ class VideoConfig(BaseSettings):
         description=_("Enable video commenting system."),
         json_schema_extra={"public": True},
     )
+    use_bulk_actions: bool = Field(
+        default=defaults.USE_BULK_ACTIONS,
+        description=_("Enable bulk update/delete on videos."),
+        json_schema_extra={"public": True},
+    )
+    bulk_async_threshold: int = Field(
+        default=defaults.BULK_ASYNC_THRESHOLD,
+        description=_(
+            "Number of videos above which bulk operations are processed asynchronously via Celery."
+        ),
+    )
 
     # --- Licensing ---
     default_license: str = Field(

--- a/src/apps/video/tasks.py
+++ b/src/apps/video/tasks.py
@@ -1,0 +1,72 @@
+"""
+Esup-Pod - Video Celery tasks.
+"""
+
+import logging
+
+from celery import shared_task
+from django.contrib.auth import get_user_model
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+@shared_task
+def task_bulk_update_videos(video_ids: list, fields: dict, user_id: int) -> None:
+    """
+    Celery task for bulk updating videos asynchronously.
+    Applied when more than BULK_ASYNC_THRESHOLD videos are selected.
+    """
+    from django.db import transaction
+    from src.apps.video.models import Video
+
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        logger.error("Bulk update: user %s not found.", user_id)
+        return
+
+    videos = Video.objects.filter(id__in=video_ids)
+
+    try:
+        with transaction.atomic():
+            for video in videos:
+                for attr, value in fields.items():
+                    setattr(video, attr, value)
+                video.save()
+        logger.info(
+            "Bulk update completed: %s videos updated by user %s.",
+            videos.count(),
+            user.username,
+        )
+    except Exception as e:
+        logger.exception("Bulk update failed for user %s: %s", user_id, e)
+
+
+@shared_task
+def task_bulk_delete_videos(video_ids: list, user_id: int) -> None:
+    """
+    Celery task for bulk deleting videos asynchronously.
+    Applied when more than BULK_ASYNC_THRESHOLD videos are selected.
+    """
+    from django.db import transaction
+    from src.apps.video.models import Video
+
+    try:
+        user = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        logger.error("Bulk delete: user %s not found.", user_id)
+        return
+
+    videos = Video.objects.filter(id__in=video_ids)
+
+    try:
+        with transaction.atomic():
+            deleted_count, _ = videos.delete()
+        logger.info(
+            "Bulk delete completed: %s videos deleted by user %s.",
+            deleted_count,
+            user.username,
+        )
+    except Exception as e:
+        logger.exception("Bulk delete failed for user %s: %s", user_id, e)

--- a/src/apps/video/tests/test_bulk_actions.py
+++ b/src/apps/video/tests/test_bulk_actions.py
@@ -1,0 +1,176 @@
+"""
+Esup-Pod - Bulk actions tests.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+
+from src.apps.video.apps import sync_metadata
+from src.apps.video.models import Video
+
+User = get_user_model()
+
+
+class BulkActionsTests(APITestCase):
+    """Tests for the bulk_actions endpoint."""
+
+    def setUp(self):
+        """Sets up users, site, and videos for bulk action testing."""
+        sync_metadata(sender=None)
+        self.client = APIClient()
+        self.site = Site.objects.get_current()
+
+        self.owner = User.objects.create_user(username="owner", password="password")
+        self.other_user = User.objects.create_user(username="other", password="password")
+
+        self.video1 = Video.objects.create(
+            title="Video 1",
+            owner=self.owner,
+            status=Video.Status.DRAFT,
+        )
+        self.video1.sites.add(self.site)
+
+        self.video2 = Video.objects.create(
+            title="Video 2",
+            owner=self.owner,
+            status=Video.Status.DRAFT,
+        )
+        self.video2.sites.add(self.site)
+
+        self.other_video = Video.objects.create(
+            title="Other Video",
+            owner=self.other_user,
+            status=Video.Status.PUBLISHED,
+        )
+        self.other_video.sites.add(self.site)
+
+    def test_bulk_delete_own_videos(self):
+        """Owner can bulk delete their own videos."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.delete(
+            "/api/videos/bulk/",
+            {"video_ids": [self.video1.id, self.video2.id]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(Video.objects.filter(id=self.video1.id).exists())
+        self.assertFalse(Video.objects.filter(id=self.video2.id).exists())
+
+    def test_bulk_delete_other_user_videos_forbidden(self):
+        """User cannot bulk delete videos they don't own."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.delete(
+            "/api/videos/bulk/",
+            {"video_ids": [self.other_video.id]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(Video.objects.filter(id=self.other_video.id).exists())
+
+    def test_bulk_patch_own_videos(self):
+        """Owner can bulk patch their own videos."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            "/api/videos/bulk/",
+            {
+                "video_ids": [self.video1.id, self.video2.id],
+                "fields": {"allow_downloading": True},
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["updated"], 2)
+        self.assertTrue(Video.objects.get(id=self.video1.id).allow_downloading)
+        self.assertTrue(Video.objects.get(id=self.video2.id).allow_downloading)
+
+    def test_bulk_patch_excluded_field_rejected(self):
+        """Bulk patch with excluded fields is rejected."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            "/api/videos/bulk/",
+            {"video_ids": [self.video1.id], "fields": {"title": "New Title"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_bulk_no_videos_selected(self):
+        """Empty video_ids returns 400."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.delete(
+            "/api/videos/bulk/",
+            {"video_ids": []},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_bulk_video_not_found(self):
+        """Non-existent video IDs return 404."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.delete(
+            "/api/videos/bulk/",
+            {"video_ids": [99999]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_bulk_unauthenticated(self):
+        """Unauthenticated users cannot use bulk actions."""
+        response = self.client.delete(
+            "/api/videos/bulk/",
+            {"video_ids": [self.video1.id]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_bulk_patch_no_fields(self):
+        """Bulk patch without fields returns 400."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            "/api/videos/bulk/",
+            {"video_ids": [self.video1.id], "fields": {}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("src.apps.video.views.VideoViewSet.video_settings.bulk_async_threshold", 0)
+    @patch("src.apps.video.views.VideoViewSet.task_bulk_delete_videos")
+    def test_bulk_delete_async_above_threshold(self, mock_task):
+        """Bulk delete above threshold triggers Celery task and returns 202."""
+        mock_task.delay = mock_task  # make .delay() callable
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.delete(
+            "/api/videos/bulk/",
+            {"video_ids": [self.video1.id]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(response.data["status"], "queued")
+
+    @patch("src.apps.video.views.VideoViewSet.video_settings.bulk_async_threshold", 0)
+    @patch("src.apps.video.views.VideoViewSet.task_bulk_update_videos")
+    def test_bulk_patch_async_above_threshold(self, mock_task):
+        """Bulk patch above threshold triggers Celery task and returns 202."""
+        mock_task.delay = mock_task
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.patch(
+            "/api/videos/bulk/",
+            {"video_ids": [self.video1.id], "fields": {"allow_downloading": True}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(response.data["status"], "queued")
+
+    @patch("src.apps.video.views.VideoViewSet.video_settings.use_bulk_actions", False)
+    def test_bulk_feature_disabled_returns_400(self):
+        """Returns 400 when USE_BULK_ACTIONS is disabled."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.delete(
+            "/api/videos/bulk/",
+            {"video_ids": [self.video1.id]},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/src/apps/video/tests/test_bulk_actions.py
+++ b/src/apps/video/tests/test_bulk_actions.py
@@ -24,8 +24,12 @@ class BulkActionsTests(APITestCase):
         self.client = APIClient()
         self.site = Site.objects.get_current()
 
-        self.owner = User.objects.create_user(username="owner", password="password")
-        self.other_user = User.objects.create_user(username="other", password="password")
+        self.owner = User.objects.create_user(
+            username="owner", password="password"
+        )  # nosec
+        self.other_user = User.objects.create_user(
+            username="other", password="password"
+        )  # nosec
 
         self.video1 = Video.objects.create(
             title="Video 1",

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -117,7 +117,9 @@ class VideoViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         """Creates a new video, checking user quota and triggering encoding."""
-        user_videos = Video.objects.filter(owner=self.request.user).exclude(video_file="")
+        user_videos = Video.objects.filter(owner=self.request.user).exclude(
+            video_file=""
+        )
         total_bytes = sum(v.video_file.size for v in user_videos if v.video_file)
         incoming_file = self.request.FILES.get("video_file")
         incoming_size = incoming_file.size if incoming_file else 0
@@ -136,7 +138,9 @@ class VideoViewSet(viewsets.ModelViewSet):
             from src.apps.video.models import License
 
             try:
-                target_license = License.objects.get(slug=video_settings.default_license)
+                target_license = License.objects.get(
+                    slug=video_settings.default_license
+                )
             except License.DoesNotExist:
                 target_license = None
 
@@ -473,7 +477,9 @@ class VideoViewSet(viewsets.ModelViewSet):
                 "properties": {"owner_id": {"type": "integer"}},
             }
         },
-        responses={200: {"type": "object", "properties": {"status": {"type": "string"}}}},
+        responses={
+            200: {"type": "object", "properties": {"status": {"type": "string"}}}
+        },
     )
     @action(detail=True, methods=["post"], permission_classes=[IsSuperUser])
     def transfer_ownership(self, request, slug=None):
@@ -553,12 +559,6 @@ class VideoViewSet(viewsets.ModelViewSet):
 
     @extend_schema(
         summary="Bulk update or delete videos",
-        description=(
-            "Applies a PATCH or DELETE operation to multiple videos at once. "
-            "Requires ownership or co-ownership of every selected video. "
-            "If more than BULK_ASYNC_THRESHOLD videos are selected (configurable, default 20), "
-            "the operation is processed asynchronously and returns 202 Accepted."
-        ),
         request={
             "application/json": {
                 "type": "object",
@@ -593,9 +593,11 @@ class VideoViewSet(viewsets.ModelViewSet):
     )
     def bulk_actions(self, request):
         """
-        Applies a PATCH or DELETE to multiple videos.
+        Applies a PATCH or DELETE operation to multiple videos at once.
+        Requires ownership or co-ownership of every selected video.
         Checks ownership on every video before processing.
-        Delegates to Celery if more than bulk_async_threshold videos are selected.
+        If more than BULK_ASYNC_THRESHOLD videos are selected (configurable, default 20),
+        the operation is processed asynchronously and returns 202 Accepted.
         Returns 400 if the feature is disabled via USE_BULK_ACTIONS setting.
         """
         if not video_settings.use_bulk_actions:

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -7,14 +7,15 @@ import logging
 import hashlib
 
 from rest_framework.response import Response
-from rest_framework import viewsets, permissions, parsers, filters
+from rest_framework import viewsets, permissions, parsers, filters, status
+from django.db import transaction
 from django.db.models import Q, F
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.utils.translation import gettext_lazy as _
 from django.http import FileResponse, Http404
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError, NotFound
 from django.contrib.auth.hashers import check_password
 from drf_spectacular.utils import (
     extend_schema,
@@ -26,6 +27,7 @@ from drf_spectacular.utils import (
 from src.apps.video.models import Video
 from src.apps.video.serializers import VideoSerializer
 from src.apps.video.permissions import IsOwnerOrCoOwnerOrChannelCollaborator
+from src.apps.video.tasks import task_bulk_update_videos, task_bulk_delete_videos
 from src.apps.authentication.permissions import IsSuperUser
 from django_filters.rest_framework import DjangoFilterBackend
 from src.apps.video.conf import video_settings
@@ -45,6 +47,17 @@ class VideoViewSet(viewsets.ModelViewSet):
     """
     API view set for the Video model.
     """
+
+    BULK_EXCLUDED_FIELDS = {
+        "title",
+        "video_file",
+        "slug",
+        "owner",
+        "created_at",
+        "updated_at",
+        "duration",
+        "encoding_status",
+    }
 
     queryset = Video.objects.all()
     serializer_class = VideoSerializer
@@ -487,3 +500,132 @@ class VideoViewSet(viewsets.ModelViewSet):
         video.save(update_fields=["owner"])
 
         return Response({"status": "ownership transferred"})
+
+    def _bulk_delete(self, request, video_ids, videos):
+        """Handles bulk deletion of videos, async if above threshold."""
+        threshold = video_settings.bulk_async_threshold
+        if len(video_ids) > threshold:
+            task_bulk_delete_videos.delay(video_ids, request.user.id)
+            return Response(
+                {"status": "queued", "detail": _("Bulk delete is being processed.")},
+                status=status.HTTP_202_ACCEPTED,
+            )
+        with transaction.atomic():
+            deleted_count, _deleted_types = videos.delete()
+        return Response({"deleted": deleted_count}, status=status.HTTP_200_OK)
+
+    def _bulk_patch(self, request, video_ids, videos):
+        """Handles bulk patch of videos, async if above threshold."""
+        fields = request.data.get("fields", {})
+        if not fields:
+            raise ValidationError({"detail": _("No fields provided for update.")})
+
+        invalid_fields = set(fields.keys()) & self.BULK_EXCLUDED_FIELDS
+        if invalid_fields:
+            raise ValidationError(
+                {
+                    "detail": _("Fields not allowed in bulk update: %(fields)s.")
+                    % {"fields": ", ".join(invalid_fields)}
+                }
+            )
+
+        threshold = video_settings.bulk_async_threshold
+        if len(video_ids) > threshold:
+            task_bulk_update_videos.delay(video_ids, fields, request.user.id)
+            return Response(
+                {"status": "queued", "detail": _("Bulk update is being processed.")},
+                status=status.HTTP_202_ACCEPTED,
+            )
+
+        allowed_fields = set(fields.keys()) - self.BULK_EXCLUDED_FIELDS
+        update_data = {k: v for k, v in fields.items() if k in allowed_fields}
+
+        # Capture count before save to return accurate number (queryset count is stable)
+        updated_count = videos.count()
+        with transaction.atomic():
+            for video in videos:
+                for attr, value in update_data.items():
+                    if hasattr(video, attr):
+                        setattr(video, attr, value)
+                video.save(update_fields=list(update_data.keys()))
+
+        return Response({"updated": updated_count}, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="Bulk update or delete videos",
+        description=(
+            "Applies a PATCH or DELETE operation to multiple videos at once. "
+            "Requires ownership or co-ownership of every selected video. "
+            "If more than BULK_ASYNC_THRESHOLD videos are selected (configurable, default 20), "
+            "the operation is processed asynchronously and returns 202 Accepted."
+        ),
+        request={
+            "application/json": {
+                "type": "object",
+                "properties": {
+                    "video_ids": {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "description": "List of video IDs to process.",
+                    },
+                    "fields": {
+                        "type": "object",
+                        "description": "Fields to update (PATCH only).",
+                    },
+                },
+                "required": ["video_ids"],
+            }
+        },
+        responses={
+            200: {"type": "object", "properties": {"updated": {"type": "integer"}}},
+            202: {"type": "object", "properties": {"status": {"type": "string"}}},
+            400: {"type": "object", "properties": {"detail": {"type": "string"}}},
+            403: {"type": "object", "properties": {"detail": {"type": "string"}}},
+            404: {"type": "object", "properties": {"detail": {"type": "string"}}},
+        },
+    )
+    @action(
+        detail=False,
+        methods=["patch", "delete"],
+        url_path="bulk",
+        permission_classes=[permissions.IsAuthenticated],
+        parser_classes=[parsers.JSONParser],
+    )
+    def bulk_actions(self, request):
+        """
+        Applies a PATCH or DELETE to multiple videos.
+        Checks ownership on every video before processing.
+        Delegates to Celery if more than bulk_async_threshold videos are selected.
+        Returns 400 if the feature is disabled via USE_BULK_ACTIONS setting.
+        """
+        if not video_settings.use_bulk_actions:
+            return Response(
+                {"detail": _("Bulk actions feature is disabled.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        video_ids = request.data.get("video_ids", [])
+
+        if not video_ids:
+            raise ValidationError({"detail": _("No videos selected.")})
+
+        videos = self.get_queryset().filter(id__in=video_ids)
+
+        if videos.count() != len(video_ids):
+            raise NotFound(_("One or more videos not found."))
+
+        for video in videos:
+            if (
+                not request.user.is_superuser
+                and video.owner != request.user
+                and not video.co_owners.filter(pk=request.user.pk).exists()
+            ):
+                raise PermissionDenied(
+                    _("You do not have permission to modify video: %(title)s.")
+                    % {"title": video.title}
+                )
+
+        if request.method == "DELETE":
+            return self._bulk_delete(request, video_ids, videos)
+
+        return self._bulk_patch(request, video_ids, videos)

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -126,9 +126,7 @@ class VideoViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         """Creates a new video, checking user quota and triggering encoding."""
-        user_videos = Video.objects.filter(owner=self.request.user).exclude(
-            video_file=""
-        )
+        user_videos = Video.objects.filter(owner=self.request.user).exclude(video_file="")
         total_bytes = sum(v.video_file.size for v in user_videos if v.video_file)
         incoming_file = self.request.FILES.get("video_file")
         incoming_size = incoming_file.size if incoming_file else 0
@@ -147,9 +145,7 @@ class VideoViewSet(viewsets.ModelViewSet):
             from src.apps.video.models import License
 
             try:
-                target_license = License.objects.get(
-                    slug=video_settings.default_license
-                )
+                target_license = License.objects.get(slug=video_settings.default_license)
             except License.DoesNotExist:
                 target_license = None
 
@@ -485,9 +481,7 @@ class VideoViewSet(viewsets.ModelViewSet):
                 "properties": {"owner_id": {"type": "integer"}},
             }
         },
-        responses={
-            200: {"type": "object", "properties": {"status": {"type": "string"}}}
-        },
+        responses={200: {"type": "object", "properties": {"status": {"type": "string"}}}},
     )
     @action(detail=True, methods=["post"], permission_classes=[IsSuperUser])
     def transfer_ownership(self, request, slug=None):

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -6,7 +6,6 @@ import os
 import hashlib
 import logging
 
-from django.db import transaction
 from django.db.models import Q, F
 from django.http import FileResponse, Http404
 from django.utils.translation import gettext_lazy as _

--- a/src/config/defaults/video.py
+++ b/src/config/defaults/video.py
@@ -15,6 +15,9 @@ USE_CUT = False
 ALLOW_AUTHENTICATED_UPLOAD = True
 CHANNEL_MODE = False
 ACTIVE_VIDEO_COMMENT = True
+USE_BULK_ACTIONS = True  # Enable bulk update/delete on videos
+BULK_ASYNC_THRESHOLD = 20  # Above this count, processing is delegated to Celery
+
 
 # UI / Display Flags
 HIDE_USER_FILTER = False


### PR DESCRIPTION
# FEAT(video): implement video bulk actions

This PR introduces an endpoint enabling mass modification or deletion of multiple videos in a single API request, directly from the dashboard.

Key Features and Technical Improvements:

Single endpoint: PATCH /api/videos/bulk/ for bulk updates, DELETE /api/videos/bulk/ for bulk deletion.
Strict security: ownership (owner/co-owner) is verified on every video before any processing — a single unauthorized video blocks the entire operation.
Protected fields: sensitive fields (title, slug, owner, video_file, encoding_status, timestamps) are explicitly excluded from bulk updates.
Asynchronous processing: above the configurable BULK_ASYNC_THRESHOLD (default: 20 videos), the operation is delegated to a Celery task and returns 202 Accepted.
Clean configuration: two new pydantic-settings parameters (USE_BULK_ACTIONS, BULK_ASYNC_THRESHOLD) to enable/disable the feature and tune the async threshold per instance.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
