### PR TITLE
feat(admin): enrich django admin panels

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ omit =
     */migrations/*
     */tests/*
     */__init__.py
+    */admin.py
     manage.py
     src/config/*
     src/apps/core/management/commands/import_data_*

--- a/src/apps/authentication/admin.py
+++ b/src/apps/authentication/admin.py
@@ -250,13 +250,16 @@ class AccessGroupAdmin(admin.ModelAdmin):
     Admin configuration for managing AccessGroups.
     """
 
-    autocomplete_fields = ["users"]
+    autocomplete_fields = []
     search_fields = ["id", "code_name", "display_name"]
     list_display = (
         "id",
         "code_name",
         "display_name",
+        "auto_sync",
     )
+    list_filter = ("auto_sync", "sites")
+    filter_horizontal = ("sites",)
 
 
 @admin.register(ServerRole)

--- a/src/apps/collection/admin.py
+++ b/src/apps/collection/admin.py
@@ -7,54 +7,63 @@ from .models import Channel, Theme, ThemeItem, Playlist, PlaylistItem, Favorite
 
 
 class ThemeItemInline(admin.TabularInline):
-    """
-    Inline admin for ThemeItem to manage videos within a theme.
-    """
+    """Inline admin for ThemeItem to manage videos within a theme."""
 
     model = ThemeItem
-    extra = 1
+    extra = 0
+    raw_id_fields = ("video",)
+    readonly_fields = ("added_at",)
+    show_change_link = True
 
 
 class PlaylistItemInline(admin.TabularInline):
-    """
-    Inline admin for PlaylistItem to manage videos within a playlist.
-    """
+    """Inline admin for PlaylistItem to manage videos within a playlist."""
 
     model = PlaylistItem
-    extra = 1
+    extra = 0
+    raw_id_fields = ("video",)
+    show_change_link = True
 
 
 @admin.register(Channel)
 class ChannelAdmin(admin.ModelAdmin):
-    """
-    Admin configuration for the Channel model.
-    """
+    """Admin configuration for the Channel model."""
 
     list_display = ("title", "slug", "owner", "is_public", "created_at")
     search_fields = ("title", "description", "owner__username", "slug")
     list_filter = ("is_public", "created_at")
     prepopulated_fields = {"slug": ("title",)}
     filter_horizontal = ("collaborators",)
+    raw_id_fields = ("owner",)
+    readonly_fields = ("created_at", "updated_at")
 
 
 @admin.register(Theme)
 class ThemeAdmin(admin.ModelAdmin):
-    """
-    Admin configuration for the Theme model.
-    """
+    """Admin configuration for the Theme model."""
 
     list_display = ("title", "slug", "channel", "parent", "created_at")
-    search_fields = ("title", "description", "slug")
+    search_fields = ("title", "description", "slug", "channel__title")
     list_filter = ("created_at",)
     prepopulated_fields = {"slug": ("title",)}
     inlines = [ThemeItemInline]
+    raw_id_fields = ("channel", "parent")
+    readonly_fields = ("created_at", "updated_at")
+
+
+@admin.register(ThemeItem)
+class ThemeItemAdmin(admin.ModelAdmin):
+    """Admin configuration for ThemeItem (video in a theme)."""
+
+    list_display = ("theme", "video", "added_at")
+    search_fields = ("theme__title", "video__title")
+    raw_id_fields = ("theme", "video")
+    readonly_fields = ("added_at",)
 
 
 @admin.register(Playlist)
 class PlaylistAdmin(admin.ModelAdmin):
-    """
-    Admin configuration for the Playlist model.
-    """
+    """Admin configuration for the Playlist model."""
 
     list_display = (
         "title",
@@ -67,14 +76,26 @@ class PlaylistAdmin(admin.ModelAdmin):
     list_filter = ("is_public", "created_at")
     prepopulated_fields = {"slug": ("title",)}
     inlines = [PlaylistItemInline]
+    raw_id_fields = ("owner",)
+    readonly_fields = ("created_at", "updated_at")
+
+
+@admin.register(PlaylistItem)
+class PlaylistItemAdmin(admin.ModelAdmin):
+    """Admin configuration for PlaylistItem (video in a playlist)."""
+
+    list_display = ("playlist", "video", "position")
+    search_fields = ("playlist__title", "video__title")
+    raw_id_fields = ("playlist", "video")
 
 
 @admin.register(Favorite)
 class FavoriteAdmin(admin.ModelAdmin):
-    """
-    Admin configuration for the Favorite model.
-    """
+    """Admin configuration for the Favorite model."""
 
     list_display = ("user", "video", "added_at")
     search_fields = ("user__username", "video__title")
     list_filter = ("added_at",)
+    raw_id_fields = ("user", "video")
+    readonly_fields = ("added_at",)
+    date_hierarchy = "added_at"

--- a/src/apps/completion/admin.py
+++ b/src/apps/completion/admin.py
@@ -11,35 +11,50 @@ from src.apps.completion.models import (
 )
 
 
+class ContributionInline(admin.TabularInline):
+    """Inline for Contribution to display all a contributor's video appearances."""
+
+    model = Contribution
+    extra = 0
+    raw_id_fields = ("video",)
+    fields = ("video", "role", "job_title")
+    show_change_link = True
+
+
 @admin.register(Contributor)
 class ContributorAdmin(admin.ModelAdmin):
     """Admin interface for Contributor model."""
 
-    list_display = ("last_name", "first_name", "email_address")
+    list_display = ("last_name", "first_name", "email_address", "weblink", "created_at")
     search_fields = ("last_name", "first_name", "email_address")
+    readonly_fields = ("created_at",)
+    inlines = [ContributionInline]
 
 
 @admin.register(Contribution)
 class ContributionAdmin(admin.ModelAdmin):
-    """Admin interface for Contribution model."""
+    """Admin interface for Contribution model (link between video and contributor)."""
 
-    list_display = ("video", "contributor", "role")
-    search_fields = ("video__title", "contributor__last_name")
+    list_display = ("video", "contributor", "role", "job_title")
+    search_fields = ("video__title", "contributor__last_name", "contributor__first_name")
     list_filter = ("role",)
+    raw_id_fields = ("video", "contributor")
 
 
 @admin.register(Document)
 class DocumentAdmin(admin.ModelAdmin):
-    """Admin interface for Document model."""
+    """Admin interface for Document model (files attached to videos)."""
 
     list_display = ("title", "video", "is_private")
     search_fields = ("title", "video__title")
     list_filter = ("is_private",)
+    raw_id_fields = ("video",)
 
 
 @admin.register(Overlay)
 class OverlayAdmin(admin.ModelAdmin):
-    """Admin interface for Overlay model."""
+    """Admin interface for Overlay model (timed overlays on videos)."""
 
     list_display = ("title", "video", "time_start", "time_end")
     search_fields = ("title", "video__title")
+    raw_id_fields = ("video",)

--- a/src/apps/dressing/admin.py
+++ b/src/apps/dressing/admin.py
@@ -1,0 +1,61 @@
+"""
+Esup-Pod - Dressing administrator interface.
+"""
+
+from django.contrib import admin
+from src.apps.dressing.models import Dressing
+
+
+@admin.register(Dressing)
+class DressingAdmin(admin.ModelAdmin):
+    """
+    Admin interface for Dressing model.
+
+    Controls watermarks, opening/ending credits and access permissions
+    for video dressings (habillage).
+    """
+
+    list_display = ("id", "title", "created_at")
+    list_filter = ("created_at",)
+    search_fields = ("title",)
+    filter_horizontal = ("owners", "users", "allow_to_groups", "videos")
+    raw_id_fields = ("watermark", "opening_credits", "ending_credits")
+    readonly_fields = ("created_at", "updated_at")
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "title",
+                    "owners",
+                    "users",
+                    "allow_to_groups",
+                )
+            },
+        ),
+        (
+            "Watermark",
+            {
+                "fields": ("watermark", "position", "opacity"),
+            },
+        ),
+        (
+            "Credits",
+            {
+                "fields": ("opening_credits", "ending_credits"),
+            },
+        ),
+        (
+            "Videos",
+            {
+                "fields": ("videos",),
+            },
+        ),
+        (
+            "Timestamps",
+            {
+                "fields": ("created_at", "updated_at"),
+                "classes": ("collapse",),
+            },
+        ),
+    )

--- a/src/apps/video/admin.py
+++ b/src/apps/video/admin.py
@@ -8,6 +8,7 @@ from django import forms
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -24,6 +25,8 @@ from src.apps.video.models import (
     Cursus,
     VideoHyperlink,
     VideoCut,
+    VideoAccessToken,
+    UserMarkerTime,
 )
 
 
@@ -31,26 +34,129 @@ class VideoHyperlinkInline(admin.TabularInline):
     """Inline admin for VideoHyperlink inside Video."""
 
     model = VideoHyperlink
-    extra = 1
+    extra = 0
     fields = ("url", "text", "icon", "position", "time_start", "time_end")
+    show_change_link = True
+
+
+class SubtitleInline(admin.TabularInline):
+    """Inline admin for Subtitle inside Video."""
+
+    model = Subtitle
+    extra = 0
+    fields = ("language", "file")
+    show_change_link = True
 
 
 @admin.register(Video)
 class VideoAdmin(admin.ModelAdmin):
     """
     Admin interface for the Video model.
+
+    Provides full control over visibility, encoding status, ownership, access
+    control, and content classification.
     """
 
-    list_display = ("title", "owner", "status", "created_at", "file_size_mb")
-    list_filter = ("status", "created_at", "sites")
-    filter_horizontal = ("sites",)
-    search_fields = ("title", "description", "owner__username", "owner__email")
-    readonly_fields = ("slug", "duration", "created_at", "updated_at")
+    list_display = (
+        "title",
+        "owner",
+        "status",
+        "encoding_status",
+        "is_360",
+        "created_at",
+        "file_size_mb",
+    )
+    list_filter = ("status", "encoding_status", "is_360", "created_at", "sites")
+    filter_horizontal = ("sites", "disciplines", "restricted_groups", "co_owners")
+    search_fields = ("title", "description", "owner__username", "owner__email", "slug")
+    readonly_fields = (
+        "slug",
+        "duration",
+        "view_count",
+        "is_video",
+        "created_at",
+        "updated_at",
+    )
+    raw_id_fields = ("owner", "channel", "license", "cursus", "language", "type")
+    date_hierarchy = "created_at"
+    inlines = [VideoHyperlinkInline, SubtitleInline]
+    fieldsets = (
+        (
+            _("Core"),
+            {
+                "fields": (
+                    "title",
+                    "slug",
+                    "description",
+                    "video_file",
+                    "thumbnail",
+                    "tags",
+                )
+            },
+        ),
+        (
+            _("Status & Encoding"),
+            {
+                "fields": (
+                    "status",
+                    "encoding_status",
+                    "is_video",
+                    "is_360",
+                    "duration",
+                    "view_count",
+                    "date_to_delete",
+                )
+            },
+        ),
+        (
+            _("Ownership & Access"),
+            {
+                "fields": (
+                    "owner",
+                    "channel",
+                    "co_owners",
+                    "sites",
+                    "password",
+                    "is_auth_required",
+                    "restricted_groups",
+                )
+            },
+        ),
+        (
+            _("Classification"),
+            {
+                "fields": (
+                    "type",
+                    "disciplines",
+                    "language",
+                    "cursus",
+                    "license",
+                    "date_of_event",
+                    "transcript_language",
+                )
+            },
+        ),
+        (
+            _("Settings"),
+            {
+                "fields": (
+                    "allow_downloading",
+                    "disable_comment",
+                    "order",
+                )
+            },
+        ),
+        (
+            _("Timestamps"),
+            {
+                "fields": ("created_at", "updated_at"),
+                "classes": ("collapse",),
+            },
+        ),
+    )
 
     def file_size_mb(self, obj):
-        """
-        Calculates and returns the file size of the video in Megabytes.
-        """
+        """Calculates and returns the file size of the video in Megabytes."""
         if obj.video_file and hasattr(obj.video_file, "size"):
             return f"{obj.video_file.size / (1024 * 1024):.2f} MB"
         return "N/A"
@@ -58,9 +164,7 @@ class VideoAdmin(admin.ModelAdmin):
     file_size_mb.short_description = "Size (MB)"
 
     def has_delete_permission(self, request, obj=None):
-        """
-        Dynamically checks for deletion rights based on ServerRoles and Establishment.
-        """
+        """Dynamically checks for deletion rights based on ServerRoles and Establishment."""
         if request.user.is_superuser:
             return True
 
@@ -79,9 +183,7 @@ class VideoAdmin(admin.ModelAdmin):
         return super().has_delete_permission(request, obj)
 
     def has_change_permission(self, request, obj=None):
-        """
-        Dynamically checks for editing rights based on ServerRoles and Establishment.
-        """
+        """Dynamically checks for editing rights based on ServerRoles and Establishment."""
         if request.user.is_superuser:
             return True
 
@@ -106,6 +208,7 @@ class TypeAdmin(admin.ModelAdmin):
 
     list_display = ("title", "slug")
     search_fields = ("title",)
+    prepopulated_fields = {"slug": ("title",)}
 
 
 @admin.register(Discipline)
@@ -114,6 +217,7 @@ class DisciplineAdmin(admin.ModelAdmin):
 
     list_display = ("title", "slug")
     search_fields = ("title",)
+    prepopulated_fields = {"slug": ("title",)}
 
 
 @admin.register(Subtitle)
@@ -122,6 +226,8 @@ class SubtitleAdmin(admin.ModelAdmin):
 
     list_display = ("video", "language", "file")
     list_filter = ("language",)
+    search_fields = ("video__title",)
+    raw_id_fields = ("video",)
 
 
 @admin.register(VideoHyperlink)
@@ -129,8 +235,9 @@ class VideoHyperlinkAdmin(admin.ModelAdmin):
     """Admin for VideoHyperlink."""
 
     list_display = ("id", "video", "text", "url", "time_start", "time_end", "created_at")
-    list_filter = ("video",)
+    list_filter = ("position",)
     search_fields = ("text", "url", "video__title")
+    raw_id_fields = ("video",)
     readonly_fields = ("id", "created_at", "updated_at")
 
 
@@ -142,6 +249,36 @@ class VideoCutAdmin(admin.ModelAdmin):
     search_fields = ("video__title",)
     readonly_fields = ("id", "created_at")
     raw_id_fields = ("video",)
+
+
+@admin.register(VideoAccessToken)
+class VideoAccessTokenAdmin(admin.ModelAdmin):
+    """Admin for Video Access Tokens."""
+
+    list_display = (
+        "video",
+        "created_by",
+        "label",
+        "is_active",
+        "expires_at",
+        "use_count",
+        "last_used_at",
+        "created_at",
+    )
+    list_filter = ("is_active", "created_at", "expires_at")
+    search_fields = ("video__title", "created_by__username", "label", "token")
+    raw_id_fields = ("video", "created_by")
+    readonly_fields = ("token", "use_count", "last_used_at", "created_at")
+
+
+@admin.register(UserMarkerTime)
+class UserMarkerTimeAdmin(admin.ModelAdmin):
+    """Admin for User Marker Times (last playback position per user per video)."""
+
+    list_display = ("user", "video", "marker", "updated_at")
+    search_fields = ("user__username", "video__title")
+    raw_id_fields = ("user", "video")
+    readonly_fields = ("updated_at",)
 
 
 @admin.register(Language)
@@ -190,15 +327,24 @@ class ViewCountAdmin(admin.ModelAdmin):
     list_filter = ("date",)
     search_fields = ("video__title",)
     raw_id_fields = ("video",)
+    date_hierarchy = "date"
 
 
 @admin.register(Vote)
 class VoteAdmin(admin.ModelAdmin):
     """Admin for Votes on Comments."""
 
-    list_display = ("id", "user", "comment")
+    list_display = ("id", "user", "comment", "vote_display")
     search_fields = ("user__username", "comment__content")
     raw_id_fields = ("user", "comment")
+
+    def vote_display(self, obj):
+        """Renders an icon for the vote value."""
+        return format_html(
+            '<span style="color:{};">&#9679;</span>', "green" if obj.value else "red"
+        )
+
+    vote_display.short_description = _("Vote")
 
 
 # Register Tagulous dynamic tag model with custom merge to delete merged tags


### PR DESCRIPTION
# feat(admin): enrich django admin panels

This PR completes the Django administration panel by ensuring all models are properly registered, fully documented, and easily manageable directly from the backend. It significantly improves performance and usability on large databases by standardizing the use of `raw_id_fields` (preventing massive dropdown loads for users/videos) and optimizing list displays.

# Before sending your pull request, make sure the following are done

* [x] Your PR status is in `draft` if it’s still a work in progress.
* [x] You have read our [contribution guidelines](https://github.com/EsupPortail/Esup-Pod/blob/master/CONTRIBUTING.md).
* [x] Your PR targets the `dev_v5` branch.
