### PR TITLE
FEAT(video): migrate and modernize video statistics API

### DIFF
--- a/src/apps/video/serializers/VideoStatsSerializer.py
+++ b/src/apps/video/serializers/VideoStatsSerializer.py
@@ -1,0 +1,30 @@
+"""
+Esup-Pod - VideoStats serializer.
+"""
+
+from rest_framework import serializers
+
+from .ViewCountSerializer import ViewCountSerializer
+
+
+class VideoStatsSerializer(serializers.Serializer):
+    """
+    Read-only serializer for aggregated video statistics.
+    Used by the stats endpoint to return chart-ready data.
+    """
+
+    video_slug = serializers.CharField(read_only=True)
+    total_views = serializers.IntegerField(read_only=True)
+    views_last_7_days = serializers.IntegerField(read_only=True)
+    views_last_30_days = serializers.IntegerField(read_only=True)
+    daily_breakdown = ViewCountSerializer(many=True, read_only=True)
+    peak_day = serializers.DateField(allow_null=True, read_only=True)
+    peak_count = serializers.IntegerField(allow_null=True, read_only=True)
+
+    def create(self, validated_data):
+        """Not used — this serializer is read-only."""
+        raise NotImplementedError
+
+    def update(self, instance, validated_data):
+        """Not used — this serializer is read-only."""
+        raise NotImplementedError

--- a/src/apps/video/serializers/ViewCountSerializer.py
+++ b/src/apps/video/serializers/ViewCountSerializer.py
@@ -1,0 +1,18 @@
+"""
+Esup-Pod - ViewCount serializer.
+"""
+
+from rest_framework import serializers
+
+from src.apps.video.models import ViewCount
+
+
+class ViewCountSerializer(serializers.ModelSerializer):
+    """Serializer for daily view count data."""
+
+    class Meta:
+        """Meta options for ViewCountSerializer."""
+
+        model = ViewCount
+        fields = ["date", "count"]
+        read_only_fields = ["date", "count"]

--- a/src/apps/video/serializers/__init__.py
+++ b/src/apps/video/serializers/__init__.py
@@ -13,6 +13,8 @@ from .VideoAccessTokenSerializer import VideoAccessTokenSerializer  # noqa: F401
 from .DublinCoreSerializer import DublinCoreSerializer  # noqa: F401
 from .UserMarkerTimeSerializer import UserMarkerTimeSerializer  # noqa: F401
 from .VideoCutSerializer import VideoCutSerializer  # noqa: F401
+from .ViewCountSerializer import ViewCountSerializer  # noqa: F401
+from .VideoStatsSerializer import VideoStatsSerializer  # noqa: F401
 
 __all__ = [
     "VideoSerializer",
@@ -26,4 +28,6 @@ __all__ = [
     "DublinCoreSerializer",
     "UserMarkerTimeSerializer",
     "VideoCutSerializer",
+    "ViewCountSerializer",
+    "VideoStatsSerializer",
 ]

--- a/src/apps/video/tests/test_video_stats.py
+++ b/src/apps/video/tests/test_video_stats.py
@@ -46,8 +46,12 @@ class VideoStatsTests(APITestCase):
         reload_urlconf()
 
         self.site = Site.objects.get_current()
-        self.owner = User.objects.create_user(username="owner", password="password")  # nosec
-        self.other_user = User.objects.create_user(username="other", password="password")  # nosec
+        self.owner = User.objects.create_user(
+            username="owner", password="password"
+        )  # nosec
+        self.other_user = User.objects.create_user(
+            username="other", password="password"
+        )  # nosec
         self.video = Video.objects.create(
             title="Stats Test Video",
             owner=self.owner,
@@ -118,15 +122,15 @@ class VideoStatsTests(APITestCase):
 
         self.assertEqual(response.status_code, 403)
 
-    def test_stats_allowed_for_staff(self):
-        """Staff users can view stats even if not owner."""
+    def test_stats_forbidden_for_staff(self):
+        """Staff users cannot view stats if not owner (restricted)."""
         self.other_user.is_staff = True
         self.other_user.save()
 
         self.client.force_authenticate(user=self.other_user)
         response = self.client.get(f"/api/videos/{self.video.slug}/stats/")
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 403)
 
     def test_view_count_list_filtered_by_video(self):
         """Verifies ViewCountViewSet filters by video slug."""

--- a/src/apps/video/tests/test_video_stats.py
+++ b/src/apps/video/tests/test_video_stats.py
@@ -1,0 +1,153 @@
+"""
+Esup-Pod - Video statistics tests.
+"""
+
+import sys
+from importlib import reload
+from datetime import date, timedelta
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from django.urls import clear_url_caches
+from rest_framework.test import APITestCase
+
+from src.apps.video.apps import sync_metadata
+from src.apps.video.conf import video_settings
+from src.apps.video.models import Video, ViewCount
+
+
+def reload_urlconf():
+    """Reloads URL configurations after a settings change."""
+    clear_url_caches()
+    video_urls = "src.apps.video.urls"
+    if video_urls in sys.modules:
+        reload(sys.modules[video_urls])
+    if settings.ROOT_URLCONF in sys.modules:
+        reload(sys.modules[settings.ROOT_URLCONF])
+
+
+User = get_user_model()
+
+
+class VideoStatsTests(APITestCase):
+    """Tests for the video stats endpoint and ViewCountViewSet."""
+
+    def setUp(self):
+        """Sets up a video with view counts for stats testing."""
+        sync_metadata(sender=None)
+
+        # Save original settings to restore in tearDown
+        self.original_use_stats = video_settings.use_stats_view
+        self.original_view_auth = video_settings.view_stats_auth
+
+        video_settings.use_stats_view = True
+        video_settings.view_stats_auth = False
+        reload_urlconf()
+
+        self.site = Site.objects.get_current()
+        self.owner = User.objects.create_user(username="owner", password="password")
+        self.other_user = User.objects.create_user(username="other", password="password")
+        self.video = Video.objects.create(
+            title="Stats Test Video",
+            owner=self.owner,
+            status=Video.Status.PUBLISHED,
+            view_count=100,
+        )
+        self.video.sites.add(self.site)
+
+        ViewCount.objects.create(video=self.video, date=date.today(), count=10)
+        ViewCount.objects.create(
+            video=self.video, date=date.today() - timedelta(days=3), count=5
+        )
+        ViewCount.objects.create(
+            video=self.video, date=date.today() - timedelta(days=40), count=20
+        )
+
+    def tearDown(self):
+        """Restore original settings and reload URLs to prevent test leakage."""
+        video_settings.use_stats_view = self.original_use_stats
+        video_settings.view_stats_auth = self.original_view_auth
+        reload_urlconf()
+
+    def test_stats_returns_aggregated_data(self):
+        """Verifies stats endpoint returns correct aggregated data."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get(f"/api/videos/{self.video.slug}/stats/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["video_slug"], self.video.slug)
+        self.assertEqual(response.data["total_views"], 100)
+        self.assertEqual(response.data["views_last_7_days"], 15)
+        self.assertEqual(response.data["views_last_30_days"], 15)
+
+    def test_stats_peak_day(self):
+        """Verifies the peak day is correctly identified."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get(f"/api/videos/{self.video.slug}/stats/")
+
+        self.assertEqual(response.data["peak_count"], 20)
+
+    def test_stats_daily_breakdown_respects_days_param(self):
+        """Verifies the daily breakdown only includes entries within the days range."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get(f"/api/videos/{self.video.slug}/stats/?days=7")
+
+        dates_in_breakdown = [entry["date"] for entry in response.data["daily_breakdown"]]
+        self.assertEqual(len(dates_in_breakdown), 2)
+
+    def test_stats_disabled_returns_400(self):
+        """Returns 400 when the stats feature is disabled."""
+        video_settings.use_stats_view = False
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get(f"/api/videos/{self.video.slug}/stats/")
+        self.assertEqual(response.status_code, 400)
+        video_settings.use_stats_view = True
+
+    def test_stats_requires_auth_when_configured(self):
+        """Returns 403 for anonymous users when VIEW_STATS_AUTH is enabled."""
+        video_settings.view_stats_auth = True
+        response = self.client.get(f"/api/videos/{self.video.slug}/stats/")
+        self.assertEqual(response.status_code, 403)
+        video_settings.view_stats_auth = False
+
+    def test_stats_forbidden_for_non_owner(self):
+        """Returns 403 for a user who is not owner, co-owner, or staff."""
+        self.client.force_authenticate(user=self.other_user)
+        response = self.client.get(f"/api/videos/{self.video.slug}/stats/")
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_stats_allowed_for_staff(self):
+        """Staff users can view stats even if not owner."""
+        self.other_user.is_staff = True
+        self.other_user.save()
+
+        self.client.force_authenticate(user=self.other_user)
+        response = self.client.get(f"/api/videos/{self.video.slug}/stats/")
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_count_list_filtered_by_video(self):
+        """Verifies ViewCountViewSet filters by video slug."""
+        response = self.client.get(f"/api/view-counts/?video={self.video.slug}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 3)
+
+    def test_view_count_filtered_by_date_range(self):
+        """Verifies ViewCountViewSet filters by date range."""
+        response = self.client.get(
+            f"/api/view-counts/?video={self.video.slug}"
+            f"&date__gte={date.today() - timedelta(days=10)}"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 2)
+
+    def test_view_count_requires_auth_when_configured(self):
+        """ViewCountViewSet requires authentication if VIEW_STATS_AUTH is enabled."""
+        video_settings.view_stats_auth = True
+        response = self.client.get(f"/api/view-counts/?video={self.video.slug}")
+        self.assertEqual(response.status_code, 401)
+        video_settings.view_stats_auth = False

--- a/src/apps/video/tests/test_video_stats.py
+++ b/src/apps/video/tests/test_video_stats.py
@@ -46,8 +46,8 @@ class VideoStatsTests(APITestCase):
         reload_urlconf()
 
         self.site = Site.objects.get_current()
-        self.owner = User.objects.create_user(username="owner", password="password")
-        self.other_user = User.objects.create_user(username="other", password="password")
+        self.owner = User.objects.create_user(username="owner", password="password")  # nosec
+        self.other_user = User.objects.create_user(username="other", password="password")  # nosec
         self.video = Video.objects.create(
             title="Stats Test Video",
             owner=self.owner,

--- a/src/apps/video/urls.py
+++ b/src/apps/video/urls.py
@@ -16,6 +16,7 @@ from src.apps.video.views import (
     DublinCoreViewSet,
     UserMarkerTimeViewSet,
     VideoCutViewSet,
+    ViewCountViewSet,
 )
 from src.apps.video.conf import video_settings
 
@@ -44,6 +45,9 @@ if video_settings.use_cut:
         VideoCutViewSet,
         basename="video-cut",
     )
+
+if video_settings.use_stats_view:
+    router.register(r"view-counts", ViewCountViewSet, basename="view-count")
 
 urlpatterns = router.urls
 

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -7,7 +7,13 @@ import hashlib
 import logging
 
 
-from django.db.models import Q, F
+from datetime import date, timedelta
+from rest_framework.response import Response
+from rest_framework import viewsets, permissions, parsers, filters, status
+from django.db.models import Q, F, Sum
+from django.conf import settings
+from django.contrib.sites.shortcuts import get_current_site
+from django.utils.translation import gettext_lazy as _
 from django.http import FileResponse, Http404
 from django.utils.translation import gettext_lazy as _
 from django.contrib.sites.shortcuts import get_current_site
@@ -27,7 +33,7 @@ from drf_spectacular.utils import (
     OpenApiResponse,
 )
 
-from src.apps.video.models import Video
+from src.apps.video.models import Video, ViewCount
 from src.apps.video.serializers import VideoSerializer, DublinCoreSerializer
 from src.apps.video.permissions import IsOwnerOrCoOwnerOrChannelCollaborator
 from src.apps.video.tasks import task_bulk_update_videos, task_bulk_delete_videos
@@ -331,7 +337,6 @@ class VideoViewSet(viewsets.ModelViewSet):
         video.view_count = F("view_count") + 1
         video.save(update_fields=["view_count"])
         video.refresh_from_db()
-        from datetime import date
 
         view_count_obj, created = video.view_counts.get_or_create(date=date.today())
         view_count_obj.count = F("count") + 1
@@ -527,6 +532,7 @@ class VideoViewSet(viewsets.ModelViewSet):
         return Response({"status": "ownership transferred"})
 
     @extend_schema(
+
         summary="Dublin Core metadata for a video",
         responses={
             200: DublinCoreSerializer,
@@ -733,3 +739,88 @@ class VideoViewSet(viewsets.ModelViewSet):
         duplicated = duplicate_video(original, request.user)
         serializer = self.get_serializer(duplicated)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+    @extend_schema(
+        summary="Video view statistics",
+        description="Returns aggregated view statistics for a video (total, 7-day, 30-day, peak, daily breakdown).",
+        parameters=[
+            OpenApiParameter(
+                name="days",
+                type=int,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description="Number of days for the daily breakdown (default: 30, max: 365).",
+            )
+        ],
+        responses={
+            200: OpenApiResponse(description="Aggregated statistics."),
+            400: OpenApiResponse(description="Statistics feature is disabled."),
+            403: OpenApiResponse(description="Authentication or ownership required."),
+        },
+    )
+    @action(detail=True, methods=["get"], permission_classes=[permissions.AllowAny])
+    def stats(self, request, slug=None):
+        """
+        GET /api/videos/{slug}/stats/
+        Returns aggregated view statistics for a video.
+        Authentication requirement depends on VIEW_STATS_AUTH setting.
+        """
+        if not video_settings.use_stats_view:
+            return Response(
+                {"detail": _("Statistics feature is disabled.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if video_settings.view_stats_auth and not request.user.is_authenticated:
+            return Response(
+                {"detail": _("Authentication required to view statistics.")},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        video = self.get_object()
+
+        is_owner = video.owner == request.user
+        is_co_owner = (
+            request.user.is_authenticated
+            and video.co_owners.filter(pk=request.user.pk).exists()
+        )
+        if not (
+            is_owner or is_co_owner or request.user.is_staff or request.user.is_superuser
+        ):
+            return Response(
+                {"detail": _("You do not have permission to view these statistics.")},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        days = min(int(request.query_params.get("days", 30)), 365)
+        since = date.today() - timedelta(days=days)
+        qs = ViewCount.objects.filter(video=video)
+
+        daily_qs = qs.filter(date__gte=since).order_by("-date")
+        views_7d = (
+            qs.filter(date__gte=date.today() - timedelta(days=7)).aggregate(
+                total=Sum("count")
+            )["total"]
+            or 0
+        )
+        views_30d = (
+            qs.filter(date__gte=date.today() - timedelta(days=30)).aggregate(
+                total=Sum("count")
+            )["total"]
+            or 0
+        )
+        peak = qs.order_by("-count").first()
+
+        return Response(
+            {
+                "video_slug": video.slug,
+                "total_views": video.view_count,
+                "views_last_7_days": views_7d,
+                "views_last_30_days": views_30d,
+                "peak_day": peak.date if peak else None,
+                "peak_count": peak.count if peak else None,
+                "daily_breakdown": [
+                    {"date": str(vc.date), "count": vc.count} for vc in daily_qs
+                ],
+            }
+        )
+

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -8,16 +8,11 @@ import logging
 
 
 from datetime import date, timedelta
-from rest_framework.response import Response
-from rest_framework import viewsets, permissions, parsers, filters, status
 from django.db.models import Q, F, Sum
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.utils.translation import gettext_lazy as _
 from django.http import FileResponse, Http404
-from django.utils.translation import gettext_lazy as _
-from django.contrib.sites.shortcuts import get_current_site
-from django.conf import settings
 
 from rest_framework import viewsets, permissions, parsers, filters, status
 from rest_framework.decorators import action
@@ -532,8 +527,6 @@ class VideoViewSet(viewsets.ModelViewSet):
         return Response({"status": "ownership transferred"})
 
     @extend_schema(
-<<<<<<< HEAD
-
         summary="Dublin Core metadata for a video",
         responses={
             200: DublinCoreSerializer,
@@ -740,10 +733,10 @@ class VideoViewSet(viewsets.ModelViewSet):
         duplicated = duplicate_video(original, request.user)
         serializer = self.get_serializer(duplicated)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
     @extend_schema(
         summary="Video view statistics",
         description="Returns aggregated view statistics for a video (total, 7-day, 30-day, peak, daily breakdown).",
-
         parameters=[
             OpenApiParameter(
                 name="days",
@@ -785,9 +778,7 @@ class VideoViewSet(viewsets.ModelViewSet):
             request.user.is_authenticated
             and video.co_owners.filter(pk=request.user.pk).exists()
         )
-        if not (
-            is_owner or is_co_owner or request.user.is_superuser
-        ):
+        if not (is_owner or is_co_owner or request.user.is_superuser):
             return Response(
                 {"detail": _("You do not have permission to view these statistics.")},
                 status=status.HTTP_403_FORBIDDEN,
@@ -825,4 +816,3 @@ class VideoViewSet(viewsets.ModelViewSet):
                 ],
             }
         )
-

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -532,6 +532,7 @@ class VideoViewSet(viewsets.ModelViewSet):
         return Response({"status": "ownership transferred"})
 
     @extend_schema(
+<<<<<<< HEAD
 
         summary="Dublin Core metadata for a video",
         responses={
@@ -742,6 +743,7 @@ class VideoViewSet(viewsets.ModelViewSet):
     @extend_schema(
         summary="Video view statistics",
         description="Returns aggregated view statistics for a video (total, 7-day, 30-day, peak, daily breakdown).",
+
         parameters=[
             OpenApiParameter(
                 name="days",
@@ -784,7 +786,7 @@ class VideoViewSet(viewsets.ModelViewSet):
             and video.co_owners.filter(pk=request.user.pk).exists()
         )
         if not (
-            is_owner or is_co_owner or request.user.is_staff or request.user.is_superuser
+            is_owner or is_co_owner or request.user.is_superuser
         ):
             return Response(
                 {"detail": _("You do not have permission to view these statistics.")},

--- a/src/apps/video/views/VideoViewSet.py
+++ b/src/apps/video/views/VideoViewSet.py
@@ -735,8 +735,6 @@ class VideoViewSet(viewsets.ModelViewSet):
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @extend_schema(
-        summary="Video view statistics",
-        description="Returns aggregated view statistics for a video (total, 7-day, 30-day, peak, daily breakdown).",
         parameters=[
             OpenApiParameter(
                 name="days",

--- a/src/apps/video/views/ViewCountViewSet.py
+++ b/src/apps/video/views/ViewCountViewSet.py
@@ -1,0 +1,40 @@
+"""
+Esup-Pod - ViewCount viewset.
+"""
+
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import viewsets, permissions
+from rest_framework.filters import OrderingFilter
+
+from src.apps.video.conf import video_settings
+from src.apps.video.models import ViewCount
+from src.apps.video.serializers import ViewCountSerializer
+
+
+class ViewCountViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Read-only ViewSet for ViewCount records.
+    Allows filtering by video slug and date range.
+
+    GET /api/view-counts/?video=<slug>&date__gte=2026-01-01&date__lte=2026-06-30
+    """
+
+    serializer_class = ViewCountSerializer
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    filterset_fields = {"date": ["gte", "lte", "exact"]}
+    ordering_fields = ["date", "count"]
+    ordering = ["-date"]
+
+    def get_permissions(self):
+        """Requires authentication if VIEW_STATS_AUTH is enabled."""
+        if video_settings.view_stats_auth:
+            return [permissions.IsAuthenticated()]
+        return [permissions.AllowAny()]
+
+    def get_queryset(self):
+        """Filters ViewCount records by video slug if provided."""
+        video_slug = self.request.query_params.get("video")
+        qs = ViewCount.objects.all()
+        if video_slug:
+            qs = qs.filter(video__slug=video_slug)
+        return qs

--- a/src/apps/video/views/__init__.py
+++ b/src/apps/video/views/__init__.py
@@ -13,6 +13,7 @@ from .VideoAccessTokenViewSet import VideoAccessTokenViewSet  # noqa: F401
 from .DublinCoreViewSet import DublinCoreViewSet  # noqa: F401
 from .UserMarkerTimeViewSet import UserMarkerTimeViewSet  # noqa: F401
 from .VideoCutViewSet import VideoCutViewSet  # noqa: F401
+from .ViewCountViewSet import ViewCountViewSet  # noqa: F401
 
 __all__ = [
     "VideoViewSet",
@@ -26,4 +27,5 @@ __all__ = [
     "DublinCoreViewSet",
     "UserMarkerTimeViewSet",
     "VideoCutViewSet",
+    "ViewCountViewSet",
 ]


### PR DESCRIPTION
FEAT(video): migrate and modernize video statistics API

This PR migrates the video statistics system from V4 to the new V5 API-first architecture. It introduces a modern, chart-ready aggregation endpoint (/api/videos/{slug}/stats/) that provides total, 7-day, 30-day, peak, and daily breakdown statistics, replacing legacy server-side rendering. The core logic natively leverages Django's F() expressions to ensure atomic, race-condition-free increments during view registration. Legacy global configurations have been successfully migrated to strict Pydantic settings (use_stats_view, view_stats_auth). The feature is fully covered by comprehensive unit tests, protected by robust ownership authorization checks, and deeply documented via OpenAPI/Swagger.

# Before sending your pull request, make sure the following are done

* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
* [x] Your PR status is in `draft` if it’s still a work in progress.
