### PR TITLE
Improve Runner Manager Administration and Task Logging

### DIFF
--- a/pod/locale/fr/LC_MESSAGES/django.po
+++ b/pod/locale/fr/LC_MESSAGES/django.po
@@ -11704,6 +11704,14 @@ msgid "URL of the runner manager"
 msgstr "URL du runner manager"
 
 #: pod/video_encode_transcript/models.py
+msgid "URL of the runner administration"
+msgstr "URL de l’administration du runner"
+
+#: pod/video_encode_transcript/models.py
+msgid "Leave blank to use the runner manager URL followed by /admin."
+msgstr "Laisser vide pour utiliser l’URL du runner manager suivie de /admin."
+
+#: pod/video_encode_transcript/models.py
 msgid "Bearer token for the runner manager."
 msgstr "Jeton porteur pour le runner manager."
 

--- a/pod/locale/nl/LC_MESSAGES/django.po
+++ b/pod/locale/nl/LC_MESSAGES/django.po
@@ -10934,6 +10934,14 @@ msgid "URL of the runner manager"
 msgstr ""
 
 #: pod/video_encode_transcript/models.py
+msgid "URL of the runner administration"
+msgstr ""
+
+#: pod/video_encode_transcript/models.py
+msgid "Leave blank to use the runner manager URL followed by /admin."
+msgstr ""
+
+#: pod/video_encode_transcript/models.py
 msgid "Bearer token for the runner manager."
 msgstr ""
 

--- a/pod/video_encode_transcript/admin.py
+++ b/pod/video_encode_transcript/admin.py
@@ -29,6 +29,9 @@ RUNNER_MANAGER_SOURCE_APP_LABEL = "video_encode_transcript"
 RUNNER_MANAGER_SECTION_APP_LABEL = "runner_managers"
 RUNNER_MANAGER_SECTION_MODEL_NAMES = {"RunnerManager", "Task", "PriorityUser"}
 RUNNER_MANAGER_PRIMARY_MODEL_NAME = "RunnerManager"
+# The health endpoint depends on the Esup-Runner manager version:
+# /api/health since 1.8.0, /manager/health for older versions.
+RUNNER_MANAGER_HEALTH_ENDPOINTS = ("api/health", "manager/health")
 
 
 def _admin_or_add_url(model):
@@ -360,12 +363,12 @@ class RunnerManagerAdmin(admin.ModelAdmin):
         ]
         return response
 
-    def _health_url(self, runner_manager: RunnerManager) -> str:
-        """Build runner manager health endpoint URL."""
-        return (
-            runner_manager.url + "manager/health"
-            if runner_manager.url.endswith("/")
-            else runner_manager.url + "/manager/health"
+    def _health_urls(self, runner_manager: RunnerManager) -> tuple[str, ...]:
+        """Build health URLs for current and pre-1.8.0 manager versions."""
+        base_url = runner_manager.url.rstrip("/")
+        return tuple(
+            f"{base_url}/{endpoint}"
+            for endpoint in RUNNER_MANAGER_HEALTH_ENDPOINTS
         )
 
     def _auth_headers(self, runner_manager: RunnerManager) -> dict[str, str]:
@@ -375,6 +378,24 @@ class RunnerManagerAdmin(admin.ModelAdmin):
             "Authorization": f"Bearer {runner_manager.token}",
         }
 
+    def _request_health(
+        self, runner_manager: RunnerManager
+    ) -> tuple[str, requests.Response]:
+        """Try health endpoints from the current one to the legacy one."""
+        current_health_url, legacy_health_url = self._health_urls(runner_manager)
+        response = requests.get(
+            current_health_url,
+            headers=self._auth_headers(runner_manager),
+            timeout=15,
+        )
+        if response.status_code != 404:
+            return current_health_url, response
+        return legacy_health_url, requests.get(
+            legacy_health_url,
+            headers=self._auth_headers(runner_manager),
+            timeout=15,
+        )
+
     def _change_url(self, runner_manager: RunnerManager) -> str:
         """Build the admin change URL for a runner manager instance."""
         return reverse(
@@ -383,8 +404,8 @@ class RunnerManagerAdmin(admin.ModelAdmin):
         )
 
     def _runner_admin_url(self, runner_manager: RunnerManager) -> str:
-        """Build runner manager admin URL, handling optional trailing slash."""
-        return f"{runner_manager.url.rstrip('/')}/admin"
+        """Return the runner manager administration URL."""
+        return runner_manager.runner_admin_url
 
     @admin.display(description=_("Status"), ordering="is_active")
     def active_badge(self, obj):
@@ -421,13 +442,8 @@ class RunnerManagerAdmin(admin.ModelAdmin):
         if not self.has_change_permission(request, runner_manager):
             raise PermissionDenied
 
-        health_url = self._health_url(runner_manager)
         try:
-            response = requests.get(
-                health_url,
-                headers=self._auth_headers(runner_manager),
-                timeout=15,
-            )
+            health_url, response = self._request_health(runner_manager)
         except requests.RequestException as exc:
             self.message_user(
                 request,

--- a/pod/video_encode_transcript/management/commands/process_tasks.py
+++ b/pod/video_encode_transcript/management/commands/process_tasks.py
@@ -35,7 +35,13 @@ the next configured runner.
 
 CLI:
 - `python manage.py process_tasks`
+- `python manage.py process_tasks --verbose`
+- `python manage.py process_tasks -v 0`
 - `python manage.py process_tasks --max-tasks 20 --site example.org`
+
+By default, the command writes one timestamped summary line. Use `--verbose`
+(or Django's `--verbosity 2`) to display the detailed processing steps. Use
+`-v 0` (or `--verbosity 0`) to disable command output completely.
 
 Example cron (every 3 minutes):
 `*/3 * * * * /usr/bin/bash -c 'export WORKON_HOME=/home/pod/.virtualenvs; export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3; cd /usr/local/django_projects/podv4; source /usr/local/bin/virtualenvwrapper.sh; workon django_pod4; python manage.py process_tasks >> /usr/local/django_projects/podv4/pod/log/process_tasks.log 2>&1'`
@@ -88,9 +94,17 @@ def handle_stalled_task(task: Task, status: str) -> None:
 
 
 class Command(BaseCommand):
+    """Process queued Runner Manager tasks and report the execution result."""
+
     help = "Process encoding tasks: check running tasks and submit pending tasks to runner managers"
 
     def add_arguments(self, parser) -> None:
+        """
+        Register command-specific command-line arguments.
+
+        Args:
+            parser: Django command argument parser to configure.
+        """
         parser.add_argument(
             "--max-tasks",
             type=int,
@@ -103,10 +117,50 @@ class Command(BaseCommand):
             default=None,
             help="Site domain to filter tasks (default: current site)",
         )
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="Display detailed, timestamped processing information",
+        )
+
+    def _configure_output_logger(self, *, verbose: bool, quiet: bool) -> None:
+        """
+        Configure timestamped command output on the current stdout stream.
+
+        Args:
+            verbose: Whether detailed processing messages must be displayed.
+            quiet: Whether all command output must be suppressed.
+        """
+        self.verbose = verbose
+        self.quiet = quiet
+        self.output_logger = logging.Logger(f"{__name__}.output", logging.DEBUG)
+        handler = logging.StreamHandler(self.stdout)
+        handler.setFormatter(
+            logging.Formatter(
+                "[%(asctime)s] %(levelname)s %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+        )
+        self.output_logger.addHandler(handler)
+
+    def _write_output(
+        self, level: int, message: str, *, verbose_only: bool = True
+    ) -> None:
+        """
+        Write a timestamped message when the selected verbosity allows it.
+
+        Args:
+            level: Standard-library logging level for the message.
+            message: Message to write to the command output stream.
+            verbose_only: Only display the message in detailed output mode.
+        """
+        if self.quiet or (verbose_only and not self.verbose):
+            return
+        self.output_logger.log(level, message)
 
     def print_log(self, message: str) -> None:
         """
-        Print a plain log message to command stdout.
+        Print a detailed informational message to command stdout.
 
         Args:
             message: Message to display
@@ -114,11 +168,11 @@ class Command(BaseCommand):
         Returns:
             None
         """
-        self.stdout.write(message)
+        self._write_output(logging.INFO, message)
 
     def print_warning(self, message: str) -> None:
         """
-        Print a warning-styled message to command stdout.
+        Print a detailed warning message to command stdout.
 
         Args:
             message: Warning message to display
@@ -126,11 +180,11 @@ class Command(BaseCommand):
         Returns:
             None
         """
-        self.stdout.write(self.style.WARNING(message))
+        self._write_output(logging.WARNING, message)
 
     def print_error(self, message: str) -> None:
         """
-        Print an error-styled message to command stdout.
+        Print an error message to command stdout.
 
         Args:
             message: Error message to display
@@ -138,11 +192,11 @@ class Command(BaseCommand):
         Returns:
             None
         """
-        self.stdout.write(self.style.ERROR(message))
+        self._write_output(logging.ERROR, message, verbose_only=False)
 
     def print_success(self, message: str) -> None:
         """
-        Print a success-styled message to command stdout.
+        Print a detailed success message to command stdout.
 
         Args:
             message: Success message to display
@@ -150,10 +204,28 @@ class Command(BaseCommand):
         Returns:
             None
         """
-        self.stdout.write(self.style.SUCCESS(message))
+        self._write_output(logging.INFO, message)
+
+    def print_summary(self, message: str, level: int = logging.INFO) -> None:
+        """
+        Print the summary line emitted by a normal command run.
+
+        Args:
+            message: Summary message to display.
+            level: Standard-library logging level for the summary.
+        """
+        self._write_output(level, message, verbose_only=False)
 
     def _format_priority_label(self, priority: int) -> str:
-        """Return a human readable queue-priority label for logs."""
+        """
+        Return a human-readable queue-priority label for logs.
+
+        Args:
+            priority: Numeric queue priority to format.
+
+        Returns:
+            str: Label describing the supplied queue priority.
+        """
         if priority == HIGH_PRIORITY:
             return "HIGH"
         if priority == LOW_PRIORITY:
@@ -209,7 +281,15 @@ class Command(BaseCommand):
         return Site.objects.get_current()
 
     def _get_available_runner_managers(self, site: Site) -> list[RunnerManager]:
-        """Return active runner managers for a site, ordered by priority."""
+        """
+        Return active runner managers for a site, ordered by priority.
+
+        Args:
+            site: Site whose runner managers must be selected.
+
+        Returns:
+            list[RunnerManager]: Active managers ordered by priority, then ID.
+        """
         return list(
             RunnerManager.objects.filter(site=site, is_active=True).order_by(
                 "priority", "id"
@@ -268,12 +348,15 @@ class Command(BaseCommand):
             log.error(f"Error checking status for task {task.id}: {str(exc)}")
             return None
 
-    def _check_running_tasks(self, site: Site) -> None:
+    def _check_running_tasks(self, site: Site) -> int:
         """
         Check running tasks that have been running for more than 2 hours.
 
         Args:
             site: Site object to filter tasks
+
+        Returns:
+            int: Number of stalled tasks checked
         """
         two_hours_ago = timezone.now() - timedelta(hours=2)
 
@@ -286,11 +369,10 @@ class Command(BaseCommand):
 
         if not stalled_tasks:
             self.print_log("No stalled running tasks found")
-            return
+            return 0
 
-        self.print_log(
-            f"Found {stalled_tasks.count()} task(s) running for more than 2 hours"
-        )
+        stalled_count = stalled_tasks.count()
+        self.print_log(f"Found {stalled_count} task(s) running for more than 2 hours")
 
         for task in stalled_tasks:
             self.print_log(f"Checking status of task {task.id}...")
@@ -314,6 +396,8 @@ class Command(BaseCommand):
                 self.print_warning(f"Task {task.id} is still {status}, no action taken")
             else:
                 self.print_error(f"Could not verify status of task {task.id}")
+
+        return stalled_count
 
     def _process_tasks(
         self, pending_tasks: list, site: Site, runner_managers: list
@@ -483,8 +567,24 @@ class Command(BaseCommand):
         return deleted_count
 
     def handle(self, *args, **options) -> None:
+        """
+        Check stalled tasks, submit pending work, and clean completed tasks.
+
+        The command emits a single summary in normal mode, detailed processing
+        messages in verbose mode, and no output at verbosity level zero.
+
+        Args:
+            *args: Positional arguments supplied by Django (unused).
+            **options: Parsed command options, including site and verbosity.
+        """
         max_tasks = options["max_tasks"]
         site_domain = options["site"]
+        verbosity = options.get("verbosity", 1)
+        verbose = options.get("verbose", False) or verbosity >= 2
+        self._configure_output_logger(
+            verbose=verbose,
+            quiet=verbosity == 0 and not options.get("verbose", False),
+        )
 
         # Get site
         site = self._get_site(site_domain)
@@ -495,11 +595,11 @@ class Command(BaseCommand):
         self.print_log("=" * 60)
 
         # First, check running tasks that might be stalled
-        self.print_log("\n1. Checking running tasks...")
-        self._check_running_tasks(site)
+        self.print_log("1. Checking running tasks...")
+        stalled_count = self._check_running_tasks(site)
 
         # Then, process pending tasks
-        self.print_log("\n2. Processing pending encoding tasks...")
+        self.print_log("2. Processing pending encoding tasks...")
         refresh_pending_task_ranks()
 
         # Get pending encoding tasks (without limiting to max_tasks yet)
@@ -540,12 +640,19 @@ class Command(BaseCommand):
             self.print_success(
                 "No pending tasks found (encoding, transcription or studio)"
             )
-            self.print_log("\n3. Cleaning completed tasks...")
-            self._delete_old_completed_tasks()
+            self.print_log("3. Cleaning completed tasks...")
+            deleted_count = self._delete_old_completed_tasks()
+            self.print_summary(
+                f"process_tasks completed for site {site.domain}: "
+                f"checked {stalled_count} stalled task(s); pending 0; submitted 0; "
+                f"deleted {deleted_count} old completed task(s)"
+            )
             return
 
         self.print_log(f"Found {all_pending_tasks.count()} pending encoding task(s)")
-        self.print_log(f"Found {all_pending_studio_tasks.count()} pending studio task(s)")
+        self.print_log(
+            f"Found {all_pending_studio_tasks.count()} pending studio task(s)"
+        )
         self.print_log(
             f"Found {all_pending_transcription_tasks.count()} pending transcription task(s)"
         )
@@ -557,7 +664,9 @@ class Command(BaseCommand):
             all_pending_transcription_tasks, max_tasks
         )
 
-        self.print_log(f"Processing {len(pending_tasks)} task(s) after priority sorting")
+        self.print_log(
+            f"Processing {len(pending_tasks)} task(s) after priority sorting"
+        )
 
         # Get available active runner managers for this site
         runner_managers = self._get_available_runner_managers(site)
@@ -566,10 +675,21 @@ class Command(BaseCommand):
             self.print_warning(
                 f"No active runner manager defined for site {site.domain}. Cannot process tasks."
             )
+            self.print_summary(
+                f"process_tasks completed for site {site.domain}: "
+                f"checked {stalled_count} stalled task(s); "
+                f"pending encoding={len(pending_tasks)}, "
+                f"transcription={len(pending_transcription_tasks)}, "
+                f"studio={len(pending_studio_tasks)}; "
+                "submitted 0; no active runner manager",
+                level=logging.WARNING,
+            )
             return
 
         # Process each pending task
-        success_count_encoding = self._process_tasks(pending_tasks, site, runner_managers)
+        success_count_encoding = self._process_tasks(
+            pending_tasks, site, runner_managers
+        )
         success_count_studio = self._process_studio_tasks(
             pending_studio_tasks, site, runner_managers
         )
@@ -578,19 +698,32 @@ class Command(BaseCommand):
         )
         refresh_pending_task_ranks()
 
-        self.print_log("\n3. Cleaning completed tasks...")
-        self._delete_old_completed_tasks()
+        self.print_log("3. Cleaning completed tasks...")
+        deleted_count = self._delete_old_completed_tasks()
 
-        self.print_success(
-            f"Completed: encoding {success_count_encoding}/{len(pending_tasks)}; "
-            f"transcription {success_count_transcription}/{len(pending_transcription_tasks)}; "
-            f"studio {success_count_studio}/{len(pending_studio_tasks)} successfully submitted"
+        self.print_summary(
+            f"process_tasks completed for site {site.domain}: "
+            f"checked {stalled_count} stalled task(s); "
+            f"submitted encoding={success_count_encoding}/{len(pending_tasks)}, "
+            f"transcription={success_count_transcription}/{len(pending_transcription_tasks)}; "
+            f"studio={success_count_studio}/{len(pending_studio_tasks)}; "
+            f"deleted {deleted_count} old completed task(s)"
         )
 
     def _submit_encoding_task(
         self, video: Video, site: Site, runner_managers: list
     ) -> bool:
-        """Submit an encoding task using shared runner manager helpers."""
+        """
+        Submit an encoding task using shared runner manager helpers.
+
+        Args:
+            video: Video to encode.
+            site: Site that owns the task.
+            runner_managers: Ordered runner managers available for submission.
+
+        Returns:
+            bool: Whether a runner manager accepted the task.
+        """
         return submit_encoding_task(
             video=video, site=site, runner_managers=runner_managers
         )
@@ -598,7 +731,17 @@ class Command(BaseCommand):
     def _submit_transcription_task(
         self, video: Video, site: Site, runner_managers: list
     ) -> bool:
-        """Submit a transcription task using shared runner manager helpers."""
+        """
+        Submit a transcription task using shared runner manager helpers.
+
+        Args:
+            video: Video to transcribe.
+            site: Site that owns the task.
+            runner_managers: Ordered runner managers available for submission.
+
+        Returns:
+            bool: Whether a runner manager accepted the task.
+        """
         return submit_transcription_task(
             video=video, site=site, runner_managers=runner_managers
         )
@@ -606,7 +749,17 @@ class Command(BaseCommand):
     def _submit_studio_task(
         self, recording: Recording, site: Site, runner_managers: list
     ) -> bool:
-        """Submit a studio task using shared runner manager helpers."""
+        """
+        Submit a studio task using shared runner manager helpers.
+
+        Args:
+            recording: Studio recording to encode.
+            site: Site that owns the task.
+            runner_managers: Ordered runner managers available for submission.
+
+        Returns:
+            bool: Whether a runner manager accepted the task.
+        """
         return submit_studio_task(
             recording=recording, site=site, runner_managers=runner_managers
         )

--- a/pod/video_encode_transcript/models.py
+++ b/pod/video_encode_transcript/models.py
@@ -483,6 +483,16 @@ class RunnerManager(models.Model):
         help_text=_("Example format: %(url)s") % {"url": "https://manager.univ.fr:port/"},
     )
 
+    # Optional URL of the runner administration interface
+    admin_url = models.CharField(
+        max_length=250,
+        blank=True,
+        verbose_name=_("URL of the runner administration"),
+        help_text=_(
+            "Leave blank to use the runner manager URL followed by /admin."
+        ),
+    )
+
     # Bearer token for the runner manager server (e.g. `6YqG_73xt-9s8v5aBz`)
     token = models.CharField(
         max_length=50,
@@ -503,6 +513,11 @@ class RunnerManager(models.Model):
 
     def __str__(self):
         return "%s (%s)" % (self.name, self.site.id)
+
+    @property
+    def runner_admin_url(self) -> str:
+        """Return the configured administration URL or its default value."""
+        return self.admin_url or f"{self.url.rstrip('/')}/admin"
 
     def save(self, *args, **kwargs):
         super(RunnerManager, self).save(*args, **kwargs)

--- a/pod/video_encode_transcript/templates/admin_test_connection.html
+++ b/pod/video_encode_transcript/templates/admin_test_connection.html
@@ -61,7 +61,7 @@
   {% if change and original %}
     <li>
       <a class="runner-admin-link"
-         href="{% if original.url|slice:'-1:' == '/' %}{{ original.url }}admin{% else %}{{ original.url }}/admin{% endif %}"
+         href="{{ original.runner_admin_url }}"
          target="_blank"
          rel="noopener noreferrer">
         <i class="bi bi-box-arrow-up-right runner-admin-icon" aria-hidden="true"></i>

--- a/pod/video_encode_transcript/tests/test_process_tasks.py
+++ b/pod/video_encode_transcript/tests/test_process_tasks.py
@@ -18,11 +18,13 @@ class ProcessTasksCommandOutputTests(SimpleTestCase):
     """Verify the command's concise and verbose output modes."""
 
     def setUp(self) -> None:
+        """Create a command with captured output and a representative site."""
         self.output = StringIO()
         self.command = Command(stdout=self.output)
         self.site = SimpleNamespace(domain="example.com")
 
     def _run_empty_command(self, *, verbose: bool = False, verbosity: int = 1) -> None:
+        """Run the command against an empty task queue."""
         empty_queryset = MagicMock()
         empty_queryset.__bool__.return_value = False
         empty_queryset.select_related.return_value.order_by.return_value = (
@@ -49,6 +51,7 @@ class ProcessTasksCommandOutputTests(SimpleTestCase):
             )
 
     def test_default_empty_run_writes_one_timestamped_summary(self) -> None:
+        """Write one timestamped summary when verbose output is disabled."""
         self._run_empty_command()
 
         lines = self.output.getvalue().splitlines()
@@ -63,6 +66,7 @@ class ProcessTasksCommandOutputTests(SimpleTestCase):
         self.assertIn("pending 0; submitted 0", lines[0])
 
     def test_verbose_empty_run_writes_timestamped_details(self) -> None:
+        """Write timestamped progress details when verbose output is enabled."""
         self._run_empty_command(verbose=True)
 
         lines = self.output.getvalue().splitlines()

--- a/pod/video_encode_transcript/tests/test_process_tasks.py
+++ b/pod/video_encode_transcript/tests/test_process_tasks.py
@@ -4,12 +4,72 @@ Tests for the process_tasks management command runner delegation for Esup-Pod.
 Run with `python manage.py test pod.video_encode_transcript.tests.test_process_tasks`
 """
 
+import re
+from io import StringIO
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
 from pod.video_encode_transcript.management.commands.process_tasks import Command
+
+
+class ProcessTasksCommandOutputTests(SimpleTestCase):
+    """Verify the command's concise and verbose output modes."""
+
+    def setUp(self) -> None:
+        self.output = StringIO()
+        self.command = Command(stdout=self.output)
+        self.site = SimpleNamespace(domain="example.com")
+
+    def _run_empty_command(self, *, verbose: bool = False, verbosity: int = 1) -> None:
+        empty_queryset = MagicMock()
+        empty_queryset.__bool__.return_value = False
+        empty_queryset.select_related.return_value.order_by.return_value = (
+            empty_queryset
+        )
+
+        with (
+            patch.object(self.command, "_get_site", return_value=self.site),
+            patch.object(self.command, "_check_running_tasks", return_value=0),
+            patch.object(self.command, "_delete_old_completed_tasks", return_value=0),
+            patch(
+                "pod.video_encode_transcript.management.commands.process_tasks.refresh_pending_task_ranks"
+            ),
+            patch(
+                "pod.video_encode_transcript.management.commands.process_tasks.Task"
+            ) as task_model,
+        ):
+            task_model.objects.filter.return_value = empty_queryset
+            self.command.handle(
+                max_tasks=20,
+                site=None,
+                verbose=verbose,
+                verbosity=verbosity,
+            )
+
+    def test_default_empty_run_writes_one_timestamped_summary(self) -> None:
+        self._run_empty_command()
+
+        lines = self.output.getvalue().splitlines()
+        self.assertEqual(len(lines), 1)
+        self.assertRegex(
+            lines[0],
+            re.compile(
+                r"^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] INFO "
+                r"process_tasks completed for site example\.com:"
+            ),
+        )
+        self.assertIn("pending 0; submitted 0", lines[0])
+
+    def test_verbose_empty_run_writes_timestamped_details(self) -> None:
+        self._run_empty_command(verbose=True)
+
+        lines = self.output.getvalue().splitlines()
+        self.assertGreater(len(lines), 1)
+        self.assertTrue(all(re.match(r"^\[\d{4}-\d{2}-\d{2} ", line) for line in lines))
+        self.assertTrue(any("1. Checking running tasks" in line for line in lines))
+        self.assertTrue(any("pending 0; submitted 0" in line for line in lines))
 
 
 class ProcessTasksCommandDelegationTests(SimpleTestCase):

--- a/pod/video_encode_transcript/tests/test_runner_manager_admin.py
+++ b/pod/video_encode_transcript/tests/test_runner_manager_admin.py
@@ -74,6 +74,24 @@ class RunnerManagerAdminTests(TestCase):
         self.assertContains(response, "runner-admin-link")
         self.assertContains(response, "https://runner-no-slash.example.com/admin")
 
+    def test_runner_admin_links_use_configured_admin_url(self):
+        """Use the optional administration URL in list and change page links."""
+        configured_url = "https://runner-admin.example.com/control-panel"
+        default_url = "https://runner.example.com/admin"
+        self.runner_manager.admin_url = configured_url
+        self.runner_manager.save(update_fields=["admin_url"])
+
+        urls = [
+            self.change_url,
+            reverse("admin:video_encode_transcript_runnermanager_changelist"),
+        ]
+        for url in urls:
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+                self.assertContains(response, configured_url)
+                self.assertNotContains(response, default_url)
+
     def test_changelist_displays_activation_badge(self):
         """Display activation badge in runner manager changelist."""
         changelist_url = reverse("admin:video_encode_transcript_runnermanager_changelist")
@@ -211,7 +229,7 @@ class RunnerManagerAdminTests(TestCase):
             )
         )
         mocked_get.assert_called_once_with(
-            "https://runner.example.com/manager/health",
+            "https://runner.example.com/api/health",
             headers={
                 "Accept": "application/json",
                 "Authorization": "Bearer runner-token",
@@ -234,10 +252,40 @@ class RunnerManagerAdminTests(TestCase):
             )
         )
         mocked_get.assert_called_once_with(
-            "https://runner.example.com/manager/health",
+            "https://runner.example.com/api/health",
             headers={
                 "Accept": "application/json",
                 "Authorization": "Bearer runner-token",
             },
+            timeout=15,
+        )
+
+    @patch("pod.video_encode_transcript.admin.requests.get")
+    def test_test_connection_supports_managers_older_than_1_8_0(self, mocked_get):
+        """Fall back to the legacy health endpoint when the new one is absent."""
+        mocked_get.side_effect = [Mock(status_code=404), Mock(status_code=200)]
+
+        response = self.client.get(self.test_connection_url, follow=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            any(
+                "Connection to runner manager" in message
+                for message in self._messages(response)
+            )
+        )
+        expected_headers = {
+            "Accept": "application/json",
+            "Authorization": "Bearer runner-token",
+        }
+        self.assertEqual(mocked_get.call_count, 2)
+        mocked_get.assert_any_call(
+            "https://runner.example.com/api/health",
+            headers=expected_headers,
+            timeout=15,
+        )
+        mocked_get.assert_any_call(
+            "https://runner.example.com/manager/health",
+            headers=expected_headers,
             timeout=15,
         )


### PR DESCRIPTION
## Summary

- Add a configurable Runner Manager administration URL while preserving the default /admin URL.
- Support the /api/health endpoint introduced in Esup-Runner Manager 1.8.0, with a fallback to the legacy /manager/health endpoint.
- Add timestamped output modes to process_tasks: concise by default, detailed with --verbose, and silent with --verbosity 0.
- Add regression tests covering administration URLs, health endpoint compatibility, and command output modes.