### PR TITLE
Harden Video Security, Fix Runner Imports and v3-to-v4 Export, and Stabilize Tests

### DIFF
--- a/.github/workflows/code_formatting.yml
+++ b/.github/workflows/code_formatting.yml
@@ -6,6 +6,9 @@ on:
     branches: [master, develop, main, dev_v4]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   code-formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/pod_dev.yml
+++ b/.github/workflows/pod_dev.yml
@@ -13,6 +13,9 @@ on:
     - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.10'
   DJANGO_SUPERUSER_USERNAME: "admin"

--- a/.github/workflows/pod_main.yml
+++ b/.github/workflows/pod_main.yml
@@ -12,6 +12,9 @@ on:
       - master
     workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
     Pod-Main:
         runs-on: ubuntu-latest

--- a/pod/authentication/tests/test_views.py
+++ b/pod/authentication/tests/test_views.py
@@ -7,6 +7,7 @@ from django.test import TestCase, Client
 from django.contrib.auth.models import User
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
+from urllib.parse import parse_qs, urlsplit
 
 # ggignore-start
 # gitguardian:ignore
@@ -42,6 +43,29 @@ class authenticationViewsTestCase(TestCase):
         self.assertRedirects(response, "/accounts/login/?next=/")
 
         print("   --->  test_authentication_login of authenticationViewsTestCase: OK!")
+
+    def test_authentication_login_rejects_external_referrers(self) -> None:
+        """Authentication redirects must remain on the current host."""
+        login_url = settings.LOGIN_URL
+
+        for referrer in ("//evil.example", "https://testserver.evil.example/path"):
+            with self.subTest(referrer=referrer):
+                response = self.client.get(login_url, {"referrer": referrer})
+                self.assertEqual(response.status_code, 400)
+
+    def test_authentication_login_encodes_local_referrer(self) -> None:
+        """Keep a local return URL as one encoded query-string value."""
+        referrer = "/video/example/?first=1&second=2"
+        response = self.client.get(
+            settings.LOGIN_URL,
+            {"referrer": referrer, "is_iframe": "true"},
+        )
+
+        location = urlsplit(response.url)
+        query = parse_qs(location.query)
+        self.assertEqual(location.path, "/accounts/login/")
+        self.assertEqual(query["next"], [referrer])
+        self.assertEqual(query["is_iframe"], ["true"])
 
     def test_authentication_logout(self) -> None:
         self.client = Client()

--- a/pod/authentication/views.py
+++ b/pod/authentication/views.py
@@ -5,6 +5,8 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
+from django.http import QueryDict
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 from django.contrib import auth
 
@@ -29,14 +31,12 @@ def authentication_login(request):
     elif referrer.startswith("http:/") and not referrer.startswith("http://"):
         referrer = "http://" + referrer[len("http:/") :]
 
-    host = (
-        "https://%s" % request.get_host()
-        if (request.is_secure())
-        else "http://%s" % request.get_host()
-    )
-    if not referrer.startswith(("/", host)):
+    if not url_has_allowed_host_and_scheme(
+        referrer,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
         raise SuspiciousOperation("referrer is not internal")
-    iframe_param = "is_iframe=true&" if (request.GET.get("is_iframe")) else ""
     if request.user.is_authenticated:
         return redirect(referrer)
     if USE_CAS or USE_SHIB or USE_OIDC:
@@ -55,7 +55,11 @@ def authentication_login(request):
         )
     else:
         url = reverse("local-login")
-        url += "?%snext=%s" % (iframe_param, referrer.replace("&", "%26"))
+        query = QueryDict(mutable=True)
+        if request.GET.get("is_iframe"):
+            query["is_iframe"] = "true"
+        query["next"] = referrer
+        url += "?" + query.urlencode(safe="/")
         return redirect(url)
 
 

--- a/pod/completion/static/js/caption_maker.js
+++ b/pod/completion/static/js/caption_maker.js
@@ -1408,7 +1408,8 @@ function processProxyVttResponse(obj) {
  * @returns stripped line
  */
 function stripHtmlTags(line) {
-  return String(line).replace(/[<>]/g, "").trim();
+  const cue = new VTTCue(0, 1, String(line));
+  return (cue.getCueAsHTML().textContent || "").trim();
 }
 
 /**

--- a/pod/cut/tests/test_views.py
+++ b/pod/cut/tests/test_views.py
@@ -3,6 +3,7 @@
 from django.test import TestCase, override_settings
 from django.contrib.auth.models import User
 from pod.cut.models import CutVideo
+from pod.video import forms as video_forms
 from pod.video.models import Video, Type
 from django.urls import reverse
 from pod.main.models import Configuration
@@ -11,6 +12,7 @@ from django.contrib.messages import get_messages
 from django.utils.translation import gettext_lazy as _
 from .. import views
 from importlib import reload
+from unittest.mock import patch
 
 # ggignore-start
 # gitguardian:ignore
@@ -95,10 +97,12 @@ class CutVideoViewsTestCase(TestCase):
             "duration": 10,
         }
 
-        response = self.client.post(
-            reverse("cut:video_cut", kwargs={"slug": self.video.slug}), data=post_data
-        )
+        with patch.object(video_forms.encode, video_forms.ENCODE_VIDEO) as start_encode:
+            response = self.client.post(
+                reverse("cut:video_cut", kwargs={"slug": self.video.slug}), data=post_data
+            )
 
+        start_encode.assert_called_once_with(self.video.id)
         self.assertTrue(CutVideo.objects.filter(video=self.video).exists())
         self.assertRedirects(response, reverse("video:dashboard"))
         messages = [m.message for m in get_messages(response.wsgi_request)]

--- a/pod/duplicate/tests/test_views.py
+++ b/pod/duplicate/tests/test_views.py
@@ -1,8 +1,14 @@
 """Unit tests for Duplicate views."""
 
-from django.test import TestCase
+from datetime import date
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from django.core.files.base import ContentFile
+from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.contrib.auth.models import User
+from pod.video import forms as video_forms
 from pod.video.models import Video, Type
 
 # ggignore-start
@@ -20,20 +26,25 @@ class VideoDuplicateViewTest(TestCase):
 
     def setUp(self) -> None:
         """Set up required objects for the tests."""
+        media_dir = TemporaryDirectory()
+        self.addCleanup(media_dir.cleanup)
+        media_settings = override_settings(MEDIA_ROOT=media_dir.name)
+        media_settings.enable()
+        self.addCleanup(media_settings.disable)
         self.user = User.objects.create_user(
             username="testuser", password=PWD, is_staff=True
         )
         self.type = Type.objects.create(title="Test Type")
         self.video = Video.objects.create(
             title="Original Video",
-            video="test.mp4",
+            video=ContentFile(b"source video content", name="test.mp4"),
             slug="original-video",
             type=self.type,
             owner=self.user,
             description="Original description",
             description_fr="Description originale",
             description_en="Original description",
-            date_evt="2023-01-01",
+            date_evt=date(2023, 1, 1),
             main_lang="en",
             licence="CC BY-SA",
             is_draft=False,
@@ -42,16 +53,20 @@ class VideoDuplicateViewTest(TestCase):
             is_360=False,
             disable_comment=False,
         )
-        self.video.save()
 
     def test_video_duplicate(self) -> None:
         """Test duplicating a video."""
         self.client.force_login(self.user)
         url = reverse("duplicate:video_duplicate", args=[self.video.slug])
-        response = self.client.get(url)
+        with patch.object(video_forms.encode, video_forms.ENCODE_VIDEO) as start_encode:
+            response = self.client.get(url)
 
         # Check that the duplicated video exists
         duplicated_video = Video.objects.get(slug="0002-copy-of-original-video")
+        start_encode.assert_called_once_with(duplicated_video.id)
+        self.assertNotEqual(duplicated_video.video.name, self.video.video.name)
+        with duplicated_video.video.open("rb") as copied_file:
+            self.assertEqual(copied_file.read(), b"source video content")
         self.assertEqual(duplicated_video.title, "Copy of Original Video")
         self.assertEqual(duplicated_video.type, self.type)
         self.assertEqual(duplicated_video.owner, self.user)
@@ -67,8 +82,9 @@ class VideoDuplicateViewTest(TestCase):
         self.assertEqual(duplicated_video.is_360, False)
         self.assertEqual(duplicated_video.disable_comment, False)
 
-        # Check the response status code
-        self.assertEqual(
-            response.status_code, 302
-        )  # Redirect after successful duplication"
+        self.assertRedirects(
+            response,
+            reverse("video:video_edit", args=[duplicated_video.slug]),
+            fetch_redirect_response=False,
+        )
         print(" --->  test_video_duplicate ok")

--- a/pod/import_video/tests/test_models.py
+++ b/pod/import_video/tests/test_models.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.test import TestCase
+from django.utils import timezone
 
 
 class ExternalRecordingTestCase(TestCase):
@@ -21,7 +22,7 @@ class ExternalRecordingTestCase(TestCase):
             id=1,
             name="test recording1",
             owner=user,
-            start_at=datetime(2022, 4, 24, 14, 0, 0),
+            start_at=timezone.make_aware(datetime(2022, 4, 24, 14, 0, 0)),
             site=Site.objects.get(id=1),
             type="bigbluebutton",
             source_url="https://bbb.url",
@@ -30,7 +31,7 @@ class ExternalRecordingTestCase(TestCase):
             id=2,
             name="test recording2",
             owner=user,
-            start_at=datetime(2022, 4, 24, 14, 0, 0),
+            start_at=timezone.make_aware(datetime(2022, 4, 24, 14, 0, 0)),
             site=Site.objects.get(id=1),
             type="bigbluebutton",
             source_url="https://bbb.url",

--- a/pod/import_video/tests/test_utils.py
+++ b/pod/import_video/tests/test_utils.py
@@ -1,13 +1,16 @@
-"""Esup-Pod tests for SSRF protections in import_video utils.
+"""Esup-Pod tests for SSRF and filesystem protections in import_video utils.
 
 test with `python manage.py test pod.import_video.tests.test_utils`
 """
 
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, override_settings
 
 from pod.import_video.utils import (
+    define_dest_file_and_path,
     download_video_file,
     safe_request,
     validate_remote_import_url,
@@ -53,6 +56,38 @@ class ImportVideoUtilsSecurityTest(SimpleTestCase):
             download_video_file(session, "http://127.0.0.1/video.mp4", "/tmp/test.mp4")
 
         session.request.assert_not_called()
+
+    def test_download_video_file_rejects_destination_outside_media_root(self):
+        """A destination path cannot escape MEDIA_ROOT."""
+        session = Mock()
+
+        with TemporaryDirectory() as media_root, patch(
+            "pod.import_video.utils.MEDIA_ROOT", media_root
+        ):
+            with self.assertRaises(ValueError):
+                download_video_file(
+                    session,
+                    "https://example.org/video.mp4",
+                    "/tmp/outside-media-root.mp4",
+                )
+
+        session.request.assert_not_called()
+
+    def test_define_destination_rejects_owner_path_traversal(self):
+        """Even a compromised owner path cannot control the created directory."""
+        user = SimpleNamespace(
+            owner=SimpleNamespace(hashkey="../../outside-media-root")
+        )
+
+        with TemporaryDirectory() as media_root, override_settings(
+            MEDIA_ROOT=media_root
+        ), patch("pod.import_video.utils.MEDIA_ROOT", media_root), patch(
+            "pod.import_video.utils.os.makedirs"
+        ) as mock_makedirs:
+            with self.assertRaises(ValueError):
+                define_dest_file_and_path(user, "recording", "mp4")
+
+        mock_makedirs.assert_not_called()
 
     @patch("pod.import_video.utils.socket.getaddrinfo")
     def test_validate_remote_import_url_accepts_public_host(self, mock_getaddrinfo):

--- a/pod/live/tests/test_security_views.py
+++ b/pod/live/tests/test_security_views.py
@@ -1,0 +1,51 @@
+"""Security regression tests for live views."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import parse_qs, urlsplit
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+from django.test import SimpleTestCase
+
+from pod.live.views import create_video, event
+
+
+class LiveErrorResponseSecurityTests(SimpleTestCase):
+    """Check that internal errors are not disclosed by live endpoints."""
+
+    def test_create_video_does_not_expose_exception_details(self) -> None:
+        """Return a stable public error while logging the internal exception."""
+        event = SimpleNamespace(
+            owner=SimpleNamespace(owner=SimpleNamespace(hashkey="owner-hash"))
+        )
+        with patch("pod.live.views.Event.objects.get", return_value=event), patch(
+            "pod.live.views.os.makedirs"
+        ), patch(
+            "pod.live.views.check_dir_exists",
+            side_effect=RuntimeError("private filesystem details"),
+        ):
+            response = create_video(1, "test_event_video.mp4", "")
+
+        self.assertEqual(response.status_code, 500)
+        response_data = json.loads(response.content)
+        self.assertNotIn("private filesystem details", response_data["error"])
+
+    def test_event_login_redirect_encodes_full_return_url(self) -> None:
+        """A return URL query string cannot alter the login redirect target."""
+        request = RequestFactory().get(
+            "/live/event/1-event/?is_iframe=true&next=//evil.example"
+        )
+        request.user = AnonymousUser()
+        request.resolver_match = SimpleNamespace(namespace="live")
+        live_event = SimpleNamespace(is_restricted=True)
+
+        with patch("pod.live.views.get_object_or_404", return_value=live_event):
+            response = event(request, "1-event")
+
+        location = urlsplit(response.url)
+        query = parse_qs(location.query)
+        self.assertEqual(location.netloc, "")
+        self.assertEqual(query["is_iframe"], ["true"])
+        self.assertEqual(query["referrer"], [request.get_full_path()])

--- a/pod/live/views.py
+++ b/pod/live/views.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import PermissionDenied
 from django.core.exceptions import SuspiciousOperation
@@ -124,10 +125,13 @@ def direct(request, slug):
     site = get_current_site(request)
     broadcaster = get_broadcaster_by_slug(slug, site)
     if broadcaster.is_restricted and not request.user.is_authenticated:
-        iframe_param = "is_iframe=true&" if (request.GET.get("is_iframe")) else ""
-        return redirect(
-            "%s?%sreferrer=%s"
-            % (settings.LOGIN_URL, iframe_param, request.get_full_path())
+        login_url = settings.LOGIN_URL
+        if request.GET.get("is_iframe"):
+            login_url += "?is_iframe=true"
+        return redirect_to_login(
+            request.get_full_path(),
+            login_url=login_url,
+            redirect_field_name="referrer",
         )
 
     return render(
@@ -297,10 +301,13 @@ def event(request, slug, slug_private=None):
     if (
         evemnt.is_restricted or evemnt.restrict_access_to_groups.all().exists()
     ) and not request.user.is_authenticated:
-        iframe_param = "is_iframe=true&" if (request.GET.get("is_iframe")) else ""
-        return redirect(
-            "%s?%sreferrer=%s"
-            % (settings.LOGIN_URL, iframe_param, request.get_full_path())
+        login_url = settings.LOGIN_URL
+        if request.GET.get("is_iframe"):
+            login_url += "?is_iframe=true"
+        return redirect_to_login(
+            request.get_full_path(),
+            login_url=login_url,
+            redirect_field_name="referrer",
         )
 
     user_owns_event = request.user.is_authenticated and (
@@ -1029,10 +1036,11 @@ def create_video(event_id, current_file, segment_number):
 
         os.remove(full_file_name)
 
-    except Exception as exc:
+    except Exception:
+        logger.exception("Unable to create a video for live event %s", event_id)
         return JsonResponse(
             status=500,
-            data={"success": False, "error": str(exc)},
+            data={"success": False, "error": _("Unable to upload the video to Pod")},
         )
 
     segment = "(" + segment_number + ")" if segment_number else ""

--- a/pod/locale/fr/LC_MESSAGES/django.po
+++ b/pod/locale/fr/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-10 15:39+0200\n"
+"POT-Creation-Date: 2026-09-09 09:42+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: obado <bado@unice.fr>\n"
 "Language-Team: Pod Team cotech-esup-pod@esup-portail.org\n"
@@ -1763,8 +1763,8 @@ msgstr ""
 #: pod/completion/templates/video_completion.html
 msgid "Subtitle and/or caption file(s) must be in “.vtt” format."
 msgstr ""
-"Les fichiers de sous-titres et/ou de légendes doivent être au format "
-"« .vtt »."
+"Les fichiers de sous-titres et/ou de légendes doivent être au format « ."
+"vtt »."
 
 #: pod/completion/templates/video_completion.html
 msgid "You can use"
@@ -3010,7 +3010,7 @@ msgid "Delete the external recording"
 msgstr "Supprimer l’enregistrement externe"
 
 #: pod/import_video/tests/test_views.py pod/import_video/utils.py
-#: pod/import_video/views.py pod/meeting/views.py
+#: pod/import_video/views.py pod/live/views.py pod/meeting/views.py
 msgid "Unable to upload the video to Pod"
 msgstr "Impossible de téléverser la vidéo sur Pod"
 
@@ -7506,10 +7506,6 @@ msgid "The playlist has been deleted."
 msgstr "La liste de lecture a été supprimée."
 
 #: pod/playlist/views.py
-msgid "Delete the playlist"
-msgstr "Supprimer la liste de lecture"
-
-#: pod/playlist/views.py
 #, python-format
 msgid "Edit the playlist “%(pname)s”"
 msgstr "Modifier la liste de lecture « %(pname)s »"
@@ -7909,7 +7905,7 @@ msgstr "Veuillez choisir si les réponses correctes seront affichées ou non."
 msgid "Quizzes"
 msgstr "Quiz"
 
-#: pod/quiz/models.py pod/quiz/tests/test_models.py
+#: pod/quiz/models.py
 msgid "Quiz of video"
 msgstr "Quiz de la vidéo"
 
@@ -11435,12 +11431,12 @@ msgid "You do not have rights to delete this category"
 msgstr "Vous n’avez pas les droits pour supprimer cette catégorie"
 
 #: pod/video/views.py
-msgid "Server error while fetching user videos."
-msgstr "Erreur serveur lors de la récupération des vidéos de l’utilisateur."
-
-#: pod/video/views.py
 msgid "Server error while processing filter."
 msgstr "Erreur serveur lors du traitement du filtre."
+
+#: pod/video/views.py
+msgid "Server error while fetching user videos."
+msgstr "Erreur serveur lors de la récupération des vidéos de l’utilisateur."
 
 #: pod/video/views.py
 #, python-format
@@ -11930,3 +11926,6 @@ msgstr "Résultats de la recherche"
 #: pod/xapi/apps.py
 msgid "Esup-Pod xAPI"
 msgstr "xAPI Esup-Pod"
+
+#~ msgid "Delete the playlist"
+#~ msgstr "Supprimer la liste de lecture"

--- a/pod/locale/nl/LC_MESSAGES/django.po
+++ b/pod/locale/nl/LC_MESSAGES/django.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Pod\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-10 15:39+0200\n"
+"POT-Creation-Date: 2026-09-09 09:42+0200\n"
 "PO-Revision-Date: 2025-10-09 14:19+0200\n"
 "Last-Translator: obado <bado@unice.fr>\n"
 "Language-Team: \n"
@@ -2846,7 +2846,7 @@ msgid "Delete the external recording"
 msgstr ""
 
 #: pod/import_video/tests/test_views.py pod/import_video/utils.py
-#: pod/import_video/views.py pod/meeting/views.py
+#: pod/import_video/views.py pod/live/views.py pod/meeting/views.py
 msgid "Unable to upload the video to Pod"
 msgstr ""
 
@@ -7032,10 +7032,6 @@ msgid "The playlist has been deleted."
 msgstr ""
 
 #: pod/playlist/views.py
-msgid "Delete the playlist"
-msgstr ""
-
-#: pod/playlist/views.py
 #, python-format
 msgid "Edit the playlist “%(pname)s”"
 msgstr ""
@@ -7423,7 +7419,7 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: pod/quiz/models.py pod/quiz/tests/test_models.py
+#: pod/quiz/models.py
 msgid "Quiz of video"
 msgstr ""
 
@@ -9458,10 +9454,8 @@ msgstr ""
 #: pod/video/templates/videos/archive_or_not.html
 #: pod/video/templates/videos/prolong_or_not.html
 #: pod/video/templates/videos/video_respite_choice.html
-#, fuzzy
-#| msgid "Date email sent"
 msgid "Date to delete:"
-msgstr "Datum verzonden e-mail"
+msgstr ""
 
 #: pod/video/templates/videos/archive_download.html
 msgid "Download video archive"
@@ -10683,11 +10677,11 @@ msgid "You do not have rights to delete this category"
 msgstr ""
 
 #: pod/video/views.py
-msgid "Server error while fetching user videos."
+msgid "Server error while processing filter."
 msgstr ""
 
 #: pod/video/views.py
-msgid "Server error while processing filter."
+msgid "Server error while fetching user videos."
 msgstr ""
 
 #: pod/video/views.py
@@ -11155,8 +11149,6 @@ msgstr ""
 msgid "Esup-Pod xAPI"
 msgstr ""
 
-#, fuzzy
-#~| msgid "Please enter a title."
 #~ msgid "Please Wait."
 #~ msgstr "Voer een titel in."
 

--- a/pod/main/static/js/main.js
+++ b/pod/main/static/js/main.js
@@ -1280,30 +1280,50 @@ var showalert = function (message, alertType, idAlertType = "formalertdiv") {
     "alert-info": "info-fill",
     "alert-warning": "exclamation-triangle-fill",
     "alert-danger": "exclamation-triangle-fill",
+    "alert-error": "exclamation-triangle-fill",
   };
+  const safeAlertType = Object.prototype.hasOwnProperty.call(
+    icon_types,
+    alertType,
+  )
+    ? alertType
+    : "alert-info";
+  const alertElement = document.createElement("div");
+  alertElement.id = idAlertType;
+  alertElement.classList.add(
+    "alert",
+    safeAlertType,
+    "alert-dismissible",
+    "fade",
+    "show",
+  );
+  alertElement.setAttribute("role", "alert");
 
-  let textHtml =
-    "<div id=" +
-    idAlertType +
-    ' class="alert ' +
-    alertType +
-    ' alert-dismissible fade show" role="alert">' +
-    '<i aria-hidden="true" class="bi bi-' +
-    icon_types[alertType] +
-    ' me-2"></i>' +
-    '<span class="alert-message">' +
-    message +
-    "</span>" +
-    '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="' +
-    gettext("Close") +
-    '"></button></div>';
+  const icon = document.createElement("i");
+  icon.setAttribute("aria-hidden", "true");
+  icon.classList.add("bi", `bi-${icon_types[safeAlertType]}`, "me-2");
+  alertElement.appendChild(icon);
 
-  let parsedHTML = new DOMParser().parseFromString(textHtml, "text/html").body
-    .firstChild;
+  const messageElement = document.createElement("span");
+  messageElement.classList.add("alert-message");
+  String(message)
+    .split(/<br\s*\/?>/i)
+    .forEach((line, index) => {
+      if (index > 0) messageElement.appendChild(document.createElement("br"));
+      messageElement.appendChild(document.createTextNode(line));
+    });
+  alertElement.appendChild(messageElement);
 
-  document.body.appendChild(parsedHTML);
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.classList.add("btn-close");
+  closeButton.dataset.bsDismiss = "alert";
+  closeButton.setAttribute("aria-label", gettext("Close"));
+  alertElement.appendChild(closeButton);
+
+  document.body.appendChild(alertElement);
   // Auto dismiss success and info types
-  if (["alert-success", "alert-info"].includes(alertType)) {
+  if (["alert-success", "alert-info"].includes(safeAlertType)) {
     setTimeout(function () {
       let formalertdiv = document.getElementById(idAlertType);
       window.setTimeout(function () {
@@ -1485,11 +1505,48 @@ function update_theme(id_theme) {
       }
     }
     // Remove all id_theme options
-    for (option in id_theme.options) {
-      id_theme.options.remove(0);
-    }
+    while (id_theme.options.length > 0) id_theme.options.remove(0);
   }
   return tab_initial;
+}
+
+/**
+ * Append theme options using DOM text nodes so labels are never parsed as HTML.
+ * @param {HTMLSelectElement} id_theme Theme selector
+ * @param {Array} themes Themes to append
+ * @param {Array} selectedThemes Initially selected theme identifiers
+ * @param {string} channelLabel Channel label prefix
+ * @param {number} level Theme nesting level
+ */
+function appendThemeOptions(
+  id_theme,
+  themes,
+  selectedThemes,
+  channelLabel,
+  level = 0,
+) {
+  let prefix = "";
+  for (let i = 0; i < level; i++) prefix += "\u00a0\u00a0";
+  if (level !== 0) prefix += "|-";
+
+  themes.forEach((theme) => {
+    const option = document.createElement("option");
+    option.value = String(theme.id);
+    option.id = `theme_${theme.id}`;
+    option.selected = selectedThemes.includes(String(theme.id));
+    option.textContent = `${prefix} ${channelLabel}${theme.title}`;
+    id_theme.appendChild(option);
+
+    if (theme.child && Object.keys(theme.child).length > 0) {
+      appendThemeOptions(
+        id_theme,
+        theme.child,
+        selectedThemes,
+        channelLabel,
+        level + 1,
+      );
+    }
+  });
 }
 
 /**
@@ -1503,29 +1560,20 @@ function channel_callback(id_channel, id_theme, listTheme) {
   const channels = id_channel.parentElement.querySelectorAll(
     ".select2-selection__choice",
   );
-  let new_themes = [];
   for (let i = 0; i < channels.length; i++) {
     for (let j = 0; j < id_channel.options.length; j++) {
       if (channels[i].title === id_channel.options[j].text) {
         if (listTheme["channel_" + id_channel.options[j].value]) {
-          new_themes.push(
-            get_list(
-              listTheme["channel_" + id_channel.options[j].value],
-              0,
-              tab_initial,
-              (tag_type = "option"),
-              (li_class = ""),
-              (attrs = ""),
-              (add_link = false),
-              (current = ""),
-              (channel = id_channel.options[j].text + ": "),
-            ),
+          appendThemeOptions(
+            id_theme,
+            listTheme["channel_" + id_channel.options[j].value],
+            tab_initial,
+            id_channel.options[j].text + ": ",
           );
         }
       }
     }
   }
-  id_theme.innerHTML = new_themes.join("\n");
   flashing(id_theme, 1000);
 }
 
@@ -1537,23 +1585,14 @@ function channel_callback(id_channel, id_theme, listTheme) {
  */
 function init_theme_selector(id_channel, id_theme, listTheme) {
   const tab_initial = update_theme(id_theme);
-  var initial_themes = [];
   for (let i = 0; i < id_channel.options.length; i++) {
     if (listTheme["channel_" + id_channel.options[i].value]) {
-      initial_themes.push(
-        get_list(
-          listTheme["channel_" + id_channel.options[i].value],
-          0,
-          tab_initial,
-          (tag_type = "option"),
-          (li_class = ""),
-          (attrs = ""),
-          (add_link = false),
-          (current = ""),
-          (channel = id_channel.options[i].text + ": "),
-        ),
+      appendThemeOptions(
+        id_theme,
+        listTheme["channel_" + id_channel.options[i].value],
+        tab_initial,
+        id_channel.options[i].text + ": ",
       );
     }
   }
-  id_theme.innerHTML = initial_themes.join("\n");
 }

--- a/pod/main/templatetags/flat_page_edito_filter.py
+++ b/pod/main/templatetags/flat_page_edito_filter.py
@@ -4,7 +4,7 @@ import hashlib
 import html
 import random
 import string
-from datetime import date, datetime
+from datetime import date
 from html.parser import HTMLParser
 
 from django import template
@@ -285,7 +285,7 @@ def render_next_events(uniq_id, params, current_site, debug_elts):
 
     query = (
         Event.objects.filter(is_draft=False)
-        .exclude(end_date__lt=datetime.now())
+        .exclude(end_date__lt=timezone.now())
         .filter(broadcaster__building__sites__exact=current_site)
     )
 

--- a/pod/main/test_settings.py
+++ b/pod/main/test_settings.py
@@ -38,12 +38,14 @@ USE_DOCKER = True
 ES_URL = ["http://elasticsearch.localhost:9200/"]
 ES_VERSION = 8
 ES_INDEX = "pod"
+ES_OPTIONS = {}
 path = "pod/custom/settings_local.py"
 if os.path.exists(path):
     _temp = __import__("pod.custom", globals(), locals(), ["settings_local"])
     USE_DOCKER = getattr(_temp.settings_local, "USE_DOCKER", USE_DOCKER)
     ES_URL = getattr(_temp.settings_local, "ES_URL", ES_URL)
     ES_VERSION = getattr(_temp.settings_local, "ES_VERSION", ES_VERSION)
+    ES_OPTIONS = getattr(_temp.settings_local, "ES_OPTIONS", ES_OPTIONS)
 
 for application in INSTALLED_APPS:
     if application.startswith("pod"):

--- a/pod/main/tests/test_security_static_assets.py
+++ b/pod/main/tests/test_security_static_assets.py
@@ -37,3 +37,47 @@ class FrontendSecurityAssetsTests(unittest.TestCase):
         self.assertIn('name="type"', template)
         self.assertIn('type="submit"', template)
         self.assertIn("btn btn-primary btn-sm", template)
+
+    def test_showalert_renders_messages_as_text(self):
+        """Alert messages must not be reparsed as arbitrary HTML."""
+        script = self._read_asset("pod/main/static/js/main.js")
+        self.assertIn("document.createTextNode(line)", script)
+        self.assertNotIn("new DOMParser().parseFromString(textHtml", script)
+        self.assertNotIn("'<span class=\"alert-message\">' +", script)
+
+    def test_caption_parser_does_not_use_a_filtering_regexp(self):
+        """Caption markup is stripped by the browser WebVTT parser."""
+        script = self._read_asset("pod/completion/static/js/caption_maker.js")
+        self.assertIn("new VTTCue(0, 1, String(line))", script)
+        self.assertIn("cue.getCueAsHTML().textContent", script)
+        self.assertNotIn('replace(/[<>]/g, "")', script)
+
+    def test_video_theme_data_and_labels_are_not_interpreted_as_html(self):
+        """Theme JSON and DOM-derived labels must use safe browser primitives."""
+        main_script = self._read_asset("pod/main/static/js/main.js")
+        for template_path in (
+            "pod/video/templates/videos/video_edit.html",
+            "pod/video/templates/videos/dashboard.html",
+        ):
+            template = self._read_asset(template_path)
+            self.assertIn('listTheme|json_script:"list-theme-data"', template)
+            self.assertNotIn("listTheme | safe", template)
+
+        self.assertIn("function appendThemeOptions(", main_script)
+        self.assertIn("option.textContent =", main_script)
+        self.assertNotIn("id_theme.innerHTML =", main_script)
+
+    def test_github_workflows_declare_minimal_permissions(self):
+        """Read-only workflows and the formatting writer declare their scopes."""
+        read_only_workflows = (
+            ".github/workflows/pod_dev.yml",
+            ".github/workflows/pod_main.yml",
+        )
+        for workflow_path in read_only_workflows:
+            workflow = self._read_asset(workflow_path)
+            self.assertIn("\npermissions:\n  contents: read\n", workflow)
+
+        formatting_workflow = self._read_asset(
+            ".github/workflows/code_formatting.yml"
+        )
+        self.assertIn("\npermissions:\n  contents: write\n", formatting_workflow)

--- a/pod/main/tests/test_test_settings.py
+++ b/pod/main/tests/test_test_settings.py
@@ -1,0 +1,69 @@
+"""Regression tests for Elasticsearch connection settings in test mode."""
+
+from copy import deepcopy
+from pathlib import Path
+import runpy
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+import pod.custom
+from pod import settings as base_settings
+
+
+class ElasticsearchTestSettingsTests(SimpleTestCase):
+    """Keep authentication and TLS options when loading test settings."""
+
+    def load_test_settings(self, local_settings=None):
+        """Execute test settings with isolated configuration and no HTTP request."""
+        local_module = SimpleNamespace(USE_DOCKER=False, **(local_settings or {}))
+        response = SimpleNamespace(
+            text=(
+                '<html><body><input id="input-custom-server-salt" '
+                'value="test-secret"></body></html>'
+            )
+        )
+
+        def path_exists(path):
+            if path == "pod/custom/settings_local.py":
+                return local_settings is not None
+            # Treat the migration directory as present to prevent filesystem writes.
+            return True
+
+        with (
+            patch.object(base_settings, "INSTALLED_APPS", []),
+            patch.object(base_settings, "TEMPLATES", deepcopy(base_settings.TEMPLATES)),
+            patch.object(pod.custom, "settings_local", local_module, create=True),
+            patch("os.path.exists", side_effect=path_exists),
+            patch("requests.get", return_value=response),
+        ):
+            return runpy.run_path(
+                str(Path(__file__).resolve().parents[1] / "test_settings.py"),
+                run_name="pod.main._test_settings_regression",
+            )
+
+    def test_preserves_local_elasticsearch_options(self):
+        """Credentials and TLS settings must accompany the local server URL."""
+        options = {
+            "basic_auth": ("test-user", "test-password"),
+            "verify_certs": False,
+        }
+        loaded = self.load_test_settings(
+            {"ES_URL": ["https://search.example.invalid:9200"], "ES_OPTIONS": options}
+        )
+
+        self.assertEqual(loaded["ES_URL"], ["https://search.example.invalid:9200"])
+        self.assertEqual(loaded["ES_OPTIONS"], options)
+
+    def test_defaults_to_empty_options_when_local_option_is_absent(self):
+        """Local configurations without authentication keep the client defaults."""
+        loaded = self.load_test_settings({})
+
+        self.assertEqual(loaded["ES_OPTIONS"], {})
+
+    def test_defaults_to_empty_options_without_local_settings(self):
+        """The CI configuration works without a settings_local.py file."""
+        loaded = self.load_test_settings()
+
+        self.assertEqual(loaded["ES_OPTIONS"], {})

--- a/pod/main/tests/test_views.py
+++ b/pod/main/tests/test_views.py
@@ -15,6 +15,7 @@ from django.contrib.auth.models import User
 from django.contrib.flatpages.models import FlatPage
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
 from pod.live.models import Broadcaster, Building, Event
@@ -606,7 +607,7 @@ class TestBlock(TestCase):
             is_draft=False,
             slug="video-on-hold",
             duration=20,
-            date_added=datetime.today(),
+            date_added=timezone.now(),
             encoding_in_progress=False,
             date_evt=datetime.today(),
         )
@@ -633,7 +634,7 @@ class TestBlock(TestCase):
             is_draft=False,
             slug="video-on-hold",
             duration=20,
-            date_added=datetime.today(),
+            date_added=timezone.now(),
             encoding_in_progress=False,
             date_evt=datetime.today(),
         )
@@ -702,8 +703,8 @@ class TestBlock(TestCase):
             type=h_type,
             is_draft=False,
         )
-        event.start_date = datetime.today() + timedelta(days=+1)
-        event.end_date = datetime.today() + timedelta(days=+2)
+        event.start_date = timezone.now() + timedelta(days=+1)
+        event.end_date = timezone.now() + timedelta(days=+2)
         event.save()
 
         Block.objects.create(

--- a/pod/meeting/tests/test_models.py
+++ b/pod/meeting/tests/test_models.py
@@ -47,7 +47,7 @@ class MeetingTestCase(TestCase):
         """
         user = User.objects.get(username="pod")
         meeting = Meeting.objects.create(
-            start_at=datetime(2022, 6, 27, 14, 0, 0),
+            start_at=timezone.make_aware(datetime(2022, 6, 27, 14, 0, 0)),
             recurring_until=date(2022, 6, 26),
             recurrence="daily",
             owner=user,
@@ -481,7 +481,7 @@ class OccurencesMeetingTestCase(TestCase):
         occurences. The monthly reccurence is on the precise date each month.
         """
         meeting = Meeting.objects.get(id=1)
-        meeting.start_at = datetime(2022, 10, 7, 14, 0, 0)
+        meeting.start_at = timezone.make_aware(datetime(2022, 10, 7, 14, 0, 0))
         meeting.recurrence = "monthly"
         meeting.frequency = 1
         meeting.recurring_until = date(2023, 4, 2)
@@ -516,7 +516,7 @@ class OccurencesMeetingTestCase(TestCase):
         """Monthly occurences with number of occurrences filled in but not date of end \
         of reccurrence. The monthly reccurence is on the nth weekday of the month."""
         meeting = Meeting.objects.get(id=1)
-        meeting.start_at = datetime(2022, 10, 7, 14, 0, 0)
+        meeting.start_at = timezone.make_aware(datetime(2022, 10, 7, 14, 0, 0))
         meeting.recurrence = "monthly"
         meeting.frequency = 1
         meeting.recurring_until = None
@@ -562,7 +562,7 @@ class OccurencesMeetingTestCase(TestCase):
         """Monthly occurences with date of end of recurrence filled in but not number \
         of occurences. The monthly reccurence is on the nth weekday of the month."""
         meeting = Meeting.objects.get(id=1)
-        meeting.start_at = datetime(2022, 10, 21, 14, 0, 0)
+        meeting.start_at = timezone.make_aware(datetime(2022, 10, 21, 14, 0, 0))
         meeting.recurrence = "monthly"
         meeting.frequency = 1
         meeting.recurring_until = date(2023, 4, 2)
@@ -604,7 +604,7 @@ class OccurencesMeetingTestCase(TestCase):
         """Monthly occurences with date of end of recurrence filled in but not number \
         of occurrences. The monthly reccurence is on the nth weekday of the month."""
         meeting = Meeting.objects.get(id=1)
-        meeting.start_at = datetime(2022, 10, 21, 14, 0, 0)
+        meeting.start_at = timezone.make_aware(datetime(2022, 10, 21, 14, 0, 0))
         meeting.recurrence = "monthly"
         meeting.frequency = 1
         meeting.recurring_until = None
@@ -660,7 +660,7 @@ class OccurencesMeetingTestCase(TestCase):
         """Yearly occurences with date of end of recurrence filled in but not \
         number of occurrences."""
         meeting = Meeting.objects.get(id=1)
-        meeting.start_at = datetime(2022, 10, 7, 14, 0, 0)
+        meeting.start_at = timezone.make_aware(datetime(2022, 10, 7, 14, 0, 0))
         meeting.recurrence = "yearly"
         meeting.frequency = 1
         meeting.recurring_until = date(2028, 4, 2)
@@ -700,7 +700,7 @@ class OccurencesMeetingTestCase(TestCase):
         """Yearly occurences with number of occurrences filled in but not date of \
         end of reccurrence."""
         meeting = Meeting.objects.get(id=1)
-        meeting.start_at = datetime(2022, 10, 7, 14, 0, 0)
+        meeting.start_at = timezone.make_aware(datetime(2022, 10, 7, 14, 0, 0))
         meeting.recurrence = "yearly"
         meeting.frequency = 1
         meeting.recurring_until = None
@@ -780,7 +780,7 @@ class InternalRecordingTestCase(TestCase):
             owner=user,
             recording_id="d058c39d3dc59d9e9516d95f76eb",
             meeting=meeting2,
-            start_at=datetime(2022, 4, 24, 14, 0, 0),
+            start_at=timezone.make_aware(datetime(2022, 4, 24, 14, 0, 0)),
             uploaded_to_pod_by=user2,
             site=Site.objects.get(id=1),
         )

--- a/pod/meeting/views.py
+++ b/pod/meeting/views.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth.views import redirect_to_login
 from django.contrib.auth.models import User
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import SuspiciousOperation
@@ -508,7 +509,11 @@ def check_user(request: WSGIRequest) -> HttpResponse:
         )
         raise PermissionDenied
     else:
-        return redirect("%s?referrer=%s" % (settings.LOGIN_URL, request.get_full_path()))
+        return redirect_to_login(
+            request.get_full_path(),
+            login_url=settings.LOGIN_URL,
+            redirect_field_name="referrer",
+        )
 
 
 def check_form(

--- a/pod/meeting/views.py
+++ b/pod/meeting/views.py
@@ -177,7 +177,7 @@ def manage_personal_meeting_room(request: WSGIRequest):
             site=site,
             attendee_password=get_random_string(8),
             moderator_password=get_random_string(8),
-            start_at=datetime.now().replace(minute=0, second=0, microsecond=0),
+            start_at=timezone.now().replace(minute=0, second=0, microsecond=0),
             recurrence=None,
             is_personal=True,
         )

--- a/pod/playlist/tests/test_views.py
+++ b/pod/playlist/tests/test_views.py
@@ -501,6 +501,51 @@ class TestAddOrRemoveFormTestCase(TestCase):
         print(" --->  test_edit_form_page ok")
 
     @override_settings(USE_PLAYLIST=True)
+    def test_add_form_rejects_external_next_url(self) -> None:
+        """A submitted next parameter cannot redirect to another host."""
+        self.client.force_login(self.user)
+        response = self.client.post(
+            f"{self.addUrl}?next=//evil.example/video/example/",
+            {
+                "name": "Playlist with safe redirect",
+                "description": "",
+                "visibility": "public",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.url.startswith("/playlist/"))
+        self.assertNotIn("evil.example", response.url)
+
+    @override_settings(USE_PLAYLIST=True)
+    def test_add_form_accepts_video_next_url(self) -> None:
+        """The existing return-to-video workflow remains available."""
+        video = Video.objects.create(
+            title="Video to add",
+            owner=self.user,
+            video="video-to-add.mp4",
+            type=Type.objects.get(id=1),
+        )
+        next_url = (
+            reverse("video:video", kwargs={"slug": video.slug}) + "?is_iframe=true"
+        )
+        self.client.force_login(self.user)
+        response = self.client.post(
+            f"{self.addUrl}?next={next_url}",
+            {
+                "name": "Playlist with video",
+                "description": "",
+                "visibility": "public",
+            },
+        )
+
+        self.assertRedirects(response, next_url)
+        playlist = Playlist.objects.get(name="Playlist with video")
+        self.assertTrue(
+            PlaylistContent.objects.filter(playlist=playlist, video=video).exists()
+        )
+
+    @override_settings(USE_PLAYLIST=True)
     def test_maintenance(self) -> None:
         """Test Pod maintenance mode in TestAddOrRemoveFormTestCase."""
         self.client.force_login(self.user)

--- a/pod/playlist/views.py
+++ b/pod/playlist/views.py
@@ -1,5 +1,7 @@
 """Esup-Pod playlist views."""
 
+from urllib.parse import urlsplit
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -7,7 +9,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import PermissionDenied
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.urls import reverse
+from django.urls import Resolver404, resolve, reverse
 from django.utils.translation import gettext_lazy as _
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
@@ -447,15 +449,31 @@ def handle_post_request_for_add_or_edit_function(
         if request.POST.get("additional_owners"):
             new_playlist.additional_owners.set(request.POST.getlist("additional_owners"))
             new_playlist.save()
-        if request.GET.get("next"):
-            video_slug = request.GET.get("next").split("/")[2]
+        next_url = request.GET.get("next")
+        is_safe_next_url = (
+            next_url
+            and next_url.startswith("/")
+            and not next_url.startswith("//")
+            and url_has_allowed_host_and_scheme(
+                next_url,
+                allowed_hosts={request.get_host()},
+                require_https=request.is_secure(),
+            )
+        )
+        try:
+            next_match = resolve(urlsplit(next_url).path) if is_safe_next_url else None
+        except Resolver404:
+            next_match = None
+        is_safe_video_url = next_match and next_match.view_name == "video:video"
+        if is_safe_video_url:
+            video_slug = next_match.kwargs["slug"]
             user_add_video_in_playlist(new_playlist, Video.objects.get(slug=video_slug))
             messages.add_message(
                 request,
                 messages.INFO,
                 _("The playlist has been created and the video has been added in it."),
             )
-            return redirect(request.GET.get("next"))
+            return redirect(next_url)
         return HttpResponseRedirect(
             reverse("playlist:content", kwargs={"slug": new_playlist.slug})
         )

--- a/pod/quiz/views.py
+++ b/pod/quiz/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ValidationError
 from django.views.decorators.csrf import csrf_protect
 from pod.main.views import in_maintenance
@@ -393,7 +394,11 @@ def video_quiz(request: WSGIRequest, video_slug: str) -> HttpResponse:
         raise Http404()
 
     if quiz.connected_user_only and not request.user.is_authenticated:
-        return redirect("%s?referrer=%s" % (settings.LOGIN_URL, request.get_full_path()))
+        return redirect_to_login(
+            request.get_full_path(),
+            login_url=settings.LOGIN_URL,
+            redirect_field_name="referrer",
+        )
 
     if request.method == "POST":
         percentage_score, questions_stats, questions_answers, questions_form_errors = (

--- a/pod/recorder/tests/test_models.py
+++ b/pod/recorder/tests/test_models.py
@@ -1,5 +1,7 @@
 """Unit tests for Pod recorder."""
 
+from unittest.mock import patch
+
 from django.test import TestCase
 from django.contrib.auth.models import User, Group
 from django.core.exceptions import ValidationError
@@ -110,6 +112,10 @@ class RecordingTestCase(TestCase):
 
     def setUp(self):
         """Create models to be tested."""
+        # The recording fixture must not start a worker if its source exists.
+        process = patch("pod.recorder.plugins.type_video.process")
+        process.start()
+        self.addCleanup(process.stop)
         other_type = Type.objects.create(title="others")
         user = User.objects.create(username="pod")
         recorder1 = Recorder.objects.create(

--- a/pod/recorder/tests/test_plugins.py
+++ b/pod/recorder/tests/test_plugins.py
@@ -6,6 +6,7 @@
 import os
 import shutil
 import importlib
+from unittest.mock import patch
 from defusedxml import minidom
 
 from django.conf import settings
@@ -31,6 +32,11 @@ class PluginVideoTestCase(TestCase):
     ]
 
     def setUp(self) -> None:
+        # Existing source files must not start workers during fixture creation.
+        for plugin in ("video", "audiovideocast"):
+            process = patch("pod.recorder.plugins.type_%s.process" % plugin)
+            process.start()
+            self.addCleanup(process.stop)
         mediatype = Type.objects.create(title="others")
         Type.objects.create(title="second")
         user = User.objects.create(username="pod", is_staff=True)
@@ -82,10 +88,12 @@ class PluginVideoTestCase(TestCase):
         mod = importlib.import_module("pod.recorder.plugins.type_%s" % ("video"))
         nbnow = Video.objects.all().count()
         nbtest = nbnow + 1
-        mod.encode_recording(recording)
+        with patch.object(mod.encode, mod.ENCODE_VIDEO) as start_encode:
+            mod.encode_recording(recording)
         # print("Number of video after encode: ", Video.objects.all().count())
         self.assertEqual(Video.objects.all().count(), nbtest)
         video = Video.objects.last()
+        start_encode.assert_called_once_with(video.id)
         self.assertEqual(video.is_draft, recorder.is_draft)
         self.assertEqual(video.channel.all().count(), recorder.channel.all().count())
         self.assertEqual(video.theme.all().count(), recorder.theme.all().count())
@@ -105,10 +113,12 @@ class PluginVideoTestCase(TestCase):
         mod = importlib.import_module("pod.recorder.plugins.type_%s" % "audiovideocast")
         nbnow = Video.objects.all().count()
         nbtest = nbnow + 1
-        mod.encode_recording(recording)
+        with patch.object(mod.encode, mod.ENCODE_VIDEO) as start_encode:
+            mod.encode_recording(recording)
         # print("Number of video after encode: ", Video.objects.all().count())
         self.assertEqual(Video.objects.all().count(), nbtest)
         video = Video.objects.last()
+        start_encode.assert_called_once_with(video.id)
         # print("Number of slide after encode: ",
         #       video.enrichment_set.all().count())
         self.assertEqual((video.enrichment_set.all().count() > 0), True)

--- a/pod/recorder/tests/test_utils.py
+++ b/pod/recorder/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+from unittest.mock import patch
 from xml.dom import minidom  # nosec
 
 from django.conf import settings
@@ -35,6 +36,10 @@ class UtilsTestCase(TestCase):
 
     def setUp(self) -> None:
         """Create models to be tested."""
+        # The recording fixture must not start a worker if its source exists.
+        process = patch("pod.recorder.plugins.type_video.process")
+        process.start()
+        self.addCleanup(process.stop)
         r_type = Type.objects.create(title="others")
         user = User.objects.create(username="pod")
         recorder1 = Recorder.objects.create(

--- a/pod/recorder/tests/test_utils.py
+++ b/pod/recorder/tests/test_utils.py
@@ -3,7 +3,7 @@
 import os
 import time
 from unittest.mock import patch
-from xml.dom import minidom  # nosec
+from xml.dom import minidom
 
 from django.conf import settings
 from django.contrib.auth.models import User

--- a/pod/recorder/tests/test_views.py
+++ b/pod/recorder/tests/test_views.py
@@ -677,7 +677,8 @@ class StudioPodTestView(TestCase):
 
         print(" -->  test_studio_ingest_addCatalog of StudioPodTestView: OK!")
 
-    def test_studio_ingest_ingest(self):
+    @patch("pod.recorder.plugins.type_studio.process")
+    def test_studio_ingest_ingest(self, mock_process):
         """Test view ingest_ingest."""
 
         self.client = Client()
@@ -709,6 +710,7 @@ class StudioPodTestView(TestCase):
             },
         )
         self.assertRaises(PermissionDenied)
+        mock_process.assert_not_called()
 
         videotype = Type.objects.create(title="others")
         recorder = Recorder.objects.create(
@@ -752,6 +754,8 @@ class StudioPodTestView(TestCase):
         )
         # check if recording object exist
         self.assertTrue(recording.first())
+        # Check dispatch without starting a worker on the test transaction.
+        mock_process.assert_called_once_with(recording.get())
 
         print(" -->  test_studio_ingest_ingest of StudioPodTestView: OK!")
 

--- a/pod/urls.py
+++ b/pod/urls.py
@@ -1,7 +1,6 @@
 """Esup-pod URL configuration."""
 
-import importlib.util
-
+from django.apps import apps as django_apps
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
@@ -223,7 +222,7 @@ if USE_RUNNER_MANAGER:
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-    if importlib.util.find_spec("debug_toolbar") is not None:
+    if django_apps.is_installed("debug_toolbar"):
         urlpatterns += [
             path("__debug__/", include("debug_toolbar.urls")),
         ]

--- a/pod/video/forms.py
+++ b/pod/video/forms.py
@@ -1011,6 +1011,15 @@ class VideoForm(forms.ModelForm):
                 self.remove_field("video")  # .widget = forms.HiddenInput()
                 self.remove_field("thumbnail")
 
+        if (
+            self.is_bound
+            and self.instance.pk
+            and self.add_prefix("thumbnail") not in self.data
+        ):
+            # A form opened during encoding has no thumbnail field. If encoding
+            # finishes before POST, preserve its thumbnail instead of clearing it.
+            self.remove_field("thumbnail")
+
         # remove required=True for videofield if instance
         if self.fields.get("video") and self.instance and self.instance.video:
             # remove del self.fields["video"].widget.attrs["required"]

--- a/pod/video/management/commands/export_data_from_v3_to_v4.py
+++ b/pod/video/management/commands/export_data_from_v3_to_v4.py
@@ -9,6 +9,8 @@ Key Features:
 - Handles both MariaDB/MySQL and PostgreSQL databases.
 - Creates a directory to store the exported data if it does not already exist.
 - Converts datetime, time, and date objects to JSON-serializable formats.
+- Corrects invalid meeting recurrence end dates before export.
+- Merges duplicate video deletion dates while preserving their video relations.
 - Provides detailed success and error messages using Django's management command framework.
 
 Important notes:
@@ -287,9 +289,12 @@ class Command(BaseCommand):
         return rows, columns
 
     def convert_to_json(
-        self, rows: List[Tuple[Any, ...]], columns: List[str]
+        self,
+        rows: List[Tuple[Any, ...]],
+        columns: List[str],
+        table: str = None,
     ) -> List[Dict[str, Any]]:
-        """Convert rows to JSON format."""
+        """Convert rows to JSON format and normalize table-specific data."""
         data = []
         for row in rows:
             row_dict = {}
@@ -304,8 +309,87 @@ class Command(BaseCommand):
                     row_dict[column] = value.strftime("%Y-%m-%d")
                 else:
                     row_dict[column] = value
+
+            # A timezone offset between the application and database servers can
+            # make the exported start date one day later than recurring_until.
+            # Keep both recurrence fields non-null and move the end date to the
+            # meeting start date so all Pod v4 meeting constraints remain valid.
+            if table == "meeting":
+                start_at = row_dict.get("start_at")
+                recurring_until = row_dict.get("recurring_until")
+                if (
+                    isinstance(start_at, str)
+                    and isinstance(recurring_until, str)
+                    and recurring_until[:10] < start_at[:10]
+                ):
+                    row_dict["recurring_until"] = start_at[:10]
+
             data.append(row_dict)
         return data
+
+    @staticmethod
+    def get_canonical_video_to_delete_ids(
+        rows: List[Dict[str, Any]],
+    ) -> Dict[Any, Any]:
+        """Map every VideoToDelete ID to the lowest ID for its deletion date."""
+        canonical_ids = {}
+        for row in rows:
+            deletion_date = row["date_deletion"]
+            row_id = row["id"]
+            canonical_ids[deletion_date] = min(
+                row_id, canonical_ids.get(deletion_date, row_id)
+            )
+        return {
+            row["id"]: canonical_ids[row["date_deletion"]]
+            for row in rows
+        }
+
+    @staticmethod
+    def merge_video_to_delete_rows(
+        rows: List[Dict[str, Any]], id_map: Dict[Any, Any]
+    ) -> List[Dict[str, Any]]:
+        """Keep only the canonical VideoToDelete row for each deletion date."""
+        return [row for row in rows if row["id"] == id_map[row["id"]]]
+
+    @staticmethod
+    def remap_video_to_delete_relations(
+        rows: List[Dict[str, Any]], id_map: Dict[Any, Any]
+    ) -> List[Dict[str, Any]]:
+        """Point video relations to canonical IDs and remove duplicate links."""
+        normalized_rows = []
+        seen_relations = set()
+        for row in rows:
+            normalized_row = row.copy()
+            previous_id = normalized_row["videotodelete_id"]
+            normalized_row["videotodelete_id"] = id_map.get(previous_id, previous_id)
+            relation = (
+                normalized_row["videotodelete_id"],
+                normalized_row["video_id"],
+            )
+            if relation in seen_relations:
+                continue
+            seen_relations.add(relation)
+            normalized_rows.append(normalized_row)
+        return normalized_rows
+
+    def normalize_video_to_delete_data(
+        self, data: Dict[str, List[Dict[str, Any]]]
+    ) -> None:
+        """Merge duplicate deletion dates and preserve all related videos."""
+        video_to_delete_table = "video_videotodelete"
+        relation_table = "video_videotodelete_video"
+        video_to_delete_rows = data.get(video_to_delete_table)
+        if not video_to_delete_rows:
+            return
+
+        id_map = self.get_canonical_video_to_delete_ids(video_to_delete_rows)
+        data[video_to_delete_table] = self.merge_video_to_delete_rows(
+            video_to_delete_rows, id_map
+        )
+        if relation_table in data:
+            data[relation_table] = self.remap_video_to_delete_relations(
+                data[relation_table], id_map
+            )
 
     def export_tables_to_json(
         self, table_names: List[str], output_directory: str, output_file: str
@@ -326,7 +410,7 @@ class Command(BaseCommand):
                     else:
                         # Management for others data
                         rows, columns = self.fetch_table_data(cursor, table)
-                    data[table] = self.convert_to_json(rows, columns)
+                    data[table] = self.convert_to_json(rows, columns, table=table)
                     self.stdout.write(
                         self.style.SUCCESS(f" - Table {table} has been processed.")
                     )
@@ -336,6 +420,8 @@ class Command(BaseCommand):
                             f" - Table {table} could not be processed. Error: {e}"
                         )
                     )
+
+        self.normalize_video_to_delete_data(data)
 
         # Write the JSON file
         json_file = os.path.join(BASE_DIR, f"{output_directory}{output_file}")

--- a/pod/video/rest_views.py
+++ b/pod/video/rest_views.py
@@ -8,6 +8,7 @@ from rest_framework import renderers, serializers, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from tagulous.contrib.drf import TagRelatedManagerField
 
 from pod.main.utils import remove_trailing_spaces
 
@@ -67,6 +68,8 @@ class DisciplineSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class VideoSerializer(serializers.HyperlinkedModelSerializer):
+    tags = TagRelatedManagerField(required=False)
+
     class Meta:
         model = Video
         fields = (
@@ -216,7 +219,9 @@ class VideoViewSet(viewsets.ModelViewSet):
         username = request.GET.get("username")
         user_videos = (
             self.filter_queryset(self.get_queryset())
-            .filter(Q(owner__username=username) | Q(additional_owners__username=username))
+            .filter(
+                Q(owner__username=username) | Q(additional_owners__username=username)
+            )
             .distinct()
         )
         if request.GET.get("encoded") and request.GET.get("encoded") == "true":

--- a/pod/video/static/js/video_stats_view.js
+++ b/pod/video/static/js/video_stats_view.js
@@ -21,6 +21,9 @@ function linkedCell(cellValue, options, rowObject) {
 }
 
 $(() => {
+  if (!document.getElementById("grid")) {
+    return;
+  }
   let data_url = window.location.href;
   $("#grid").jqGrid({
     url: data_url,
@@ -114,11 +117,16 @@ $(() => {
       try {
         // Set min date
         let min_date = data.filter((obj) => {
-          return obj.min_date != undefined;
+          return obj.min_date !== undefined;
         });
         // remove date_min in data
         data.pop();
-        document.getElementById("jsperiode").min = min_date[0].min_date;
+        const dateInput = document.getElementById("jsperiode");
+        if (min_date[0].min_date) {
+          dateInput.min = min_date[0].min_date;
+        } else {
+          dateInput.removeAttribute("min");
+        }
       } catch (uselesserr) {
         /* empty */
       }

--- a/pod/video/templates/videos/dashboard.html
+++ b/pod/video/templates/videos/dashboard.html
@@ -253,6 +253,7 @@
 {% block more_script %}
   <script src="{% static 'admin/js/core.js' %}?ver={{VERSION}}"></script>
   {{form.media.js}}
+  {{ listTheme|json_script:"list-theme-data" }}
 
   <script>
     const urlVideos = "{% url 'video:dashboard' %}";
@@ -268,7 +269,7 @@
     let nextPage = false;
     const ownerFilter = {{ owner_filter|yesno:'true,false'}};
     const formFieldsets = {{ fieldsets_dashboard|safe }};
-    const listTheme = {{listTheme | safe}};
+    const listTheme = JSON.parse(document.getElementById("list-theme-data").textContent);
 
     {% if videos.has_next %}
       page = parseInt("{{videos.next_page_number}}", 10);

--- a/pod/video/templates/videos/video_edit.html
+++ b/pod/video/templates/videos/video_edit.html
@@ -277,8 +277,9 @@
 
 {% block more_script %}
   <script src="{% static 'admin/js/core.js' %}?ver={{VERSION}}"></script>
+  {{ listTheme|json_script:"list-theme-data" }}
   <script>
-    const listTheme = {{listTheme | safe}};
+    const listTheme = JSON.parse(document.getElementById("list-theme-data").textContent);
   </script>
   {{ form.media.js }}
   <script defer src="{% static 'js/video_edit.js' %}?ver={{VERSION}}"></script>

--- a/pod/video/tests/test_bulk_update.py
+++ b/pod/video/tests/test_bulk_update.py
@@ -10,6 +10,7 @@ from django.contrib.auth.models import Permission
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.contrib.sites.models import Site
 from django.test import RequestFactory, Client, TransactionTestCase
+from django.utils import timezone
 
 from pod.authentication.backends import User
 from pod.video.models import Video, Type
@@ -48,7 +49,7 @@ class BulkUpdateTestCase(TransactionTestCase):
             type=type1,
             title="Video1",
             password=None,
-            date_added=datetime.today(),
+            date_added=timezone.now(),
             encoding_in_progress=False,
             owner=user1,
             date_evt=datetime.today(),
@@ -63,7 +64,7 @@ class BulkUpdateTestCase(TransactionTestCase):
             type=type1,
             title="Video2",
             password=None,
-            date_added=datetime.today(),
+            date_added=timezone.now(),
             encoding_in_progress=False,
             owner=user2,
             date_evt=datetime.today(),
@@ -78,7 +79,7 @@ class BulkUpdateTestCase(TransactionTestCase):
             type=type2,
             title="Video3",
             password=None,
-            date_added=datetime.today(),
+            date_added=timezone.now(),
             encoding_in_progress=False,
             owner=user2,
             date_evt=datetime.today(),
@@ -93,7 +94,7 @@ class BulkUpdateTestCase(TransactionTestCase):
             type=type2,
             title="Video4",
             password=None,
-            date_added=datetime.today(),
+            date_added=timezone.now(),
             encoding_in_progress=False,
             owner=user3,
             date_evt=datetime.today(),
@@ -108,7 +109,7 @@ class BulkUpdateTestCase(TransactionTestCase):
             type=type2,
             title="Video5",
             password=None,
-            date_added=datetime.today(),
+            date_added=timezone.now(),
             encoding_in_progress=False,
             owner=user3,
             date_evt=datetime.today(),

--- a/pod/video/tests/test_export_data_from_v3_to_v4.py
+++ b/pod/video/tests/test_export_data_from_v3_to_v4.py
@@ -1,0 +1,173 @@
+"""Tests for the Pod v3 to v4 data export command."""
+
+import json
+import tempfile
+from datetime import date, datetime
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from pod.video.management.commands import export_data_from_v3_to_v4
+
+Command = export_data_from_v3_to_v4.Command
+
+
+class ExportDataFromV3ToV4Tests(SimpleTestCase):
+    """Verify table-specific data normalization during export."""
+
+    def setUp(self) -> None:
+        """Create the command under test."""
+        self.command = Command()
+        self.columns = ["id", "start_at", "recurring_until", "nb_occurrences"]
+
+    def test_invalid_meeting_recurring_until_is_moved_to_start_date(self) -> None:
+        """An end date before the meeting start date must satisfy Pod v4 checks."""
+        rows = [(1, datetime(2025, 12, 26, 0, 30), date(2025, 12, 25), 2)]
+
+        result = self.command.convert_to_json(rows, self.columns, table="meeting")
+
+        self.assertEqual(result[0]["start_at"], "2025-12-26 00:30:00")
+        self.assertEqual(result[0]["recurring_until"], "2025-12-26")
+        self.assertEqual(result[0]["nb_occurrences"], 2)
+
+    def test_valid_meeting_recurring_until_is_unchanged(self) -> None:
+        """A valid recurrence end date must be preserved."""
+        rows = [(1, datetime(2025, 12, 26, 10, 0), date(2025, 12, 27), 2)]
+
+        result = self.command.convert_to_json(rows, self.columns, table="meeting")
+
+        self.assertEqual(result[0]["recurring_until"], "2025-12-27")
+
+    def test_same_day_meeting_recurring_until_is_unchanged(self) -> None:
+        """Equality is accepted by recurring_until_greater_than_start."""
+        rows = [(1, datetime(2025, 12, 26, 10, 0), date(2025, 12, 26), 1)]
+
+        result = self.command.convert_to_json(rows, self.columns, table="meeting")
+
+        self.assertEqual(result[0]["recurring_until"], "2025-12-26")
+
+    def test_other_tables_are_not_normalized_as_meetings(self) -> None:
+        """Only meeting rows receive recurrence normalization."""
+        rows = [(1, datetime(2025, 12, 26, 0, 30), date(2025, 12, 25), 2)]
+
+        result = self.command.convert_to_json(rows, self.columns, table="other")
+
+        self.assertEqual(result[0]["recurring_until"], "2025-12-25")
+
+    def test_duplicate_video_to_delete_rows_are_merged(self) -> None:
+        """Duplicate dates must share one parent while preserving every video."""
+        data = {
+            "video_videotodelete": [
+                {"id": 12, "date_deletion": "2025-12-25"},
+                {"id": 10, "date_deletion": "2025-12-25"},
+                {"id": 11, "date_deletion": "2025-12-26"},
+            ],
+            "video_videotodelete_video": [
+                {"id": 100, "videotodelete_id": 12, "video_id": 1},
+                {"id": 101, "videotodelete_id": 10, "video_id": 2},
+                {"id": 102, "videotodelete_id": 12, "video_id": 2},
+                {"id": 103, "videotodelete_id": 11, "video_id": 3},
+            ],
+        }
+
+        self.command.normalize_video_to_delete_data(data)
+
+        self.assertEqual(
+            data["video_videotodelete"],
+            [
+                {"id": 10, "date_deletion": "2025-12-25"},
+                {"id": 11, "date_deletion": "2025-12-26"},
+            ],
+        )
+        self.assertEqual(
+            data["video_videotodelete_video"],
+            [
+                {"id": 100, "videotodelete_id": 10, "video_id": 1},
+                {"id": 101, "videotodelete_id": 10, "video_id": 2},
+                {"id": 103, "videotodelete_id": 11, "video_id": 3},
+            ],
+        )
+
+    def test_video_to_delete_rows_without_duplicates_are_preserved(self) -> None:
+        """Already valid deletion data must remain unchanged."""
+        data = {
+            "video_videotodelete": [
+                {"id": 10, "date_deletion": "2025-12-25"},
+                {"id": 11, "date_deletion": "2025-12-26"},
+            ],
+            "video_videotodelete_video": [
+                {"id": 100, "videotodelete_id": 10, "video_id": 1},
+                {"id": 101, "videotodelete_id": 11, "video_id": 2},
+            ],
+        }
+        expected = {
+            table: [row.copy() for row in rows]
+            for table, rows in data.items()
+        }
+
+        self.command.normalize_video_to_delete_data(data)
+
+        self.assertEqual(data, expected)
+
+    def test_video_to_delete_normalization_accepts_missing_relation_table(self) -> None:
+        """A partial export can still merge duplicate parent rows safely."""
+        data = {
+            "video_videotodelete": [
+                {"id": 2, "date_deletion": "2025-12-25"},
+                {"id": 1, "date_deletion": "2025-12-25"},
+            ]
+        }
+
+        self.command.normalize_video_to_delete_data(data)
+
+        self.assertEqual(
+            data["video_videotodelete"],
+            [{"id": 1, "date_deletion": "2025-12-25"}],
+        )
+        self.assertNotIn("video_videotodelete_video", data)
+
+    def test_export_writes_normalized_video_to_delete_data(self) -> None:
+        """The complete export flow must normalize data before writing JSON."""
+        tables = ["video_videotodelete", "video_videotodelete_video"]
+        table_data = {
+            "video_videotodelete": (
+                [(2, date(2025, 12, 25)), (1, date(2025, 12, 25))],
+                ["id", "date_deletion"],
+            ),
+            "video_videotodelete_video": (
+                [(10, 2, 20), (11, 1, 21)],
+                ["id", "videotodelete_id", "video_id"],
+            ),
+        }
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            with (
+                patch.object(export_data_from_v3_to_v4, "BASE_DIR", temporary_directory),
+                patch.object(export_data_from_v3_to_v4, "connection"),
+                patch.object(
+                    self.command, "check_table_existence", return_value=tables
+                ),
+                patch.object(
+                    self.command,
+                    "fetch_table_data",
+                    side_effect=lambda cursor, table: table_data[table],
+                ),
+            ):
+                self.command.export_tables_to_json(tables, "", "export.json")
+
+            with open(
+                f"{temporary_directory}/export.json", "r", encoding="utf-8"
+            ) as json_file:
+                exported_data = json.load(json_file)
+
+        self.assertEqual(
+            exported_data["video_videotodelete"],
+            [{"id": 1, "date_deletion": "2025-12-25"}],
+        )
+        self.assertEqual(
+            exported_data["video_videotodelete_video"],
+            [
+                {"id": 10, "videotodelete_id": 1, "video_id": 20},
+                {"id": 11, "videotodelete_id": 1, "video_id": 21},
+            ],
+        )

--- a/pod/video/tests/test_forms_thumbnail.py
+++ b/pod/video/tests/test_forms_thumbnail.py
@@ -1,0 +1,132 @@
+"""Regression tests for thumbnail selection when editing a video."""
+
+from django import forms
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from pod.video.forms import VideoForm
+from pod.video.models import Type, Video
+from pod.video_encode_transcript.models import EncodingVideo
+
+if getattr(settings, "USE_PODFILE", False):
+    from pod.podfile.models import CustomImageModel
+else:
+    from pod.main.models import CustomImageModel
+
+
+class VideoFormThumbnailTests(TestCase):
+    """Preserve a generated thumbnail omitted by an earlier edit form."""
+
+    fixtures = ["initial_data.json"]
+
+    def setUp(self) -> None:
+        """Create an editor and a video awaiting its generated thumbnail."""
+        self.user = User.objects.create(username="thumbnail-editor", is_staff=True)
+        self.video = Video.objects.create(
+            title="Video being encoded",
+            owner=self.user,
+            video="thumbnail-editor.mp4",
+            type=Type.objects.get(pk=1),
+            encoding_in_progress=True,
+        )
+
+    def _form(self, **kwargs) -> VideoForm:
+        return VideoForm(
+            instance=self.video,
+            current_user=self.user,
+            is_staff=True,
+            is_superuser=False,
+            **kwargs,
+        )
+
+    def _form_data(self, form) -> dict:
+        """Submit the editable values actually available when the form opened."""
+        return {
+            form.add_prefix(name): field.prepare_value(
+                form.initial.get(name, field.initial)
+            )
+            for name, field in form.fields.items()
+            if not isinstance(field, forms.FileField)
+        }
+
+    def _create_thumbnail(self, filename="generated-thumbnail.png") -> CustomImageModel:
+        kwargs = {"file": filename}
+        if getattr(settings, "USE_PODFILE", False):
+            kwargs.update(
+                folder=self.video.get_or_create_video_folder(),
+                created_by=self.user,
+            )
+        return CustomImageModel.objects.create(**kwargs)
+
+    def _finish_encoding(self) -> CustomImageModel:
+        thumbnail = self._create_thumbnail()
+        EncodingVideo.objects.create(
+            video=self.video,
+            rendition_id=1,
+            source_file="encoded-thumbnail-editor.mp4",
+        )
+        Video.objects.filter(pk=self.video.pk).update(
+            thumbnail=thumbnail,
+            encoding_in_progress=False,
+        )
+        self.video.refresh_from_db()
+        return thumbnail
+
+    def test_form_opened_during_encoding_preserves_generated_thumbnail(self) -> None:
+        """Finishing encoding before POST must not turn an omitted field into NULL."""
+        initial_form = self._form()
+        self.assertNotIn("thumbnail", initial_form.fields)
+        data = self._form_data(initial_form)
+        data["title"] = "Edited after encoding"
+        thumbnail = self._finish_encoding()
+
+        form = self._form(data=data)
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        self.video.refresh_from_db()
+        self.assertEqual(self.video.title, "Edited after encoding")
+        self.assertEqual(self.video.thumbnail_id, thumbnail.pk)
+
+    def test_prefixed_form_preserves_omitted_thumbnail(self) -> None:
+        """Detect omitted thumbnails using the submitted field's full name."""
+        initial_form = self._form(prefix="video")
+        data = self._form_data(initial_form)
+        thumbnail = self._finish_encoding()
+
+        form = self._form(data=data, prefix="video")
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        self.video.refresh_from_db()
+        self.assertEqual(self.video.thumbnail_id, thumbnail.pk)
+
+    def test_explicit_empty_thumbnail_clears_selection(self) -> None:
+        """An explicit empty selection remains a request to remove the thumbnail."""
+        self._finish_encoding()
+        initial_form = self._form()
+        self.assertIn("thumbnail", initial_form.fields)
+        data = self._form_data(initial_form)
+        data["thumbnail"] = ""
+
+        form = self._form(data=data)
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        self.video.refresh_from_db()
+        self.assertIsNone(self.video.thumbnail_id)
+
+    def test_explicit_thumbnail_changes_selection_on_prefixed_form(self) -> None:
+        """A submitted thumbnail ID still replaces the existing selection."""
+        self._finish_encoding()
+        replacement = self._create_thumbnail("selected-thumbnail.png")
+        data = self._form_data(self._form(prefix="video"))
+        data["video-thumbnail"] = str(replacement.pk)
+
+        form = self._form(data=data, prefix="video")
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        self.video.refresh_from_db()
+        self.assertEqual(self.video.thumbnail_id, replacement.pk)

--- a/pod/video/tests/test_models.py
+++ b/pod/video/tests/test_models.py
@@ -10,6 +10,7 @@ from django.db.models.fields.files import ImageFieldFile
 from django.db.utils import IntegrityError
 from django.template.defaultfilters import slugify
 from django.contrib.auth.models import User
+from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django.urls import reverse
 from django.conf import settings
@@ -306,7 +307,7 @@ class VideoTestCase(TestCase):
             type=type,
             title="Video2",
             password=None,
-            date_added=datetime.today(),
+            date_added=timezone.now(),
             encoding_in_progress=False,
             owner=user,
             date_evt=datetime.today(),
@@ -343,7 +344,7 @@ class VideoTestCase(TestCase):
         self.assertFalse(video.allow_downloading)
         self.assertEqual(video.description, "")
         self.assertEqual(video.slug, "%04d-%s" % (video.id, slugify(video.title)))
-        date = datetime.today()
+        date = timezone.now()
         self.assertEqual(video.owner, User.objects.get(username="pod"))
         self.assertEqual(video.date_added.year, date.year)
         self.assertEqual(video.date_added.month, date.month)

--- a/pod/video/tests/test_rest_views.py
+++ b/pod/video/tests/test_rest_views.py
@@ -1,0 +1,40 @@
+"""Tests for the video REST API."""
+
+from http import HTTPStatus
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from rest_framework.authtoken.models import Token
+
+from ..models import Type, Video
+
+
+class VideoRestApiTestCase(TestCase):
+    """Check the serialized representation returned by the video API."""
+
+    fixtures = ["initial_data.json"]
+
+    def test_list_serializes_tagulous_tags_as_names(self) -> None:
+        """A tagged video must not require a REST route for the tag model."""
+        user = User.objects.create_superuser(
+            username="rest-admin",
+            email="rest-admin@example.com",
+            password="test-password",
+        )
+        video = Video.objects.create(
+            title="Tagged video",
+            owner=user,
+            video="test.mp4",
+            type=Type.objects.get(pk=1),
+            tags="first-tag second-tag",
+        )
+        token = Token.objects.create(user=user)
+
+        response = self.client.get(
+            "/rest/videos/", HTTP_AUTHORIZATION=f"Token {token.key}"
+        )
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        result = response.json()["results"][0]
+        self.assertEqual(result["id"], video.pk)
+        self.assertCountEqual(result["tags"], ["first-tag", "second-tag"])

--- a/pod/video/tests/test_stats_view.py
+++ b/pod/video/tests/test_stats_view.py
@@ -5,17 +5,19 @@
 
 import json
 import logging
-from datetime import date
+from datetime import date, timedelta
 from unittest import skipUnless
+from unittest.mock import patch
 
 from django.conf import settings
+from django.contrib.auth.models import Permission
 from django.contrib.sites.models import Site
 from django.http import JsonResponse
-from django.test import Client, TestCase
+from django.test import Client, RequestFactory, TestCase
 from django.urls import NoReverseMatch, reverse
 
 from pod.authentication.models import AccessGroup, User
-from pod.video.models import Channel, Theme, Type, Video
+from pod.video.models import Channel, Theme, Type, Video, ViewCount
 from pod.video.views import get_all_views_count, stats_view
 from pod.video_encode_transcript.models import EncodingVideo, VideoRendition
 
@@ -168,6 +170,20 @@ class TestStatsView(TestCase):
                         0001_videodoesnotexist",
                 status_code=404)
         """
+
+    def test_missing_video_slug_is_escaped(self) -> None:
+        """The reflected missing-video message must not render slug markup."""
+        malicious_slug = '<img src=x onerror="alert(1)">'
+        request = RequestFactory().get("/video-stats/?from=video")
+        request.user = self.superuser
+
+        with patch("pod.video.views.get_videos", return_value=([], "")):
+            response = stats_view(request, slug=malicious_slug)
+
+        content = response.content.decode()
+        self.assertEqual(response.status_code, 404)
+        self.assertNotIn("<img", content)
+        self.assertIn("&lt;img", content)
 
     @skipUnless(USE_STATS_VIEW, "Require activate URL video_stats_view")
     def test_stats_view_GET_request_videos(self) -> None:
@@ -423,6 +439,318 @@ class TestStatsView(TestCase):
         del title_expected
         del response
         del password
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    @patch("pod.video.views.VIEW_STATS_AUTH", True)
+    def test_login_requirement_does_not_replace_video_authorization(self) -> None:
+        """Requiring login must still enforce the video password afterwards."""
+        self.video.password = "StatsPassword"
+        self.video.save()
+        for url in (self.stat_video_url, reverse("video:video_stats_view")):
+            for method in ("get", "post"):
+                with self.subTest(url=url, method=method):
+                    response = getattr(self.client, method)(url)
+                    self.assertEqual(response.status_code, 302)
+
+        self.client.force_login(self.visitor)
+        self.assertContains(self.client.get(self.stat_video_url), 'name="password"')
+        self.assertEqual(self.client.post(self.stat_video_url).status_code, 403)
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_password_post_requires_authorization_with_valid_csrf(self) -> None:
+        """A valid CSRF token alone must never expose protected statistics."""
+        self.video.password = "StatsPassword"
+        self.video.save()
+
+        for user in (None, self.visitor):
+            client = Client(enforce_csrf_checks=True)
+            if user is not None:
+                client.force_login(user)
+            response = client.get(self.stat_video_url)
+            self.assertContains(response, 'name="password"')
+            csrf_token = client.cookies[settings.CSRF_COOKIE_NAME].value
+            for password_data in ({}, {"password": "wrong-password"}):
+                with self.subTest(user=user, password=password_data):
+                    response = client.post(
+                        self.stat_video_url,
+                        {"csrfmiddlewaretoken": csrf_token, **password_data},
+                    )
+                    self.assertEqual(response.status_code, 403)
+                    self.assertNotIn(b'"since_created":', response.content)
+
+            response = client.post(
+                self.stat_video_url,
+                {"csrfmiddlewaretoken": csrf_token, "password": self.video.password},
+            )
+            self.assertContains(response, self.video.title.capitalize())
+            response = client.post(
+                self.stat_video_url, {"csrfmiddlewaretoken": csrf_token}
+            )
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()[0]["slug"], self.video.slug)
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_password_authorization_survives_ajax_and_period_changes(self) -> None:
+        """Unlocking the page also authorizes its following statistics requests."""
+        self.video.password = "StatsPassword"
+        self.video.save()
+        previous_day = TODAY - timedelta(days=1)
+        ViewCount.objects.create(video=self.video, date=previous_day, count=7)
+        ViewCount.objects.create(video=self.video, date=TODAY, count=3)
+
+        response = self.client.post(
+            self.stat_video_url, {"password": self.video.password}
+        )
+        self.assertContains(response, self.video.title.capitalize())
+        self.assertNotContains(response, 'name="password"')
+        response = self.client.get(self.stat_video_url)
+        self.assertNotContains(response, 'name="password"')
+        for period, expected_count in ((previous_day, 7), (TODAY, 3)):
+            with self.subTest(period=period):
+                response = self.client.post(
+                    self.stat_video_url, {"periode": period.isoformat()}
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json()[0]["day"], expected_count)
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_password_authorization_is_limited_to_video_and_session(self) -> None:
+        """Unlocking one video does not unlock another video or another client."""
+        for video in (self.video, self.video2):
+            video.password = "SamePassword"
+            video.save()
+        response = self.client.post(
+            self.stat_video_url, {"password": self.video.password}
+        )
+        self.assertEqual(response.status_code, 200)
+
+        other_url = (
+            reverse("video:video_stats_view", kwargs={"slug": self.video2.slug})
+            + "?from=video"
+        )
+        self.assertEqual(self.client.post(other_url).status_code, 403)
+        self.assertEqual(Client().post(self.stat_video_url).status_code, 403)
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_password_change_invalidates_existing_authorization(self) -> None:
+        """A previous password grant must expire when the video password changes."""
+        self.video.password = "PreviousPassword"
+        self.video.save()
+        self.assertEqual(
+            self.client.post(
+                self.stat_video_url, {"password": self.video.password}
+            ).status_code,
+            200,
+        )
+        self.video.password = "ReplacementPassword"
+        self.video.save()
+
+        self.assertEqual(self.client.post(self.stat_video_url).status_code, 403)
+        self.assertContains(self.client.get(self.stat_video_url), 'name="password"')
+        self.assertEqual(
+            self.client.post(
+                self.stat_video_url, {"password": self.video.password}
+            ).status_code,
+            200,
+        )
+        self.assertEqual(self.client.post(self.stat_video_url).status_code, 200)
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_restrictions_apply_to_get_and_post(self) -> None:
+        """A password submission must not bypass draft or group restrictions."""
+        group = AccessGroup.objects.create(code_name="stats-restricted")
+        self.client.force_login(self.visitor)
+        for restriction in ("draft", "group"):
+            self.video.is_draft = restriction == "draft"
+            self.video.is_restricted = restriction == "group"
+            self.video.restrict_access_to_groups.clear()
+            if restriction == "group":
+                self.video.restrict_access_to_groups.add(group)
+            for password in (None, "StatsPassword"):
+                self.video.password = password
+                self.video.save()
+                for method, data in (
+                    ("get", {}),
+                    ("post", {}),
+                    ("post", {"password": password or ""}),
+                ):
+                    with self.subTest(
+                        restriction=restriction, password=password, method=method
+                    ):
+                        response = getattr(self.client, method)(self.stat_video_url, data)
+                        self.assertIn(response.status_code, (403, 404))
+                        self.assertNotIn(b'"since_created":', response.content)
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_group_membership_is_rechecked_after_password_authorization(self) -> None:
+        """A session grant must not preserve access after group membership removal."""
+        group = AccessGroup.objects.create(code_name="stats-members")
+        self.video.password = "StatsPassword"
+        self.video.is_restricted = True
+        self.video.save()
+        self.video.restrict_access_to_groups.add(group)
+        self.visitor.owner.accessgroup_set.add(group)
+        self.client.force_login(self.visitor)
+        self.assertContains(self.client.get(self.stat_video_url), 'name="password"')
+        self.assertEqual(self.client.post(self.stat_video_url).status_code, 403)
+        self.assertEqual(
+            self.client.post(
+                self.stat_video_url, {"password": self.video.password}
+            ).status_code,
+            200,
+        )
+        self.assertEqual(self.client.post(self.stat_video_url).status_code, 200)
+
+        self.visitor.owner.accessgroup_set.remove(group)
+        for method in ("get", "post"):
+            with self.subTest(method=method):
+                response = getattr(self.client, method)(self.stat_video_url)
+                self.assertIn(response.status_code, (403, 404))
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_privileged_users_keep_access_without_password(self) -> None:
+        """Owners, co-owners, superusers and statistics managers retain access."""
+        manager = User.objects.create(username="stats-manager")
+        manager.owner.sites.add(Site.objects.get_current())
+        manager.user_permissions.add(
+            Permission.objects.get(
+                content_type__app_label="video", codename="change_viewcount"
+            )
+        )
+        self.video.additional_owners.add(self.visitor)
+        self.video.password = "StatsPassword"
+        self.video.is_draft = True
+        self.video.is_restricted = True
+        self.video.save()
+        self.video.restrict_access_to_groups.add(
+            AccessGroup.objects.create(code_name="stats-privileged")
+        )
+
+        for user in (self.user, self.visitor, self.superuser, manager):
+            self.client.force_login(user)
+            with self.subTest(user=user):
+                response = self.client.get(self.stat_video_url)
+                self.assertContains(response, self.video.title.capitalize())
+                self.assertNotContains(response, 'name="password"')
+                response = self.client.post(self.stat_video_url)
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.json()[0]["slug"], self.video.slug)
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_collective_statistics_filter_videos_and_earliest_date(self) -> None:
+        """Collective statistics disclose only each viewer's authorized videos."""
+        group = AccessGroup.objects.create(code_name="stats-collection")
+        self.video.password = "StatsPassword"
+        self.video.save()
+        self.video2.is_restricted = True
+        self.video2.save()
+        self.video2.restrict_access_to_groups.add(group)
+        self.video3.channel.add(self.channel)
+        self.video3.theme.add(self.theme)
+        older_date = self.video.date_added - timedelta(days=100)
+        Video.objects.filter(pk__in=(self.video.pk, self.video2.pk)).update(
+            date_added=older_date
+        )
+        urls = (
+            reverse("video:video_stats_view"),
+            self.stat_channel_url,
+            self.stat_theme_url,
+        )
+
+        for audience in ("anonymous", "visitor", "group", "password", "owner"):
+            expected_slugs = {self.video3.slug}
+            expected_min_date = self.video3.date_added.date()
+            if audience == "visitor":
+                self.client.force_login(self.visitor)
+            elif audience == "group":
+                self.visitor.owner.accessgroup_set.add(group)
+            elif audience == "password":
+                response = self.client.post(
+                    self.stat_video_url, {"password": self.video.password}
+                )
+                self.assertEqual(response.status_code, 200)
+            elif audience == "owner":
+                self.client.force_login(self.user)
+            if audience in ("group", "password", "owner"):
+                expected_slugs.add(self.video2.slug)
+                expected_min_date = older_date.date()
+            if audience in ("password", "owner"):
+                expected_slugs.add(self.video.slug)
+
+            for url in urls:
+                with self.subTest(audience=audience, url=url):
+                    response = self.client.post(url)
+                    self.assertEqual(response.status_code, 200)
+                    data = response.json()
+                    self.assertEqual({row["slug"] for row in data[:-1]}, expected_slugs)
+                    self.assertEqual(
+                        data[-1], {"min_date": expected_min_date.isoformat()}
+                    )
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_empty_authorized_collections_return_empty_statistics(self) -> None:
+        """A collection with no accessible video must not leak its earliest date."""
+        Video.objects.filter(
+            pk__in=(self.video.pk, self.video2.pk, self.video3.pk)
+        ).update(password="StatsPassword")
+        for url in (
+            reverse("video:video_stats_view"),
+            self.stat_channel_url,
+            self.stat_theme_url,
+        ):
+            for data in ({"password": "StatsPassword"}, {}):
+                with self.subTest(url=url, data=data):
+                    response = self.client.post(url, data)
+                    self.assertEqual(response.status_code, 200)
+                    self.assertEqual(response.json(), [{"min_date": None}])
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_individual_statistics_do_not_disclose_other_videos_earliest_date(
+        self,
+    ) -> None:
+        """An individual response's date bounds must concern only its video."""
+        Video.objects.filter(pk=self.video2.pk).update(
+            date_added=self.video2.date_added - timedelta(days=100)
+        )
+        response = self.client.post(self.stat_video_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()[-1], {"min_date": self.video.date_added.date().isoformat()}
+        )
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_individual_statistics_require_video_on_current_site(self) -> None:
+        """Knowing a slug must not expose statistics belonging to another site."""
+        other_site = Site.objects.create(domain="other-stats.example", name="Other")
+        self.video.sites.set([other_site])
+        for user in (self.visitor, self.superuser):
+            self.client.force_login(user)
+            for method in ("get", "post"):
+                with self.subTest(user=user, method=method):
+                    response = getattr(self.client, method)(self.stat_video_url)
+                    self.assertEqual(response.status_code, 404)
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_missing_video_returns_404_for_get_and_post(self) -> None:
+        """A missing or unknown individual slug must never fall back to JSON."""
+        urls = (
+            reverse("video:video_stats_view") + "?from=video",
+            reverse("video:video_stats_view", kwargs={"slug": "missing-video"})
+            + "?from=video",
+        )
+        for url in urls:
+            for method in ("get", "post"):
+                with self.subTest(url=url, method=method):
+                    response = getattr(self.client, method)(url)
+                    self.assertEqual(response.status_code, 404)
+
+    @skipUnless(USE_STATS_VIEW, "Require URL video_stats_view")
+    def test_statistics_reject_unsupported_http_methods(self) -> None:
+        """Only GET and POST may be used to request video statistics."""
+        for method in ("head", "put", "patch", "delete", "options"):
+            with self.subTest(method=method):
+                response = getattr(self.client, method)(self.stat_video_url)
+                self.assertEqual(response.status_code, 405)
 
     def tearDown(self) -> None:
         del self.video

--- a/pod/video/tests/test_views.py
+++ b/pod/video/tests/test_views.py
@@ -2,7 +2,6 @@
 *  run with 'python manage.py test pod.video.tests.test_views'
 """
 
-from django.conf import settings
 from django.http import JsonResponse
 from django.test import Client, TestCase, override_settings, TransactionTestCase
 from django.urls import reverse
@@ -11,7 +10,6 @@ from django.contrib.auth.models import User
 from pod.authentication.models import AccessGroup
 from django.contrib.sites.models import Site
 from django.contrib.messages import get_messages
-from django.core.files.temp import NamedTemporaryFile
 from django.utils.translation import gettext_lazy as _
 
 from pod.main.models import AdditionalChannelTab
@@ -23,21 +21,18 @@ from ..models import Channel
 from ..models import Discipline
 from ..models import AdvancedNotes
 from ..models import VideoAccessToken
-from pod.video_encode_transcript import encode
+from pod.video_encode_transcript.models import EncodingAudio
 from pod.video_encode_transcript.models import VideoRendition
 from pod.video_encode_transcript.models import EncodingVideo
+from .. import forms as video_forms
 from .. import views
 
 import re
 import json
 from http import HTTPStatus
 from importlib import reload
-import shutil
-import os
 import uuid
 from unittest.mock import patch
-
-AUDIO_TEST = getattr(settings, "AUDIO_TEST", "pod/main/static/video_test/pod.mp3")
 
 
 class ChannelTestView(TestCase):
@@ -884,7 +879,8 @@ class VideoEditTestView(TestCase):
         self.assertEqual(response.status_code, 403)
         print(" --->  test_video_edit_get_request of VideoEditTestView: OK!")
 
-    def test_video_edit_post_request(self) -> None:
+    @patch.object(video_forms.encode, video_forms.ENCODE_VIDEO)
+    def test_video_edit_post_request(self, mock_start_encode) -> None:
 
         # Force user `pod` login
         self.client = Client()
@@ -913,6 +909,7 @@ class VideoEditTestView(TestCase):
         # Check that the newly modified video has proper attrs
         v = Video.objects.get(title="VideoTest1")
         self.assertEqual(v.description, "<p>bl</p>")
+        mock_start_encode.assert_not_called()
 
         # Replace video source file
         video_file = SimpleUploadedFile(
@@ -931,6 +928,7 @@ class VideoEditTestView(TestCase):
         v = Video.objects.get(title="VideoTest1")
         p = re.compile(r"^videos/([\d\w]+)/file([_\d\w]*).mp4$")
         self.assertRegex(v.video.name, p)
+        mock_start_encode.assert_called_once_with(v.id)
 
         # Force user `pod2` login
         self.client = Client()
@@ -1714,6 +1712,7 @@ class VideoTranscriptTestView(TestCase):
 
     @override_settings(
         USE_TRANSCRIPTION=True,
+        TRANSCRIPT_VIDEO="start_transcript",
         TRANSCRIPTION_TYPE="VOSK",
         TRANSCRIPTION_MODEL_PARAM={
             # les modèles Vosk
@@ -1727,8 +1726,13 @@ class VideoTranscriptTestView(TestCase):
             }
         },
     )
-    def test_video_transcript_get_request_transcription(self) -> None:
+    @patch("pod.video_encode_transcript.transcript.start_transcript")
+    def test_video_transcript_get_request_transcription(
+        self, mock_start_transcript
+    ) -> None:
         """Check response for get request with use transcription."""
+        # Test dispatch without a worker accessing SQLite's uncommitted test data.
+        self.addCleanup(reload, views)
         reload(views)
 
         def inner_get_transcription_choices() -> list:
@@ -1766,14 +1770,16 @@ class VideoTranscriptTestView(TestCase):
             owner=self.user,
             video="test.mp3",
             type=Type.objects.get(id=1),
+            encoding_in_progress=False,
         )
-        tempfile = NamedTemporaryFile(delete=True)
-        audio.video.save("test.mp3", tempfile)
-        dest = os.path.join(settings.MEDIA_ROOT, audio.video.name)
-        shutil.copyfile(AUDIO_TEST, dest)
-        print("\n ---> Start Encoding audio")
-        encode.encode_video(audio.id)
-        print("\n ---> End Encoding audio")
+        # The view needs encoded audio records, not an actual FFmpeg run.
+        for extension, encoding_format in (("m4a", "video/mp4"), ("mp3", "audio/mp3")):
+            EncodingAudio.objects.create(
+                video=audio,
+                name="audio",
+                encoding_format=encoding_format,
+                source_file="audio.%s" % extension,
+            )
         url = reverse("video:video_transcript", kwargs={"slug": audio.slug})
         response = self.client.get(url)
         messages = list(get_messages(response.wsgi_request))
@@ -1782,6 +1788,7 @@ class VideoTranscriptTestView(TestCase):
             str_messages.append(str(message))
         check_message = "An available transcription language must be specified."
         self.assertTrue(check_message in str_messages)
+        mock_start_transcript.assert_not_called()
         url = reverse("video:video_transcript", kwargs={"slug": audio.slug})
         url += "?lang=fr"
         response = self.client.get(url)
@@ -1800,6 +1807,7 @@ class VideoTranscriptTestView(TestCase):
         )
         audio.refresh_from_db()
         self.assertEqual(audio.transcript, "fr")
+        mock_start_transcript.assert_called_once_with(audio.id)
         print(" ---> test_video_transcript_get_request_transcription: OK!")
 
 

--- a/pod/video/tests/test_views.py
+++ b/pod/video/tests/test_views.py
@@ -196,6 +196,59 @@ class ChannelTestView(TestCase):
             in response.content
         )
 
+    @patch.object(views, "ORGANIZE_BY_THEME", True)
+    def test_regroup_shared_video_by_current_channel(self) -> None:
+        """A theme in one channel must not hide a video in another channel."""
+        self.v.channel.add(self.c2)
+        self.v.theme.add(self.theme)
+
+        for url, expected_videos in (
+            (self.c2.get_absolute_url(), [self.v]),
+            (self.c.get_absolute_url(), []),
+            (self.theme.get_absolute_url(), [self.v]),
+        ):
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
+                self.assertEqual(response.context["videos"], expected_videos)
+                self.assertEqual(response.context["count_videos"], len(expected_videos))
+
+    @patch.object(views, "ORGANIZE_BY_THEME", True)
+    def test_regroup_shared_video_ajax(self) -> None:
+        """Both AJAX video responses keep videos themed in another channel."""
+        self.v.channel.add(self.c2)
+        self.v.theme.add(self.theme)
+
+        for params in ({}, {"target": "videos"}):
+            with self.subTest(params=params):
+                response = self.client.get(
+                    self.c2.get_absolute_url(),
+                    params,
+                    headers={"x-requested-with": "XMLHttpRequest"},
+                )
+                self.assertEqual(response.status_code, HTTPStatus.OK)
+                self.assertEqual(list(response.context["videos"]), [self.v])
+                self.assertEqual(response.context["videos"].paginator.count, 1)
+
+    @patch.object(views, "ORGANIZE_BY_THEME", True)
+    def test_regroup_shared_video_with_theme_in_both_channels(self) -> None:
+        """A local subtheme still excludes a shared video from the channel root."""
+        theme = Theme.objects.create(title="Theme2", channel=self.c2)
+        child = Theme.objects.create(title="ChildTheme2", channel=self.c2, parentId=theme)
+        self.v.channel.add(self.c2)
+        self.v.theme.add(self.theme, child)
+
+        for url, expected_videos in (
+            (self.c2.get_absolute_url(), []),
+            (theme.get_absolute_url(), []),
+            (child.get_absolute_url(), [self.v]),
+        ):
+            with self.subTest(url=url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, HTTPStatus.OK)
+                self.assertEqual(response.context["videos"], expected_videos)
+                self.assertEqual(response.context["count_videos"], len(expected_videos))
+
 
 class MyChannelsTestView(TestCase):
     fixtures = [

--- a/pod/video/tests/test_views.py
+++ b/pod/video/tests/test_views.py
@@ -35,6 +35,7 @@ from importlib import reload
 import shutil
 import os
 import uuid
+from unittest.mock import patch
 
 AUDIO_TEST = getattr(settings, "AUDIO_TEST", "pod/main/static/video_test/pod.mp3")
 
@@ -1415,6 +1416,20 @@ class VideoTestFiltersViews(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content.decode("utf-8")), expected)
 
+    def test_filter_owners_does_not_expose_exception_details(self) -> None:
+        """Internal exception messages must not be sent to API clients."""
+        self.client.force_login(self.admin)
+        url = reverse("video:filter_owners")
+
+        with patch(
+            "pod.video.views.auth_get_owners",
+            side_effect=RuntimeError("private database details"),
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertNotIn("private database details", response.json()["detail"])
+
     def test_filter_videos(self) -> None:
         url = reverse("video:filter_videos", kwargs={"user_id": self.admin.id})
 
@@ -1460,6 +1475,20 @@ class VideoTestFiltersViews(TestCase):
         }
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(json.loads(response.content.decode("utf-8")), expected)
+
+    def test_filter_videos_does_not_expose_exception_details(self) -> None:
+        """Internal exception messages must not be sent to API clients."""
+        self.client.force_login(self.admin)
+        url = reverse("video:filter_videos", kwargs={"user_id": self.admin.id})
+
+        with patch(
+            "pod.video.views.video_get_videos",
+            side_effect=RuntimeError("private storage details"),
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertNotIn("private storage details", response.json()["detail"])
 
     def test_available_filters_endpoint(self):
         """API available_filters should return the expected structure."""

--- a/pod/video/views.py
+++ b/pod/video/views.py
@@ -286,7 +286,6 @@ def _regroup_videos_by_theme(  # noqa: C901
 
     if target in ("", "themes"):
         theme_children = Theme.objects.filter(parentId=theme, channel=channel)
-        videos = videos.filter(theme=theme, channel=channel).distinct()
 
         if theme is not None and theme.parentId is not None:
             parent_title = theme.parentId.title
@@ -294,7 +293,13 @@ def _regroup_videos_by_theme(  # noqa: C901
             parent_title = channel.title
 
     if target in ("", "videos"):
-        videos = videos.filter(theme=theme, channel=channel).distinct()
+        videos = videos.filter(channel=channel)
+        if theme is None:
+            # Themes in other channels do not affect this channel's root videos.
+            videos = videos.exclude(theme__channel=channel)
+        else:
+            videos = videos.filter(theme=theme)
+        videos = videos.distinct()
         response["next_videos"], *_ = pagination_data(
             request.path, offset, limit, videos.count()
         )

--- a/pod/video/views.py
+++ b/pod/video/views.py
@@ -2725,18 +2725,16 @@ def get_videos(p_slug, target, p_slug_t=None, request=None):
         .prefetch_related("additional_owners", "restrict_access_to_groups")
     )
     if target.lower() == "video":
-        video_founded = (
+        video_found = (
             Video.objects.filter(slug=p_slug, sites=get_current_site(request))
             .select_related("owner")
             .prefetch_related("additional_owners", "restrict_access_to_groups")
             .first()
         )
         # In case that the slug is a bad one
-        if video_founded:
-            videos.append(video_founded)
-            title = (
-                _("Video viewing statistics for %s") % video_founded.title.capitalize()
-            )
+        if video_found:
+            videos.append(video_found)
+            title = _("Video viewing statistics for %s") % video_found.title.capitalize()
 
     elif target.lower() == "channel":
         title = _("Video viewing statistics for the channel %s") % p_slug

--- a/pod/video/views.py
+++ b/pod/video/views.py
@@ -16,6 +16,7 @@ from dateutil.parser import parse
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth.views import redirect_to_login
 from django.contrib.auth.models import User
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import (
@@ -32,7 +33,6 @@ from django.db.models import (
     Case,
     Count,
     F,
-    Min,
     Q,
     QuerySet,
     Sum,
@@ -53,11 +53,13 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.crypto import constant_time_compare, salted_hmac
 from django.utils.html import escape
 from django.utils.timezone import timedelta
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import ngettext
 from django.views.decorators.csrf import csrf_protect, ensure_csrf_cookie
+from django.views.decorators.http import require_http_methods
 
 from pod.authentication.utils import get_owners as auth_get_owners
 from pod.main.context_processors import WEBTV_MODE
@@ -750,7 +752,7 @@ def dashboard(request):
     data_context["display_mode"] = display_mode
     data_context["video_list_template"] = template
     data_context["page_title"] = _("Dashboard")
-    data_context["listTheme"] = json.dumps(get_list_theme_in_form(form))
+    data_context["listTheme"] = get_list_theme_in_form(form)
     data_context["error_message"] = error_message
 
     return render(request, "videos/dashboard.html", data_context)
@@ -1420,10 +1422,13 @@ def render_video(
             )
             raise PermissionDenied
         else:
-            iframe_param = "is_iframe=true&" if (request.GET.get("is_iframe")) else ""
-            return redirect(
-                "%s?%sreferrer=%s"
-                % (settings.LOGIN_URL, iframe_param, request.get_full_path())
+            login_url = settings.LOGIN_URL
+            if request.GET.get("is_iframe"):
+                login_url += "?is_iframe=true"
+            return redirect_to_login(
+                request.get_full_path(),
+                login_url=login_url,
+                redirect_field_name="referrer",
             )
 
 
@@ -1495,7 +1500,7 @@ def video_edit(request, slug=None):
         "videos/video_edit.html",
         {
             "form": form,
-            "listTheme": json.dumps(get_list_theme_in_form(form)),
+            "listTheme": get_list_theme_in_form(form),
             "USE_RUNNER_MANAGER": USE_RUNNER_MANAGER,
             **_get_video_queue_context(form.instance if form else None),
         },
@@ -2697,7 +2702,7 @@ def get_all_views_count(v_id, date_filter=date.today()):
     return all_views
 
 
-def get_videos(p_slug, target, p_slug_t=None):
+def get_videos(p_slug, target, p_slug_t=None, request=None):
     """Retourne une ou plusieurs videos selon le slug donné.
 
     Renvoi vidéo/s et titre de
@@ -2707,9 +2712,20 @@ def get_videos(p_slug, target, p_slug_t=None):
     """
     videos = []
     title = _("Pod video viewing statistics")
-    available_videos = get_available_videos()
+    available_videos = (
+        get_available_videos(request)
+        .defer(None)
+        .defer("video", "description")
+        .select_related("owner")
+        .prefetch_related("additional_owners", "restrict_access_to_groups")
+    )
     if target.lower() == "video":
-        video_founded = Video.objects.filter(slug=p_slug).first()
+        video_founded = (
+            Video.objects.filter(slug=p_slug, sites=get_current_site(request))
+            .select_related("owner")
+            .prefetch_related("additional_owners", "restrict_access_to_groups")
+            .first()
+        )
         # In case that the slug is a bad one
         if video_founded:
             videos.append(video_founded)
@@ -2750,51 +2766,63 @@ def get_videos_for_owner(request: WSGIRequest):
 
 
 def view_stats_if_authenticated(user) -> bool:
-    if VIEW_STATS_AUTH and user.__str__() == "AnonymousUser":
-        return False
-    return True
+    return not VIEW_STATS_AUTH or user.is_authenticated
 
 
-def manage_access_rights_stats_video(request, video, page_title):
-    video_access_ok = get_video_access(request, video, slug_private=None)
-    is_password_protected = video.password is not None and video.password != ""
+def get_video_stats_password_token(video: Video) -> str:
+    """Bind a statistics session grant to this video and its current password."""
+    return salted_hmac(
+        "pod.video.stats_password",
+        f"{video.pk}:{video.password}",
+        algorithm="sha256",
+    ).hexdigest()
 
+
+def can_view_video_stats(request: WSGIRequest, video: Video) -> bool:
+    """Check the same video permissions for HTML and JSON statistics."""
     has_rights = (
-        request.user == video.owner
+        request.user.pk == video.owner_id
         or request.user.is_superuser
         or request.user.has_perm("video.change_viewcount")
         or request.user in video.additional_owners.all()
     )
-    if not has_rights and is_password_protected:
-        form = VideoPasswordForm()
-        return render(
-            request,
-            "videos/video_stats_view.html",
-            {"form": form, "page_title": page_title},
+    if has_rights:
+        return True
+    if not get_video_access(request, video, slug_private=None):
+        return False
+    if not video.password:
+        return True
+    token = request.session.get("video_stats_passwords", {}).get(str(video.pk), "")
+    return constant_time_compare(token, get_video_stats_password_token(video))
+
+
+def manage_access_rights_stats_video(request, video, page_title):
+    """Return an access response, or None when statistics may be returned."""
+    if can_view_video_stats(request, video):
+        return None
+    if not get_video_access(request, video, slug_private=None):
+        return HttpResponseNotFound(
+            _("You do not have access rights to this video: %s ") % video.slug
         )
-    elif (
-        (not has_rights and video_access_ok and not is_password_protected)
-        or (video_access_ok and not is_password_protected)
-        or has_rights
-    ):
-        highlight = request.GET.get("highlight", None)
-        if highlight not in (
-            "playlist_since_created",
-            "since_created",
-            "fav_since_created",
-        ):
-            highlight = None
-        return render(
-            request,
-            "videos/video_stats_view.html",
-            {"page_title": page_title, "highlight": highlight},
-        )
-    return HttpResponseNotFound(
-        _("You do not have access rights to this video: %s " % video.slug)
+
+    form = VideoPasswordForm(request.POST if request.method == "POST" else None)
+    if request.method == "POST" and form.is_valid():
+        if constant_time_compare(request.POST["password"], video.password):
+            authorized_videos = request.session.get("video_stats_passwords", {})
+            authorized_videos[str(video.pk)] = get_video_stats_password_token(video)
+            request.session["video_stats_passwords"] = authorized_videos
+            return None
+        form.add_error("password", _("The password is incorrect."))
+    return render(
+        request,
+        "videos/video_stats_view.html",
+        {"form": form, "page_title": page_title},
+        status=403 if request.method == "POST" else 200,
     )
 
 
 @user_passes_test(view_stats_if_authenticated, redirect_field_name="referrer")
+@require_http_methods(["GET", "POST"])
 def stats_view(request, slug=None, slug_t=None):
     """
     View for statistics.
@@ -2808,59 +2836,57 @@ def stats_view(request, slug=None, slug_t=None):
     allowed_targets = {"videos", "video", "channel", "theme"}
     if target not in allowed_targets:
         target = "videos"
-    videos, title = get_videos(slug, target, slug_t)
+    videos, title = get_videos(slug, target, slug_t, request=request)
     error_message = _(
         "The following “%(target)s” type target does not exist or contains no videos: %(slug)s."
     )
-    if request.method == "GET" and target == "video" and videos:
-        return manage_access_rights_stats_video(request, videos[0], title)
+    if target == "video":
+        if not videos:
+            return HttpResponseNotFound(
+                _("The following video does not exist: %s") % escape(slug)
+            )
+        access_response = manage_access_rights_stats_video(request, videos[0], title)
+        if access_response is not None:
+            return access_response
+    else:
+        videos = [video for video in videos if can_view_video_stats(request, video)]
 
-    elif request.method == "GET" and target == "video" and not videos:
-        return HttpResponseNotFound(_("The following video does not exist: %s") % slug)
-
-    if request.method == "GET" and (
-        not videos and target in ("channel", "theme", "videos")
-    ):
+    if request.method == "GET" and not videos:
         slug = slug if not slug_t else slug_t
         target = "Pod" if target == "videos" else target
         return HttpResponseNotFound(
             error_message % {"target": escape(target), "slug": escape(slug)}
         )
 
-    if (
-        request.method == "POST"
-        and target == "video"
-        and (
-            request.POST.get("password")
-            and request.POST.get("password") == videos[0].password
-            # and check_password(request.POST.get("password"), videos[0].password)
-        )
-    ) or (
-        request.method == "GET" and videos and target in ("videos", "channel", "theme")
-    ):
-        return render(request, "videos/video_stats_view.html", {"page_title": title})
-    else:
-        date_filter = request.POST.get("periode", date.today())
-        if isinstance(date_filter, str):
-            date_filter = parse(date_filter).date()
-
-        data = list(
-            map(
-                lambda v: {
-                    "title": v.title,
-                    "slug": v.slug,
-                    **get_all_views_count(v.id, date_filter),
-                },
-                videos,
-            )
+    if request.method == "GET" or (target == "video" and "password" in request.POST):
+        highlight = request.GET.get("highlight")
+        if highlight not in (
+            "playlist_since_created",
+            "since_created",
+            "fav_since_created",
+        ):
+            highlight = None
+        return render(
+            request,
+            "videos/video_stats_view.html",
+            {"page_title": title, "highlight": highlight},
         )
 
-        min_date = (
-            get_available_videos().aggregate(Min("date_added"))["date_added__min"].date()
-        )
-        data.append({"min_date": min_date})
+    date_filter = request.POST.get("periode", date.today())
+    if isinstance(date_filter, str):
+        date_filter = parse(date_filter).date()
 
-        return JsonResponse(data, safe=False)
+    data = [
+        {
+            "title": video.title,
+            "slug": video.slug,
+            **get_all_views_count(video.id, date_filter),
+        }
+        for video in videos
+    ]
+    min_date = min((video.date_added.date() for video in videos), default=None)
+    data.append({"min_date": min_date})
+    return JsonResponse(data, safe=False)
 
 
 @login_required(redirect_field_name="referrer")
@@ -3668,8 +3694,11 @@ def filter_owners(request):
         search = request.GET.get("q", "")
         return auth_get_owners(search, limit, offset)
 
-    except Exception as err:
-        return JsonResponse({"success": False, "detail": "Syntax error: {0}".format(err)})
+    except Exception:
+        logger.exception("Unable to filter owners")
+        return JsonResponse(
+            {"success": False, "detail": _("Server error while processing filter.")}
+        )
 
 
 @login_required(redirect_field_name="referrer")
@@ -3682,8 +3711,11 @@ def filter_videos(request, user_id):
         search = request.GET.get("q", None)
         return video_get_videos(title, user_id, search, limit, offset)
 
-    except Exception as err:
-        return JsonResponse({"success": False, "detail": "Syntax error: {0}".format(err)})
+    except Exception:
+        logger.exception("Unable to filter videos")
+        return JsonResponse(
+            {"success": False, "detail": _("Server error while processing filter.")}
+        )
 
 
 def get_serialized_channels(request: WSGIRequest, channels: QueryDict) -> dict:

--- a/pod/video_encode_transcript/tests/test_notify_task_end.py
+++ b/pod/video_encode_transcript/tests/test_notify_task_end.py
@@ -89,6 +89,55 @@ class NotifyTaskEndAuthTests(TestCase):
         self.task.refresh_from_db()
         self.assertEqual(self.task.status, "running")
 
+    @patch("pod.video_encode_transcript.views.download_and_import_task_result")
+    def test_completed_runner_task_stays_running_during_local_import(
+        self, mock_download_and_import
+    ):
+        """Do not report completion before Pod has imported the Runner result."""
+        status_during_import = []
+
+        def complete_local_import(task):
+            task.refresh_from_db()
+            status_during_import.append(task.status)
+            task.status = "completed"
+            task.save(update_fields=["status"])
+
+        mock_download_and_import.side_effect = complete_local_import
+
+        response = self._post_notify("Bearer runner-token", status="completed")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(status_during_import, ["running"])
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "completed")
+
+    @patch("pod.video_encode_transcript.views.download_and_import_task_result")
+    def test_failed_local_import_does_not_report_task_as_completed(
+        self, mock_download_and_import
+    ):
+        """Keep a task retryable when result retrieval or import does not finish."""
+        response = self._post_notify("Bearer runner-token", status="completed")
+
+        self.assertEqual(response.status_code, 200)
+        mock_download_and_import.assert_called_once()
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "running")
+
+    @patch("pod.video_encode_transcript.views.download_and_import_task_result")
+    def test_repeated_completed_notification_preserves_completed_status(
+        self, mock_download_and_import
+    ):
+        """Do not reopen a task when the Runner repeats a completion callback."""
+        self.task.status = "completed"
+        self.task.save(update_fields=["status"])
+
+        response = self._post_notify("Bearer runner-token", status="completed")
+
+        self.assertEqual(response.status_code, 200)
+        mock_download_and_import.assert_called_once()
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "completed")
+
     @patch("pod.video_encode_transcript.views.send_email_item")
     def test_notify_task_end_sends_alert_on_failed_status(self, mock_send_email_item):
         """Send an alert email when runner notifies a failed task."""

--- a/pod/video_encode_transcript/tests/test_rest_views.py
+++ b/pod/video_encode_transcript/tests/test_rest_views.py
@@ -131,13 +131,15 @@ class RestViewsApiTests(TestCase):
             recording_type="studio",
             type=recorder_type,
         )
-        recording = Recording.objects.create(
-            recorder=recorder,
-            user=self.user,
-            title="studio recording",
-            type="studio",
-            source_file="/tmp/recording.mp4",
-        )
+        # Creating this fixture must not process a file left by another test.
+        with patch("pod.recorder.plugins.type_studio.process"):
+            recording = Recording.objects.create(
+                recorder=recorder,
+                user=self.user,
+                title="studio recording",
+                type="studio",
+                source_file="/tmp/recording.mp4",
+            )
         payload = {
             "video_output": "records/output.mp4",
             "msg": "encoded",

--- a/pod/video_encode_transcript/tests/test_runner_manager_utils.py
+++ b/pod/video_encode_transcript/tests/test_runner_manager_utils.py
@@ -1,16 +1,22 @@
 """Regression tests for Runner Manager artifact persistence."""
 
+import json
+import shutil
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 
 from pod.video.models import Type, Video
+from pod.video_encode_transcript.models import EncodingLog, Task
 from pod.video_encode_transcript.runner_manager_utils import (
     FILEPICKER,
     CustomImageModel,
     remote_video_part,
 )
+from pod.video_encode_transcript.views import _finalize_task_import
 
 
 class RunnerManagerArtifactPersistenceTests(TestCase):
@@ -80,3 +86,65 @@ class RunnerManagerArtifactPersistenceTests(TestCase):
             self.video.id,
             "attach existing overview: /tmp/media/videos/0001/overview.vtt",
         )
+
+    @patch("pod.video_encode_transcript.runner_manager_utils.USE_NOTIFICATIONS", False)
+    @patch("pod.video_encode_transcript.runner_manager_utils.USE_TRANSCRIPTION", False)
+    @patch(
+        "pod.video_encode_transcript.runner_manager_utils.EMAIL_ON_ENCODING_COMPLETION",
+        False,
+    )
+    def test_completed_import_preserves_thumbnail_after_audio_and_finalization(self):
+        """A complete Runner import must retain the selected image in the database."""
+        task = Task.objects.create(video=self.video, type="encoding", status="running")
+        info_video = {
+            "duration": 47,
+            "has_stream_video": True,
+            "has_stream_audio": True,
+            "has_stream_thumbnail": True,
+            "encode_video": [
+                {
+                    "encoding_format": "video/mp4",
+                    "filename": "720p_runner.mp4",
+                    "rendition": "1280x720",
+                }
+            ],
+            "encode_audio": {
+                "encoding_format": "audio/mp3",
+                "filename": "audio_runner.mp3",
+            },
+            "encode_thumbnail": [
+                {"filename": f"thumbnail_{index}.jpg"} for index in (2, 0, 1)
+            ],
+        }
+        with TemporaryDirectory() as media_root, self.settings(MEDIA_ROOT=media_root):
+            output_dir = Path(media_root) / f"{self.video.id:04d}"
+            output_dir.mkdir()
+            (output_dir / "info_video.json").write_text(
+                json.dumps(info_video), encoding="utf-8"
+            )
+            (output_dir / "720p_runner.mp4").write_bytes(b"encoded video")
+            (output_dir / "audio_runner.mp3").write_bytes(b"encoded audio")
+            (output_dir / "overview.vtt").write_text("WEBVTT\n", encoding="utf-8")
+            image_fixture = Path(__file__).with_name("testimage.jpg")
+            for entry in info_video["encode_thumbnail"]:
+                shutil.copyfile(image_fixture, output_dir / entry["filename"])
+
+            _finalize_task_import(task, str(output_dir), "")
+
+            self.video.refresh_from_db()
+            task.refresh_from_db()
+            self.assertEqual(task.status, "completed")
+            self.assertFalse(self.video.encoding_in_progress)
+            self.assertEqual(self.video.duration, 47)
+            self.assertEqual(
+                self.video.overview.name, f"{self.video.id:04d}/overview.vtt"
+            )
+            self.assertIsNotNone(self.video.thumbnail_id)
+            thumbnail = CustomImageModel.objects.get(id=self.video.thumbnail_id)
+            self.assertEqual(Path(thumbnail.file.name).name, "thumbnail_1.jpg")
+            self.assertTrue(thumbnail.file_exist())
+            self.assertEqual(self.video.encodingvideo_set.count(), 1)
+            self.assertEqual(self.video.encodingaudio_set.count(), 1)
+            encoding_log = EncodingLog.objects.get(video=self.video).log
+            self.assertIn("- persisted_thumbnail_id:\n%s" % thumbnail.id, encoding_log)
+            self.assertIn("End:", encoding_log)

--- a/pod/video_encode_transcript/tests/test_task_import_lock.py
+++ b/pod/video_encode_transcript/tests/test_task_import_lock.py
@@ -1,0 +1,266 @@
+"""Regression tests for exclusive Runner result imports and retryable failures."""
+
+import json
+import subprocess
+import sys
+from contextlib import ExitStack
+from datetime import timedelta
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from django.contrib.sites.models import Site
+from django.http import JsonResponse
+from django.test import RequestFactory, TestCase
+from django.utils import timezone
+
+from pod.video_encode_transcript import views
+from pod.video_encode_transcript.management.commands.process_tasks import Command
+from pod.video_encode_transcript.models import RunnerManager, Task
+
+
+class TaskImportLockTests(TestCase):
+    """Serialize callback and cron imports using the actual shared file lock."""
+
+    def setUp(self) -> None:
+        """Create an aged Runner task and isolate downloaded artifacts and locks."""
+        self.contexts = ExitStack()
+        self.addCleanup(self.contexts.close)
+        self.media_root = self.contexts.enter_context(TemporaryDirectory())
+        self.contexts.enter_context(self.settings(MEDIA_ROOT=self.media_root))
+        self.site, _ = Site.objects.get_or_create(
+            pk=1, defaults={"domain": "example.com", "name": "example.com"}
+        )
+        self.runner = RunnerManager.objects.create(
+            name="import-lock-runner",
+            url="https://runner.example.com/",
+            token="import-lock-token",
+            site=self.site,
+        )
+        self.task = Task.objects.create(
+            task_id="import-lock-task",
+            runner_manager=self.runner,
+            status="running",
+            date_added=timezone.now() - timedelta(hours=3),
+        )
+        self.manifest_data = {"files": [{"path": "info_video.json"}]}
+        self.manifest = self.contexts.enter_context(
+            patch.object(
+                views, "_get_task_result_manifest", return_value=self.manifest_data
+            )
+        )
+        self.download = self.contexts.enter_context(
+            patch.object(
+                views, "_save_manifest_files", return_value=(self.media_root, "")
+            )
+        )
+        self.real_finalize = views._finalize_task_import
+        self.finalize = self.contexts.enter_context(
+            patch.object(
+                views, "_finalize_task_import", side_effect=self._complete_import
+            )
+        )
+        self.command = Command()
+        self.command._configure_output_logger(verbose=False, quiet=True)
+
+    def _complete_import(
+        self, task: Task, extracted_dir: str, extracted_vtt_path: str
+    ) -> None:
+        """Represent successful artifact persistence without creating media files."""
+        task.status = "completed"
+        task.save(update_fields=["status"])
+
+    def _post_completed_callback(self) -> JsonResponse:
+        """Send an authenticated completion callback through the actual view."""
+        request = RequestFactory().post(
+            "/runner/notify_task_end/",
+            data=json.dumps({"task_id": self.task.task_id, "status": "completed"}),
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.runner.token}",
+        )
+        return views.notify_task_end(request)
+
+    def test_callback_during_cron_import_does_not_duplicate_import(self) -> None:
+        """Ignore a completion callback while cron already imports the same task."""
+        callback_responses = []
+
+        def receive_callback(
+            manifest: dict, task: Task, manager_url: str, bearer_token: str
+        ) -> tuple[str, str]:
+            """Deliver one callback while the outer import holds its file lock."""
+            if not callback_responses:
+                callback_responses.append(None)
+                callback_responses[0] = self._post_completed_callback()
+            return self.media_root, ""
+
+        self.download.side_effect = receive_callback
+        with patch.object(self.command, "_check_task_status", return_value="completed"):
+            self.assertEqual(self.command._check_running_tasks(self.site), 1)
+
+        self.assertEqual(callback_responses[0].status_code, 200)
+        self.manifest.assert_called_once()
+        self.download.assert_called_once()
+        self.finalize.assert_called_once()
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "completed")
+
+    def test_cron_during_callback_import_does_not_duplicate_import(self) -> None:
+        """Keep cron from importing an aged task already handled by its callback."""
+        checked_tasks = []
+
+        def run_cron(
+            manifest: dict, task: Task, manager_url: str, bearer_token: str
+        ) -> tuple[str, str]:
+            """Run one cron pass during the callback's artifact download."""
+            if not checked_tasks:
+                checked_tasks.append(None)
+                checked_tasks[0] = self.command._check_running_tasks(self.site)
+            return self.media_root, ""
+
+        self.download.side_effect = run_cron
+        with patch.object(self.command, "_check_task_status", return_value="completed"):
+            response = self._post_completed_callback()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(checked_tasks, [1])
+        self.manifest.assert_called_once()
+        self.download.assert_called_once()
+        self.finalize.assert_called_once()
+
+    def test_import_skips_task_completed_after_instance_was_loaded(self) -> None:
+        """Read current completion state before starting another artifact download."""
+        Task.objects.filter(pk=self.task.pk).update(status="completed")
+
+        views.download_and_import_task_result(self.task)
+
+        self.manifest.assert_not_called()
+        self.download.assert_not_called()
+        self.finalize.assert_not_called()
+        self.assertEqual(self.task.status, "completed")
+
+    def test_stale_completion_callback_does_not_reopen_completed_task(self) -> None:
+        """Preserve a concurrent import's completion when persisting callback output."""
+        Task.objects.filter(pk=self.task.pk).update(status="completed")
+
+        views._apply_notify_payload_to_task(
+            self.task, {"status": "completed", "script_output": "Runner finished"}
+        )
+
+        self.assertEqual(self.task.status, "completed")
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "completed")
+        self.assertEqual(self.task.script_output, "Runner finished")
+
+    def test_retry_after_manifest_is_unavailable(self) -> None:
+        """Release the lock when the Runner manifest cannot yet be retrieved."""
+        self.manifest.side_effect = [None, self.manifest_data]
+
+        views.download_and_import_task_result(self.task)
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "running")
+        self.download.assert_not_called()
+        views.download_and_import_task_result(self.task)
+
+        self.assertEqual(self.manifest.call_count, 2)
+        self.finalize.assert_called_once()
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "completed")
+
+    def test_retry_after_download_does_not_produce_artifacts(self) -> None:
+        """Release the lock when downloaded artifacts are unavailable."""
+        self.download.side_effect = [("", ""), (self.media_root, "")]
+
+        views.download_and_import_task_result(self.task)
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "running")
+        self.finalize.assert_not_called()
+        views.download_and_import_task_result(self.task)
+
+        self.assertEqual(self.download.call_count, 2)
+        self.finalize.assert_called_once()
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "completed")
+
+    def test_retry_after_finalization_returns_without_completion(self) -> None:
+        """Allow retry when finalization handles an error without completing the task."""
+        self.task.type = "transcription"
+        self.task.save(update_fields=["type"])
+        self.finalize.side_effect = self.real_finalize
+
+        with patch.object(
+            views,
+            "_import_transcription_result",
+            side_effect=[RuntimeError("transcription import failed"), None],
+        ) as import_transcription:
+            views.download_and_import_task_result(self.task)
+            self.task.refresh_from_db()
+            self.assertEqual(self.task.status, "running")
+            views.download_and_import_task_result(self.task)
+
+        self.assertEqual(import_transcription.call_count, 2)
+        self.assertEqual(self.finalize.call_count, 2)
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "completed")
+
+    def test_retry_after_unhandled_download_exception(self) -> None:
+        """Release the file lock even when artifact download raises an exception."""
+        self.download.side_effect = [
+            RuntimeError("interrupted download"),
+            (self.media_root, ""),
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "interrupted download"):
+            views.download_and_import_task_result(self.task)
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "running")
+        views.download_and_import_task_result(self.task)
+
+        self.assertEqual(self.download.call_count, 2)
+        self.finalize.assert_called_once()
+        self.task.refresh_from_db()
+        self.assertEqual(self.task.status, "completed")
+
+    def test_separate_tasks_can_import_while_another_task_is_locked(self) -> None:
+        """Keep unrelated Runner tasks independent of an active task import."""
+        other_task = Task.objects.create(
+            task_id="another-import-task", runner_manager=self.runner, status="running"
+        )
+
+        with views._task_import_lock(self.task) as acquired:
+            self.assertTrue(acquired)
+            views.download_and_import_task_result(other_task)
+
+        self.finalize.assert_called_once()
+        other_task.refresh_from_db()
+        self.assertEqual(other_task.status, "completed")
+
+    def test_file_lock_coordinates_processes_and_survives_file_reuse(self) -> None:
+        """Block another process and reuse the stable lock file after each holder exits."""
+        lock_path = Path(self.media_root) / ".runner_task_locks" / f"{self.task.pk}.lock"
+        child_script = (
+            "import sys\n"
+            "from django.core.files import locks\n"
+            "handle = open(sys.argv[1], 'a+b')\n"
+            "print(int(locks.lock(handle, locks.LOCK_EX | locks.LOCK_NB)))\n"
+        )
+
+        def acquire_in_child() -> str:
+            """Try a real lock in another process and let process exit release it."""
+            result = subprocess.run(
+                [sys.executable, "-c", child_script, str(lock_path)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=True,
+            )
+            return result.stdout.strip()
+
+        with views._task_import_lock(self.task) as acquired:
+            self.assertTrue(acquired)
+            inode = lock_path.stat().st_ino
+            self.assertEqual(acquire_in_child(), "0")
+
+        self.assertEqual(acquire_in_child(), "1")
+        with views._task_import_lock(self.task) as acquired:
+            self.assertTrue(acquired)
+            self.assertEqual(lock_path.stat().st_ino, inode)

--- a/pod/video_encode_transcript/views.py
+++ b/pod/video_encode_transcript/views.py
@@ -14,12 +14,15 @@ import secrets
 import shutil
 import tempfile
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from hashlib import sha256
 from typing import TypeAlias, TypedDict, cast
 
 import requests
 import webvtt
 from django.conf import settings
+from django.core.files import locks
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
@@ -254,8 +257,24 @@ def _authorize_notify_task(task: Task, bearer_token: str) -> JsonResponse | None
 
 
 def _apply_notify_payload_to_task(task: Task, data: NotifyTaskPayload) -> None:
-    """Persist task status and append optional script output details."""
-    task.status = str(data["status"])
+    """Persist task progress and append optional script output details.
+
+    A Runner ``completed`` status only means that the remote processing has
+    finished.  Pod still has to download and import the result before the
+    local task can be considered completed.  Keep it running during that
+    phase so failed encoding and transcription imports remain eligible for
+    the periodic retry.
+    """
+    notified_status = str(data["status"])
+    update_fields = ["script_output"]
+    if notified_status == "completed":
+        # A callback may hold a stale instance while another process finishes importing.
+        Task.objects.filter(pk=task.pk).exclude(status="completed").update(
+            status="running"
+        )
+    else:
+        task.status = notified_status
+        update_fields.append("status")
 
     script_output = task.script_output or ""
     error_message = data.get("error_message")
@@ -266,7 +285,8 @@ def _apply_notify_payload_to_task(task: Task, data: NotifyTaskPayload) -> None:
         script_output += str(script_output_payload)
 
     task.script_output = script_output
-    task.save()
+    task.save(update_fields=update_fields)
+    task.refresh_from_db(fields=["status"])
 
     if task.video_id and task.status in {"failed", "timeout"}:
         detail = (
@@ -308,12 +328,13 @@ def notify_task_end(request: WSGIRequest) -> JsonResponse:
             status=500,
         )
 
+    notified_status = str(data["status"])
     _apply_notify_payload_to_task(task, data)
 
-    if task.status == "failed":
+    if notified_status == "failed":
         send_email_item(f"Task {task.id} failed", "Task", task.task_id)
 
-    if task.status == "completed":
+    if notified_status == "completed":
         download_and_import_task_result(task)
 
     return JsonResponse({"status": "OK"}, status=200)
@@ -362,31 +383,65 @@ def _get_task_result_manifest(
     return manifest
 
 
+@contextmanager
+def _task_import_lock(task: Task) -> Iterator[bool]:
+    """Yield whether this process acquired the task's exclusive import lock.
+
+    Callback and periodic workers must share MEDIA_ROOT on a filesystem that
+    supports file locks. Closing the file, including on process exit, releases
+    the lock so an interrupted import can be retried without an expiry delay.
+    Keep the lock file in place: unlinking it could let workers lock different
+    files for the same task. Store it outside directories moved by Studio imports.
+    """
+    lock_dir = os.path.join(_get_media_root(), ".runner_task_locks")
+    os.makedirs(lock_dir, exist_ok=True)
+    lock_path = os.path.join(lock_dir, f"{task.pk}.lock")
+    with open(lock_path, "a") as lock_file:
+        acquired = locks.lock(lock_file, locks.LOCK_EX | locks.LOCK_NB)
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                locks.unlock(lock_file)
+
+
 def download_and_import_task_result(task: Task) -> None:
-    """Download the result of a completed task from the runner manager, extract it,
-    and import the encoded video back into Pod.
+    """Download and import a Runner result while holding the task's file lock.
+
+    Skip imports already running in another worker or completed in the database.
+    Failed attempts release the lock and remain eligible for a later retry.
 
     Args:
-        task (Task): Task object
+        task: Task whose remote result is ready to import.
     """
-    runner_manager = _get_runner_manager_for_task(task)
-    if not runner_manager:
-        return
+    with _task_import_lock(task) as acquired:
+        if not acquired:
+            log.info("Result import already in progress for task %s", task.pk)
+            return
 
-    manifest = _get_task_result_manifest(task, runner_manager)
-    if manifest is None:
-        return
+        task.refresh_from_db()
+        if task.status == "completed":
+            log.info("Result already imported for task %s", task.pk)
+            return
 
-    extracted_dir, extracted_vtt_path = _save_manifest_files(
-        manifest, task, runner_manager.url, runner_manager.token
-    )
+        runner_manager = _get_runner_manager_for_task(task)
+        if not runner_manager:
+            return
 
-    if not extracted_dir:
-        log.error(f"Failed to import result for task {task.id}")
-        return
+        manifest = _get_task_result_manifest(task, runner_manager)
+        if manifest is None:
+            return
 
-    log.info(f"Successfully downloaded and extracted result for task {task.id}")
-    _finalize_task_import(task, extracted_dir, extracted_vtt_path)
+        extracted_dir, extracted_vtt_path = _save_manifest_files(
+            manifest, task, runner_manager.url, runner_manager.token
+        )
+
+        if not extracted_dir:
+            log.error(f"Failed to import result for task {task.id}")
+            return
+
+        log.info(f"Successfully downloaded and extracted result for task {task.id}")
+        _finalize_task_import(task, extracted_dir, extracted_vtt_path)
 
 
 def _import_transcription_result(task: Task, extracted_vtt_path: str) -> None:

--- a/pod/video_search/models.py
+++ b/pod/video_search/models.py
@@ -5,6 +5,7 @@ from pod.video_search.utils import index_es, delete_es
 from pod.video.models import Video
 from django.dispatch import receiver
 from django.db.models.signals import post_save, pre_delete
+from django.utils import translation
 
 import threading
 
@@ -17,8 +18,14 @@ ES_URL = getattr(settings, "ES_URL", ["http://elasticsearch.localhost:9200/"])
 def update_video_index(
     sender, instance=None, created=False, **kwargs
 ) -> None:  # pragma: no cover
-    """Start index_video as daemon thread."""
+    """Index synchronously in tests, otherwise start a daemon thread."""
     if ES_URL is None:
+        return
+    # Use the test transaction's connection to avoid SQLite table locks.
+    if getattr(settings, "TEST_SETTINGS", False):
+        # Keep indexing's language changes local, as they are in a thread.
+        with translation.override(settings.LANGUAGE_CODE):
+            index_video(instance)
         return
     t = threading.Thread(target=index_video, args=[instance])
     t.daemon = True
@@ -37,8 +44,12 @@ def index_video(video) -> None:  # pragma: no cover
 def delete_video_index(
     sender, instance=None, created=False, **kwargs
 ) -> None:  # pragma: no cover
-    """Start delete_es as daemon thread."""
+    """Delete synchronously in tests, otherwise start a daemon thread."""
     if ES_URL is None:
+        return
+    # Complete deletion before the next test can reuse the same video ID.
+    if getattr(settings, "TEST_SETTINGS", False):
+        delete_es(instance.id)
         return
     # delete_es(instance)
     t = threading.Thread(target=delete_es, args=[instance.id])

--- a/pod/video_search/tests/test_utils.py
+++ b/pod/video_search/tests/test_utils.py
@@ -5,8 +5,10 @@
 
 from django.test import TestCase
 from django.contrib.auth.models import User
+from elasticsearch import Elasticsearch
 
 from pod.video.models import Video, Type
+from .. import utils
 from ..utils import index_es, delete_es
 
 
@@ -19,6 +21,17 @@ class VideoSearchTestUtils(TestCase):
 
     def setUp(self) -> None:
         """Set up required objects for next tests."""
+        # ping() hides connection/API errors and only returns False. Let info()
+        # expose the original failure before creating or indexing a test video.
+        with Elasticsearch(
+            utils.ES_URL,
+            request_timeout=utils.ES_TIMEOUT,
+            max_retries=utils.ES_MAX_RETRIES,
+            retry_on_timeout=True,
+            **utils.ES_OPTIONS,
+        ) as es:
+            es.info()
+
         self.user = User.objects.create(username="pod", password="pod1234pod")
         self.v = Video.objects.create(
             title="Video1",
@@ -29,10 +42,26 @@ class VideoSearchTestUtils(TestCase):
         )
 
     def test_index_and_delete_es(self) -> None:
+        self.assertNotEqual(
+            self.v.get_json_to_index(),
+            "{}",
+            "The test video could not be serialized. Check its related objects "
+            "and the video model logs before testing Elasticsearch indexing.",
+        )
         res = index_es(self.v)
+        self.assertIsNotNone(
+            res,
+            "Elasticsearch indexing returned no response. Check ES_URL, ES_OPTIONS "
+            "and the video_search logs for connection or indexing errors.",
+        )
         self.assertTrue(res["result"] in ["created", "updated"])
         self.assertEqual(res["_id"], str(self.v.id))
         delete = delete_es(self.v.id)
+        self.assertIsNotNone(
+            delete,
+            "Elasticsearch deletion returned no response. Check ES_URL, ES_OPTIONS "
+            "and the video_search logs for connection or deletion errors.",
+        )
         self.assertEqual(delete["result"], "deleted")
         self.assertEqual(delete["_id"], str(self.v.id))
         print("--> test_index_and_delete_es ok! ")


### PR DESCRIPTION
## Summary

- Fix statistics access controls to address security advisory GHSA-9543-4fhq-r448. Restrict statistics pages, JSON responses and aggregate queries to authorized videos on the current site.
- Preserve password authorization across statistics requests while rechecking access restrictions and invalidating authorization when the video password changes.
- Validate redirect targets, safely render alerts and theme labels, and prevent internal exception details from being exposed to users.
- Declare explicit GitHub Actions token permissions and address unsafe patterns to reduce GitHub code scanning alerts.
- Prevent concurrent Runner result imports from callbacks and periodic workers using per-task file locks under the shared `MEDIA_ROOT`. Mark tasks as completed only after successful local import, keeping failed attempts eligible for retry.
- Preserve generated thumbnails when submitting video edit forms opened during encoding.
- Fix v3-to-v4 exports by correcting invalid meeting recurrence end dates and merging duplicate video deletion dates while preserving video relationships.
- Fix video tag serialization in the REST API, preserve Elasticsearch authentication and TLS options in test settings, and load debug toolbar URLs only when the application is enabled.
- Use timezone-aware datetimes for upcoming-event filtering, personal meeting room creation and test fixtures.
- Run Elasticsearch indexing and deletion synchronously in test settings to avoid SQLite locking and cross-test races, while restoring the active language after indexing.
- Expand regression coverage and isolate encoding, transcription and recorder workers in tests. Verify worker dispatch and ensure video duplication copies the source file correctly.
- Fix videos missing from a channel’s root when they belong to a theme in another channel, with regression tests for page rendering and AJAX loading.
- Refresh translation catalogs.

## Related issues

Fixes https://github.com/EsupPortail/Esup-Pod/issues/1501
Fixes https://github.com/EsupPortail/Esup-Pod/issues/1448
Fixes https://github.com/EsupPortail/Esup-Pod/issues/1447