### PR TITLE
Fix tag cleanup during v3 to v4 import

### DIFF
--- a/pod/video/management/commands/import_data_from_v3_to_v4.py
+++ b/pod/video/management/commands/import_data_from_v3_to_v4.py
@@ -350,28 +350,36 @@ class Command(BaseCommand):
 
     def delete_old_tag_data(self, cursor, table: str) -> None:
         """Delete old tag data for the given table."""
-        if table == "video_tagging_tag_2_tagulous":
-            self.stdout.write(self.style.SUCCESS(" - Delete old tags for videos"))
-            cursor.execute(
-                f"DELETE FROM {self.quote_identifier('video_tagulous_video_tags')}"
-            )
-            self.reset_auto_increment(cursor, "video_video_tags", "id")
-            cursor.execute(f"DELETE FROM {self.quote_identifier('video_video_tags')}")
-            cursor.execute(
-                f"ALTER TABLE {self.quote_identifier('video_video_tags')} AUTO_INCREMENT = 1"
-            )
-        elif table == "recorder_tagging_tag_2_tagulous":
-            self.stdout.write(self.style.SUCCESS(" - Delete old tags for recorders"))
-            cursor.execute(
-                f"DELETE FROM {self.quote_identifier('recorder_tagulous_recorder_tags')}"
-            )
-            self.reset_auto_increment(cursor, "recorder_recorder_tags", "id")
-            cursor.execute(
-                f"DELETE FROM {self.quote_identifier('recorder_recorder_tags')}"
-            )
-            cursor.execute(
-                f"ALTER TABLE {self.quote_identifier('recorder_recorder_tags')} AUTO_INCREMENT = 1"
-            )
+        backend = connection.vendor
+        if backend == "mysql":
+            cursor.execute("SET FOREIGN_KEY_CHECKS=0;")
+
+        try:
+            if table == "video_tagging_tag_2_tagulous":
+                self.stdout.write(self.style.SUCCESS(" - Delete old tags for videos"))
+                cursor.execute(f"DELETE FROM {self.quote_identifier('video_video_tags')}")
+                self.reset_auto_increment(cursor, "video_video_tags", "id")
+                cursor.execute(
+                    f"DELETE FROM {self.quote_identifier('video_tagulous_video_tags')}"
+                )
+                cursor.execute(
+                    f"ALTER TABLE {self.quote_identifier('video_video_tags')} AUTO_INCREMENT = 1"
+                )
+            elif table == "recorder_tagging_tag_2_tagulous":
+                self.stdout.write(self.style.SUCCESS(" - Delete old tags for recorders"))
+                cursor.execute(
+                    f"DELETE FROM {self.quote_identifier('recorder_recorder_tags')}"
+                )
+                self.reset_auto_increment(cursor, "recorder_recorder_tags", "id")
+                cursor.execute(
+                    f"DELETE FROM {self.quote_identifier('recorder_tagulous_recorder_tags')}"
+                )
+                cursor.execute(
+                    f"ALTER TABLE {self.quote_identifier('recorder_recorder_tags')} AUTO_INCREMENT = 1"
+                )
+        finally:
+            if backend == "mysql":
+                cursor.execute("SET FOREIGN_KEY_CHECKS=1;")
 
     def reset_auto_increment(self, cursor, table: str, id_column="id") -> None:
         """Reset auto increment for a table (manage for for Postgre or Mysql/MariaDB)."""


### PR DESCRIPTION
## Summary

This fixes tag cleanup during the Pod v3 to v4 import command.

The import command could fail when rerun on a non-empty database because tag parent tables were deleted before their many-to-many relation tables. MySQL then raised a foreign key constraint error when existing rows in `video_video_tags` still referenced `video_tagulous_video_tags`.

## Changes

- Delete tag relation tables before deleting Tagulous tag tables.
- Apply the same cleanup order for video and recorder tags.
- Temporarily disable MySQL foreign key checks during tag cleanup.
- Re-enable foreign key checks in a `finally` block to avoid leaving them disabled after an error.

## Validation

- Ran Python syntax validation with:

```bash
python3 -m py_compile pod/video/management/commands/import_data_from_v3_to_v4.py