### PR TITLE
FEAT(completion): add completion data to VideoSerializer and related tests

### DIFF
--- a/docs/completion/details.md
+++ b/docs/completion/details.md
@@ -86,6 +86,16 @@ Managed via `CompletionConfig` (pydantic-settings in `src/apps/completion/conf.p
 
 ---
 
+## 5. Integration with Video API
+
+Contributions, overlays, and documents are **automatically embedded** in the `VideoSerializer` response (read-only nested fields). This means:
+
+- A single `GET /api/videos/{slug}/` request returns all completion data for the player.
+- The `VideoViewSet.get_queryset()` uses `prefetch_related("contributions__contributor", "overlays", "documents")` to prevent N+1 query issues on list endpoints.
+- **Writing** completion data (creating/editing contributions, documents, overlays) is done via the dedicated `/api/completion/` endpoints — not through `PATCH /api/videos/`.
+
+---
+
 ## 6. Testing
 
 Run tests for the completion application:

--- a/docs/video/README.md
+++ b/docs/video/README.md
@@ -11,7 +11,9 @@ The **Video** application is the core module of Pod V5. It manages the full life
 | **Co-ownership**       | Multiple users can share edit rights on the same video.                            |
 | **Subtitles**          | Attach subtitle files (VTT/SRT) per language (FR, EN, ES).                         |
 | **Streaming**          | Direct file streaming via a dedicated API endpoint.                                |
+| **Marker Time**        | Automatically saves and retrieves the user's video playback position.              |
 | **Hyperlinks**         | Add interactive links (timecodes, external resources) to videos.                   |
+| **Completion Data**    | Contributions, overlays, and documents are embedded in the video response.         |
 | **Categorization**     | Organize videos with Types, Disciplines, and Tags.                                 |
 | **Comments & Votes**   | Engage users with a commenting and upvote/downvote system.                         |
 | **Multi-tenancy**      | Videos are linked to specific Sites (portals) for data isolation.                  |
@@ -76,6 +78,11 @@ A video passes through the following states:
 | **GET**      | `/api/subtitles/`                     | List subtitles (filterable by `?video_id=`).      |
 | **POST**     | `/api/subtitles/`                     | Attach a subtitle to a video.                     |
 | **DELETE**   | `/api/subtitles/{id}/`                | Delete a subtitle (video owner only).             |
+| **GET**      | `/api/marker/{video_slug}/`           | Retrieve the playback position for the user.      |
+| **POST**     | `/api/marker/{video_slug}/save/`      | Save the playback position for the user.          |
+| **DELETE**   | `/api/marker/{video_slug}/reset/`     | Delete the playback position marker.              |
+
+> **Note:** Completion data (contributions, overlays, documents) is automatically embedded in the `GET /api/videos/{slug}/` and `GET /api/videos/` responses. To create or modify these elements, use the dedicated [`/api/completion/`](../completion/README.md) endpoints.
 
 ## Further Reading
 

--- a/src/apps/video/serializers/VideoSerializer.py
+++ b/src/apps/video/serializers/VideoSerializer.py
@@ -13,6 +13,11 @@ from src.apps.encoding.conf import encoding_settings
 from src.apps.video.conf import video_settings
 from src.apps.authentication.models import AccessGroup
 from src.apps.collection.models import Theme, ThemeItem
+from src.apps.completion.serializers import (
+    ContributionSerializer,
+    OverlaySerializer,
+    DocumentSerializer,
+)
 from .DisciplineSerializer import DisciplineSerializer
 from .HyperlinkSerializer import VideoHyperlinkSerializer
 
@@ -110,6 +115,9 @@ class VideoSerializer(serializers.ModelSerializer):
     )
 
     hyperlinks = VideoHyperlinkSerializer(many=True, read_only=True)
+    contributions = ContributionSerializer(many=True, read_only=True)
+    overlays = OverlaySerializer(many=True, read_only=True)
+    documents = DocumentSerializer(many=True, read_only=True)
 
     class Meta:
         """Video serializer metadata."""
@@ -159,6 +167,9 @@ class VideoSerializer(serializers.ModelSerializer):
             "discipline_details",
             "tags",
             "hyperlinks",
+            "contributions",
+            "overlays",
+            "documents",
         ]
         extra_kwargs = {
             "video_file": {"write_only": True},

--- a/src/apps/video/tests/test_completion_link.py
+++ b/src/apps/video/tests/test_completion_link.py
@@ -20,7 +20,9 @@ class VideoCompletionLinkTests(APITestCase):
         """Sets up a video with linked contribution, overlay, and document."""
         sync_metadata(sender=None)
         self.site = Site.objects.get_current()
-        self.user = User.objects.create_user(username="owner", password="password")
+        self.user = User.objects.create_user(
+            username="owner", password="password"
+        )  # nosec
         self.video = Video.objects.create(
             title="Completion Test Video",
             owner=self.user,

--- a/src/apps/video/tests/test_completion_link.py
+++ b/src/apps/video/tests/test_completion_link.py
@@ -1,0 +1,123 @@
+"""
+Esup-Pod - Video completion link tests.
+"""
+
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from rest_framework.test import APITestCase
+
+from src.apps.completion.models import Contribution, Contributor, Document, Overlay
+from src.apps.video.apps import sync_metadata
+from src.apps.video.models import Video
+
+User = get_user_model()
+
+
+class VideoCompletionLinkTests(APITestCase):
+    """Tests for completion data exposed via VideoSerializer."""
+
+    def setUp(self):
+        """Sets up a video with linked contribution, overlay, and document."""
+        sync_metadata(sender=None)
+        self.site = Site.objects.get_current()
+        self.user = User.objects.create_user(username="owner", password="password")
+        self.video = Video.objects.create(
+            title="Completion Test Video",
+            owner=self.user,
+            status=Video.Status.PUBLISHED,
+        )
+        self.video.sites.add(self.site)
+
+        self.contributor = Contributor.objects.create(
+            first_name="John",
+            last_name="Doe",
+        )
+        Contribution.objects.create(
+            video=self.video,
+            contributor=self.contributor,
+            role="author",
+        )
+        Overlay.objects.create(
+            video=self.video,
+            title="Test Overlay",
+            time_start=5,
+            time_end=10,
+            content="<p>Hello</p>",
+        )
+        Document.objects.create(
+            video=self.video,
+            title="Test Document",
+            file="documents/test.pdf",
+        )
+
+    def test_video_detail_includes_completion_data(self):
+        """Verifies that GET /api/videos/{slug}/ includes contributions, overlays, documents."""
+        url = f"/api/videos/{self.video.slug}/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["contributions"]), 1)
+        self.assertEqual(
+            response.data["contributions"][0]["contributor_details"]["first_name"],
+            "John",
+        )
+        self.assertEqual(len(response.data["overlays"]), 1)
+        self.assertEqual(response.data["overlays"][0]["title"], "Test Overlay")
+        self.assertEqual(len(response.data["documents"]), 1)
+        self.assertEqual(response.data["documents"][0]["title"], "Test Document")
+
+    def test_completion_data_isolated_per_video(self):
+        """Verifies that completion data from another video does not appear in the response."""
+        other_video = Video.objects.create(
+            title="Other Video",
+            owner=self.user,
+            status=Video.Status.PUBLISHED,
+        )
+        other_video.sites.add(self.site)
+        other_contributor = Contributor.objects.create(
+            first_name="Jane",
+            last_name="Smith",
+        )
+        Contribution.objects.create(
+            video=other_video,
+            contributor=other_contributor,
+            role="author",
+        )
+
+        response = self.client.get(f"/api/videos/{self.video.slug}/")
+
+        self.assertEqual(response.status_code, 200)
+        # Still only 1 contribution linked to self.video
+        self.assertEqual(len(response.data["contributions"]), 1)
+        self.assertEqual(
+            response.data["contributions"][0]["contributor_details"]["first_name"],
+            "John",
+        )
+
+    def test_completion_data_empty_for_video_without_completion(self):
+        """Verifies that contributions, overlays, and documents are empty lists when absent."""
+        empty_video = Video.objects.create(
+            title="Empty Video",
+            owner=self.user,
+            status=Video.Status.PUBLISHED,
+        )
+        empty_video.sites.add(self.site)
+
+        response = self.client.get(f"/api/videos/{empty_video.slug}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["contributions"], [])
+        self.assertEqual(response.data["overlays"], [])
+        self.assertEqual(response.data["documents"], [])
+
+    def test_completion_data_present_in_video_list(self):
+        """Verifies that GET /api/videos/ also includes completion data (prefetch check)."""
+        response = self.client.get("/api/videos/")
+
+        self.assertEqual(response.status_code, 200)
+        results = response.data.get("results", response.data)
+        video_data = next((v for v in results if v["slug"] == self.video.slug), None)
+        self.assertIsNotNone(video_data)
+        self.assertIn("contributions", video_data)
+        self.assertIn("overlays", video_data)
+        self.assertIn("documents", video_data)

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -100,7 +100,16 @@ class VideoViewSet(viewsets.ModelViewSet):
         if getattr(self, "action", None) in ["stream", "unlock", "register_view"]:
             return qs
 
-        return Video.objects.visible_for(user).filter(id__in=qs).distinct()
+        return (
+            Video.objects.visible_for(user)
+            .filter(id__in=qs)
+            .prefetch_related(
+                "contributions__contributor",
+                "overlays",
+                "documents",
+            )
+            .distinct()
+        )
 
     def perform_create(self, serializer):
         """Creates a new video, checking user quota and triggering encoding."""


### PR DESCRIPTION
# [FEAT(completion): add completion data to VideoSerializer and related tests]

This PR bridges the existing `completion` application with the `VideoSerializer`, enabling the frontend to retrieve all video enrichment data in a single request.

**Features and Technical Improvements:**
- **Completion data embedding**: Contributions (speakers + roles), time-based overlays, and attached documents are now automatically included in `GET /api/videos/{slug}/` and `GET /api/videos/` responses.
- **N+1 optimization**: Added `prefetch_related("contributions__contributor", "overlays", "documents")` to `VideoViewSet` to prevent SQL query explosion on video list endpoints.
- **Read / Write separation**: Completion data is exposed as **read-only** in the video serializer. Creating and editing completion objects continues through the dedicated `/api/completion/` endpoints.
- **Tests**: 4 tests covering integration, cross-video data isolation, empty state handling, and presence on the list endpoint.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
