### PR TITLE
FIX(video): resolve me endpoint filtering, encoding webhook URL, and password removal

### DIFF
--- a/src/apps/video/serializers/VideoSerializer.py
+++ b/src/apps/video/serializers/VideoSerializer.py
@@ -66,7 +66,7 @@ class VideoSerializer(serializers.ModelSerializer):
     encoding_status_label = serializers.CharField(
         source="get_encoding_status_display", read_only=True
     )
-    has_password = serializers.BooleanField(source="password", read_only=True)
+    has_password = serializers.SerializerMethodField()
     password = serializers.CharField(
         write_only=True, required=False, allow_blank=True, allow_null=True
     )
@@ -178,6 +178,11 @@ class VideoSerializer(serializers.ModelSerializer):
             "subtitles",
             "encodings",
         ]
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_has_password(self, obj):
+        """Returns True if the video has a password, False otherwise."""
+        return bool(obj.password)
 
     @extend_schema_field(serializers.ListField(child=serializers.CharField()))
     def get_encodings(self, obj):
@@ -291,6 +296,10 @@ class VideoSerializer(serializers.ModelSerializer):
         """
         Creates a Video instance and assigns the themes list.
         """
+        has_pw_flag = self.initial_data.get("has_password")
+        if str(has_pw_flag).lower() == "false":
+            validated_data["password"] = ""
+
         themes_data = validated_data.pop("themes", None)
         video = super().create(validated_data)
         if themes_data is not None:
@@ -302,6 +311,10 @@ class VideoSerializer(serializers.ModelSerializer):
         """
         Updates a Video instance and updates its themes list.
         """
+        has_pw_flag = self.initial_data.get("has_password")
+        if str(has_pw_flag).lower() == "false":
+            validated_data["password"] = ""
+
         themes_data = validated_data.pop("themes", None)
         video = super().update(instance, validated_data)
         if themes_data is not None:

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -149,8 +149,7 @@ class VideoViewSet(viewsets.ModelViewSet):
         if video.video_file:
             from src.apps.encoding.tasks import trigger_runner_encoding_task
 
-            site_url = video_settings.site_url.rstrip("/")
-            source_url = f"{site_url}{video.video_file.url}"
+            source_url = self.request.build_absolute_uri(video.video_file.url)
 
             logger.debug("source_url: %s", source_url)
 
@@ -410,7 +409,7 @@ class VideoViewSet(viewsets.ModelViewSet):
         Returns only videos owned or co-owned by the current user.
         """
         user = request.user
-        queryset = (
+        queryset = self.filter_queryset(
             self.get_queryset().filter(Q(owner=user) | Q(co_owners=user)).distinct()
         )
 


### PR DESCRIPTION
# FIX(video): resolve me endpoint filtering, encoding webhook URL, and password removal

This PR fixes several anomalous behaviors reported on the API when used in a pre-production environment:

**Fixes included:**
- **`/me/` Endpoint Filters**: Added `self.filter_queryset()` so that the `GET /api/videos/me/` endpoint correctly processes query parameters sent by the user (e.g., `?status=PU`).
- **Robust Encoding Webhook**: The URL sent to the *Runner* (Celery) to download the video is now built dynamically using `request.build_absolute_uri()` rather than relying on static configuration. This prevents encoding failures if `POD_VIDEO_SITE_URL` is misconfigured on new servers (which previously fell back to localhost).
- **Password Removal**: The `has_password` boolean field was converted to a `SerializerMethodField` and is now actively intercepted during `PATCH` requests. Explicitly sending `has_password: false` now correctly clears the video's password from the database.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.