### PR TITLE
Add source language to runner transcription payload

### DIFF
--- a/pod/video_encode_transcript/runner_manager.py
+++ b/pod/video_encode_transcript/runner_manager.py
@@ -243,6 +243,14 @@ def _attach_video_metadata(parameters: ParametersDict, video: Video) -> None:
         parameters["video_title"] = str(video_title)
 
 
+def _resolve_source_language(video: Video) -> str:
+    """Return the video's source language or auto-detection fallback."""
+    source_language = getattr(video, "main_lang", None)
+    if isinstance(source_language, str) and source_language:
+        return source_language.strip() or "auto"
+    return "auto"
+
+
 def _prepare_encoding_parameters(
     video: Optional[Video] = None,
     base_url: Optional[str] = None,
@@ -751,6 +759,7 @@ def _prepare_transcription_parameters(video: Video) -> ParametersDict:
     Returns:
         Parameter dictionary for the Runner Manager.
     """
+    source_language = _resolve_source_language(video)
     try:
         from .transcript import resolve_transcription_language
 
@@ -762,7 +771,10 @@ def _prepare_transcription_parameters(video: Video) -> ParametersDict:
         normalize = bool(getattr(settings, "TRANSCRIPTION_NORMALIZE", False))
 
         params: ParametersDict = {
+            # Final subtitle/VTT language requested by the user
             "language": lang,
+            # Main audio/source language, supported by Esup-Runner since version 1.5
+            "source_language": source_language,
             # Duration may help runner to tune/optimize
             "duration": float(getattr(video, "duration", 0) or 0),
             # Text normalization (punctuation/casing) on runner side if supported
@@ -778,7 +790,10 @@ def _prepare_transcription_parameters(video: Video) -> ParametersDict:
         return params
     except Exception:
         # Keep legacy key name for backward compatibility with older runners.
-        params: ParametersDict = {"lang": getattr(video, "transcript", "") or ""}
+        params: ParametersDict = {
+            "lang": getattr(video, "transcript", "") or "",
+            "source_language": source_language,
+        }
         _attach_video_metadata(params, video)
         return params
 

--- a/pod/video_encode_transcript/tests/test_runner_manager_helpers.py
+++ b/pod/video_encode_transcript/tests/test_runner_manager_helpers.py
@@ -29,6 +29,7 @@ from pod.video_encode_transcript.runner_manager import (
     _prepare_transcription_parameters,
     _prestore_encoding_if_needed,
     _rotate_same_priority_runner_managers,
+    _resolve_source_language,
     _send_task_to_runner_manager,
     _submit_to_runner_manager,
     _try_send_to_rm,
@@ -366,6 +367,7 @@ class RunnerManagerHelperTests(SimpleTestCase):
             slug="transcript-video",
             title="Transcript video",
             transcript="fr",
+            main_lang="en",
             duration=12.5,
             video="videos/transcript.mp4",
         )
@@ -385,6 +387,7 @@ class RunnerManagerHelperTests(SimpleTestCase):
         self.assertTrue(result)
         payload = mock_submit_to_runner_managers.call_args.kwargs["data"]
         self.assertEqual(payload["parameters"]["language"], "fr")
+        self.assertEqual(payload["parameters"]["source_language"], "en")
         self.assertEqual(payload["parameters"]["duration"], 12.5)
         self.assertTrue(payload["parameters"]["normalize"])
         self.assertEqual(payload["parameters"]["model_type"], "whisper")
@@ -555,6 +558,7 @@ class RunnerManagerHelperTests(SimpleTestCase):
         """Build transcription params with resolved language or legacy fallback."""
         video = SimpleNamespace(
             transcript="fr",
+            main_lang="de",
             duration=12.5,
             id=3,
             slug="video-slug",
@@ -575,6 +579,7 @@ class RunnerManagerHelperTests(SimpleTestCase):
             params,
             {
                 "language": "en",
+                "source_language": "de",
                 "duration": 12.5,
                 "normalize": True,
                 "video_id": 3,
@@ -594,11 +599,18 @@ class RunnerManagerHelperTests(SimpleTestCase):
             legacy_params,
             {
                 "lang": "fr",
+                "source_language": "de",
                 "video_id": 3,
                 "video_slug": "video-slug",
                 "video_title": "Video title",
             },
         )
+
+    def test_resolve_source_language_uses_auto_when_missing(self) -> None:
+        """Fallback to runner auto-detection when no source language is defined."""
+        self.assertEqual(_resolve_source_language(SimpleNamespace(main_lang="fr")), "fr")
+        self.assertEqual(_resolve_source_language(SimpleNamespace(main_lang="")), "auto")
+        self.assertEqual(_resolve_source_language(SimpleNamespace()), "auto")
 
     def test_execute_url_normalizes_trailing_slash(self) -> None:
         """Always target the task execute endpoint."""

--- a/pod/video_encode_transcript/tests/test_transcription_language.py
+++ b/pod/video_encode_transcript/tests/test_transcription_language.py
@@ -119,6 +119,7 @@ class TranscriptionLanguageResolutionTests(TestCase):
         params = _prepare_transcription_parameters(self.video)
 
         self.assertEqual(params["language"], "es")
+        self.assertEqual(params["source_language"], "fr")
         self.assertEqual(params["duration"], 12.5)
         self.assertTrue(params["normalize"])
         self.assertEqual(params["model_type"], "whisper")
@@ -133,13 +134,14 @@ class TranscriptionLanguageResolutionTests(TestCase):
     def test_prepare_transcription_parameters_falls_back_to_legacy_lang_key(
         self, mock_resolve_transcription_language
     ) -> None:
-        """Keep the legacy payload shape when language resolution fails."""
+        """Keep the legacy language key when final-language resolution fails."""
         self.video.transcript = "en"
         self.video.save(update_fields=["transcript"])
 
         params = _prepare_transcription_parameters(self.video)
 
         self.assertEqual(params["lang"], "en")
+        self.assertEqual(params["source_language"], "fr")
         self.assertEqual(params["video_id"], self.video.id)
         self.assertEqual(params["video_slug"], self.video.slug)
         self.assertEqual(params["video_title"], self.video.title)


### PR DESCRIPTION
## Summary

This PR adds the optional `source_language` parameter to the Runner Manager transcription payload.

`language` is preserved as the final subtitle/VTT language requested by the user, while `source_language` now carries the main audio/source language from `Video.main_lang`. When no source language is defined, the payload falls back to `"auto"`.

The new parameter is supported by **Esup-Runner since version 1.5**.